### PR TITLE
Integrate Envers

### DIFF
--- a/src/java/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/src/java/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -65,7 +65,7 @@ public class Hbm2DDLExporter extends AbstractExporter {
 
 	protected void setupContext() {
 
-		exportToDatabase = setupBoolProperty("export", exportToDatabase);
+		exportToDatabase = setupBoolProperty("exportToDatabase", exportToDatabase);
 		scriptToConsole = setupBoolProperty("scriptToConsole", scriptToConsole);
 		schemaUpdate = setupBoolProperty("schemaUpdate", schemaUpdate);
 		delimiter = getProperties().getProperty("delimiter", delimiter);


### PR DESCRIPTION
Hereby pull request makes sure that Hibernate Envers is integrated while generating schema DDL scripts. There is no need to use `org.hibernate.tool.ant.EnversHibernateToolTask` instead of `org.hibernate.tool.ant.HibernateToolTask` any more, but Envers JAR has to be present in the classpath.
