### PR TITLE
HBX-1215 Improve handling of Oracle's NUMBER type when generating hibernate mappings

### DIFF
--- a/src/java/org/hibernate/cfg/reveng/dialect/OracleMetaDataDialect.java
+++ b/src/java/org/hibernate/cfg/reveng/dialect/OracleMetaDataDialect.java
@@ -102,7 +102,8 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 			+ "'RAW',-3, 'ROWID',1111, 'UROWID',1111, 'LONG RAW', -4, "
 			+ "'TIMESTAMP', 93, 'XMLTYPE',2005, 1111) as DATA_TYPE, "
 			+ "a.table_name as TABLE_NAME, a.data_type as TYPE_NAME, "
-			+ "decode(a.data_scale, null, 0 ,a.data_scale) as DECIMAL_DIGITS, b.comments "
+			+ "decode(a.data_scale, null, decode(a.data_type, 'NUMBER', "
+			+ "decode(a.data_precision, null, 38, 0), 0), a.data_scale) as DECIMAL_DIGITS, b.comments "
 			+ "from all_tab_columns a left join all_col_comments b on "
 			+ "(a.owner=b.owner and a.table_name=b.table_name and a.column_name=b.column_name) ";
 


### PR DESCRIPTION
Hi all,

we use hibernate-tools in order to generate Hibernate mapping files and have implemented our own reverse engineering strategy. Now I have come across some peculiarities regarding the NUMBER type.

Side remark: The impact of the behaviour described below will become evident when implementing an alternate reverse engineering strategy that maps a BigInteger when the scale is zero and a BigDecimal otherwise.

The issues:
1) A number type can have a precision and a scale. When no precision is given, e.g. in NUMBER(*,2), then hibernate-tools will take the data length of the NUMBER field as the default column size. In my testcases the data length was always 22 bytes. I think a better choice for the default column size would be the maximum allowed precision, i.e. 38.

2) When no precision and scale are given for the NUMBER field, then Oracle will store the value as is, meaning with an arbitrary number of decimal places. Hibernate-tools will default to a precision of 22 and zero decimal digits (because null will become zero in the default case). I would suggest setting precision and scale to 38.

I would really appreciate your comments on this.

With kind regards,

Thorsten Schäfer
