### PR TITLE
Update for Hibernate 4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
 		<dependency>
 			<groupId>org.eclipse.equinox</groupId>
 			<artifactId>common</artifactId>
-			<version>3.2.0-v20060603</version>
+			<version>3.6.200-v20130402-1505</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.hibernate</groupId>
 	<artifactId>hibernate-tools</artifactId>
-	<version>4.0.0-CR1</version>
+	<version>4.3.1-LOCAL</version>
 	<packaging>jar</packaging>
 
 	<name>Hibernate Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
 	</developers>
 
 	<properties>
-		<hibernateversion>4.0.0.Final</hibernateversion>
+		<hibernateversion>4.3.1.Final</hibernateversion>
 		<hibernateJpaversion>1.0.0.Final</hibernateJpaversion>
-		<hibernateCommonsAnnotationsVersion>3.2.0.Final</hibernateCommonsAnnotationsVersion>
+		<hibernateCommonsAnnotationsVersion>4.0.4.Final</hibernateCommonsAnnotationsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- Default settings for Database connection; to be overridden in db specific profiles -->
@@ -82,7 +82,7 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hibernate</groupId>
+			<groupId>org.hibernate.common</groupId>
 			<artifactId>hibernate-commons-annotations</artifactId>
 			<version>${hibernateCommonsAnnotationsVersion}</version>
 			<scope>compile</scope>
@@ -95,7 +95,7 @@
 		</dependency>		
 		<dependency>
 			<groupId>org.hibernate.javax.persistence</groupId>
-			<artifactId>hibernate-jpa-2.0-api</artifactId>
+			<artifactId>hibernate-jpa-2.1-api</artifactId>
 			<version>${hibernateJpaversion}</version>
 			<scope>compile</scope>
 		</dependency>
@@ -150,19 +150,19 @@
         <dependency>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.8.0.v_C03</version>
+            <version>3.9.1.v20130905-0837</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>
 			<groupId>org.eclipse</groupId>
 			<artifactId>text</artifactId>
-			<version>3.2.0-v20060605-1400</version>
+			<version>3.3.0-v20070606-0010</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.core</groupId>
 			<artifactId>runtime</artifactId>
-			<version>3.2.0-v20060603</version>
+			<version>3.9.0-v20130326-1255</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -254,7 +254,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-clean-plugin</artifactId>
-				<version>2.4.1</version>
+				<version>2.5</version>
 				<configuration>
 					<filesets>
 						<fileset>
@@ -290,7 +290,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.4</version>
+				<version>1.7</version>
 				<executions>
 					<execution>
 						<phase>process-resources</phase>
@@ -309,7 +309,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.5</version>
+				<version>1.8</version>
 				<executions>
 					<execution>
 						<id>add-test-source</id>
@@ -351,7 +351,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.1</version>
+				<version>3.1</version>
 				<configuration>
 					<includes>
 						<include>**/*.java</include>
@@ -363,7 +363,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.2</version>
+				<version>2.4</version>
 				<configuration>
 					<archive>
 				<!--		<manifestEntries>
@@ -381,7 +381,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.5</version>
+				<version>2.9.1</version>
 				<configuration>
 					<stylesheetfile>${basedir}/src/javadoc/jdstyle.css</stylesheetfile>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,11 @@
 		<type>jar</type>
 		<scope>compile</scope>
 	</dependency>
+	<dependency>
+		<groupId>commons-collections</groupId>
+		<artifactId>commons-collections</artifactId>
+		<version>3.2.1</version>
+	</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
 		<artifactId>commons-collections</artifactId>
 		<version>3.2.1</version>
 	</dependency>
+	<dependency>
+		<groupId>org.slf4j</groupId>
+		<artifactId>slf4j-api</artifactId>
+		<version>1.5.8</version>
+	</dependency>
 	</dependencies>
 
 	<build>

--- a/src/java/org/hibernate/cfg/JDBCBinder.java
+++ b/src/java/org/hibernate/cfg/JDBCBinder.java
@@ -160,6 +160,7 @@ public class JDBCBinder {
 			String className = revengStrategy.tableToClassName( tableIdentifier );
 			log.debug("Building entity " + className + " based on " + tableIdentifier);
 			rc.setEntityName( className );
+			rc.setJpaEntityName( StringHelper.unqualify( className ) );
 			rc.setClassName( className );
 			rc.setProxyInterfaceName( rc.getEntityName() ); // TODO: configurable ?
 			rc.setLazy(true);

--- a/src/java/org/hibernate/cfg/JDBCBinder.java
+++ b/src/java/org/hibernate/cfg/JDBCBinder.java
@@ -26,7 +26,9 @@ import org.hibernate.cfg.reveng.JDBCToHibernateTypeHelper;
 import org.hibernate.cfg.reveng.MappingsDatabaseCollector;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.TableIdentifier;
+import org.hibernate.engine.OptimisticLockStyle;
 import org.hibernate.engine.internal.Versioning;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.StringHelper;
@@ -48,7 +50,6 @@ import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
-import org.hibernate.service.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.service.spi.Stoppable;
 import org.hibernate.type.ForeignKeyDirection;
 import org.hibernate.type.Type;
@@ -768,7 +769,7 @@ public class JDBCBinder {
 		Property property = bindBasicProperty(makeUnique(rc, propertyName), table, column, processed, mapping);
 		rc.addProperty(property);
 		rc.setVersion(property);
-		rc.setOptimisticLockMode(Versioning.OPTIMISTIC_LOCK_VERSION);
+		rc.setOptimisticLockStyle(OptimisticLockStyle.VERSION);
 		log.debug("Column " + column.getName() + " will be used for <version>/<timestamp> columns in " + identifier);
 
 	}

--- a/src/java/org/hibernate/cfg/JDBCMetaDataConfiguration.java
+++ b/src/java/org/hibernate/cfg/JDBCMetaDataConfiguration.java
@@ -8,6 +8,8 @@ import java.util.Set;
 
 import org.dom4j.Element;
 import org.hibernate.MappingException;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.engine.spi.Mapping;
@@ -16,8 +18,6 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
-import org.hibernate.service.internal.StandardServiceRegistryImpl;
 import org.hibernate.type.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,9 +44,9 @@ public class JDBCMetaDataConfiguration extends Configuration {
 	
 	public ServiceRegistry getServiceRegistry(){
 		if(serviceRegistry == null){
-			serviceRegistry = new ServiceRegistryBuilder()
+			serviceRegistry = new StandardServiceRegistryBuilder()
 				.applySettings(getProperties())
-				.buildServiceRegistry();
+				.build();
 		}
 		return serviceRegistry;
 	}

--- a/src/java/org/hibernate/cfg/reveng/JDBCReader.java
+++ b/src/java/org/hibernate/cfg/reveng/JDBCReader.java
@@ -22,7 +22,7 @@ import org.hibernate.JDBCException;
 import org.hibernate.MappingException;
 import org.hibernate.cfg.JDBCBinderException;
 import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
-import org.hibernate.service.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;

--- a/src/java/org/hibernate/cfg/reveng/OverrideRepository.java
+++ b/src/java/org/hibernate/cfg/reveng/OverrideRepository.java
@@ -17,6 +17,7 @@ import org.apache.commons.collections.MultiMap;
 import org.dom4j.Document;
 import org.hibernate.MappingException;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.xml.ErrorLogger;
 import org.hibernate.internal.util.xml.XMLHelper;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
@@ -140,9 +141,9 @@ public class OverrideRepository  {
 
 	public OverrideRepository addInputStream(InputStream xmlInputStream) throws MappingException {
 		try {
-			List errors = new ArrayList();
-			org.dom4j.Document doc = xmlHelper.createSAXReader( "XML InputStream", errors, entityResolver ).read( new InputSource( xmlInputStream ) );
-			if ( errors.size() != 0 ) throw new MappingException( "invalid override definition", ( Throwable ) errors.get( 0 ) );
+			ErrorLogger errorLogger = new ErrorLogger( "XML InputStream" );
+			org.dom4j.Document doc = xmlHelper.createSAXReader( errorLogger, entityResolver ).read( new InputSource( xmlInputStream ) );
+			if ( errorLogger.hasErrors() ) throw new MappingException( "invalid override definition", ( Throwable ) errorLogger.getErrors().get( 0 ) );
 			add( doc );
 			return this;
 		}

--- a/src/java/org/hibernate/cfg/reveng/ReverseEngineeringRuntimeInfo.java
+++ b/src/java/org/hibernate/cfg/reveng/ReverseEngineeringRuntimeInfo.java
@@ -1,9 +1,9 @@
 package org.hibernate.cfg.reveng;
 
 
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.Table;
-import org.hibernate.service.jdbc.connections.spi.ConnectionProvider;
 
 /**
  * Provides runtime-only information for reverse engineering process.

--- a/src/java/org/hibernate/tool/Version.java
+++ b/src/java/org/hibernate/tool/Version.java
@@ -5,7 +5,7 @@ import org.apache.commons.logging.LogFactory;
 
 final public class Version {
 
-	public static final String VERSION = "4.0.0";
+	public static final String VERSION = "4.3.1";
 	
 	private static final Version instance = new Version();
 	

--- a/src/java/org/hibernate/tool/hbm2x/Cfg2HbmTool.java
+++ b/src/java/org/hibernate/tool/hbm2x/Cfg2HbmTool.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import org.hibernate.FetchMode;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.engine.internal.Versioning;
+import org.hibernate.engine.OptimisticLockStyle;
 import org.hibernate.engine.query.spi.sql.NativeSQLQueryCollectionReturn;
 import org.hibernate.engine.query.spi.sql.NativeSQLQueryJoinReturn;
 import org.hibernate.engine.query.spi.sql.NativeSQLQueryReturn;
@@ -291,18 +291,18 @@ public class Cfg2HbmTool {
 	}
 
 	public boolean isClassLevelOptimisticLockMode(PersistentClass pc) {
-		return pc.getOptimisticLockMode() != Versioning.OPTIMISTIC_LOCK_VERSION;
+		return pc.getOptimisticLockStyle() != OptimisticLockStyle.VERSION;
 	}
 
 	public String getClassLevelOptimisticLockMode(PersistentClass pc) {
-		int oMode = pc.getOptimisticLockMode();
-		if ( oMode == Versioning.OPTIMISTIC_LOCK_DIRTY ) {
+		OptimisticLockStyle oMode = pc.getOptimisticLockStyle();
+		if ( oMode == OptimisticLockStyle.DIRTY ) {
 			return "dirty";
 		}
-		else if ( oMode == Versioning.OPTIMISTIC_LOCK_ALL ) {
+		else if ( oMode == OptimisticLockStyle.ALL ) {
 			return "all";
 		}
-		else if ( oMode == Versioning.OPTIMISTIC_LOCK_NONE ) {
+		else if ( oMode == OptimisticLockStyle.NONE ) {
 			return "none";
 		}
 		else {

--- a/src/java/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/src/java/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -21,11 +21,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Iterator;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.integrator.spi.IntegratorService;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
 import org.hibernate.service.spi.SessionFactoryServiceRegistryFactory;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
@@ -83,9 +83,9 @@ public class Hbm2DDLExporter extends AbstractExporter {
 
 	protected void doStart() {
 		final Configuration configuration = getConfiguration();
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings( configuration.getProperties() );
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		ServiceRegistry serviceRegistry = builder.build();
 		integrateEnvers( configuration, serviceRegistry );
 
 		if (schemaUpdate) {

--- a/src/java/org/hibernate/tool/hbm2x/HibernateConfigurationExporter.java
+++ b/src/java/org/hibernate/tool/hbm2x/HibernateConfigurationExporter.java
@@ -95,7 +95,8 @@ public class HibernateConfigurationExporter extends AbstractExporter {
         ignoredProperties.put(Environment.SESSION_FACTORY_NAME, null);
         ignoredProperties.put(Environment.HBM2DDL_AUTO, "false" );
         ignoredProperties.put("hibernate.temp.use_jdbc_metadata_defaults", null );
-        ignoredProperties.put(Environment.TRANSACTION_MANAGER_STRATEGY, "org.hibernate.console.FakeTransactionManagerLookup");
+        // FIXME was Environment.TRANSACTION_MANAGER_STRATEGY
+        ignoredProperties.put(Environment.TRANSACTION_STRATEGY, "org.hibernate.console.FakeTransactionManagerLookup");
         
         Set set = props.entrySet();
         Iterator iterator = set.iterator();

--- a/src/java/org/hibernate/tool/hbm2x/doc/DocHelper.java
+++ b/src/java/org/hibernate/tool/hbm2x/doc/DocHelper.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.HibernateException;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Settings;
 import org.hibernate.dialect.Dialect;
@@ -135,9 +136,9 @@ public final class DocHelper {
 
         this.cfg = cfg;
 
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+        StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(cfg.getProperties());
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		ServiceRegistry serviceRegistry = builder.build();
 		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
 		Settings settings = cfg.buildSettings(serviceRegistry);
 		

--- a/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
+++ b/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
@@ -828,7 +828,7 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 			return false;
 		}
 		if(field.getValue()!=null) {			
-			if (!field.isOptional() && field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER)) {				
+			if (!field.isOptional() && field.getValueGenerationStrategy() != null && field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER)) {				
 				return true;
 			} else if (field.getValue() instanceof Component) {
 				Component c = (Component) field.getValue();

--- a/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
+++ b/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
@@ -828,7 +828,7 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 			return false;
 		}
 		if(field.getValue()!=null) {			
-			if (!field.isOptional() && field.getValueGenerationStrategy() != null && field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER)) {				
+			if (!field.isOptional() && (field.getValueGenerationStrategy() == null || field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER))) {				
 				return true;
 			} else if (field.getValue() instanceof Component) {
 				Component c = (Component) field.getValue();

--- a/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
+++ b/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
@@ -28,6 +28,7 @@ import org.hibernate.tool.hbm2x.Cfg2JavaTool;
 import org.hibernate.tool.hbm2x.MetaAttributeConstants;
 import org.hibernate.tool.hbm2x.MetaAttributeHelper;
 import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
+import org.hibernate.tuple.GenerationTiming;
 import org.hibernate.internal.util.StringHelper;
 
 /**
@@ -827,7 +828,7 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 			return false;
 		}
 		if(field.getValue()!=null) {			
-			if (!field.isOptional() && field.getGeneration().equals(PropertyGeneration.NEVER)) {				
+			if (!field.isOptional() && field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER)) {				
 				return true;
 			} else if (field.getValue() instanceof Component) {
 				Component c = (Component) field.getValue();

--- a/src/java/org/hibernate/tool/hbmlint/HbmLint.java
+++ b/src/java/org/hibernate/tool/hbmlint/HbmLint.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.hbmlint;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Settings;
 import org.hibernate.service.ServiceRegistry;
@@ -25,9 +26,9 @@ public class HbmLint implements IssueCollector {
 	
 	public void analyze(Configuration cfg) {
 		
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(cfg.getProperties());
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		ServiceRegistry serviceRegistry = builder.build();
 		Settings settings = cfg.buildSettings(serviceRegistry);
 		
 		for (int i = 0; i < detectors.length; i++) {

--- a/src/java/org/hibernate/tool/hbmlint/detector/SchemaByMetaDataDetector.java
+++ b/src/java/org/hibernate/tool/hbmlint/detector/SchemaByMetaDataDetector.java
@@ -8,6 +8,7 @@ import java.util.TreeMap;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.JDBCReaderFactory;
 import org.hibernate.cfg.Settings;
@@ -59,9 +60,9 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 
 	public void initialize(Configuration cfg, Settings settings) {
 		super.initialize( cfg, settings );
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(cfg.getProperties());
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		ServiceRegistry serviceRegistry = builder.build();
 		
 		dialect = serviceRegistry.getService(JdbcServices.class).getDialect();
 

--- a/src/test/org/hibernate/tool/BaseTestCase.java
+++ b/src/test/org/hibernate/tool/BaseTestCase.java
@@ -18,6 +18,7 @@ import junit.framework.TestCase;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.io.SAXReader;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Settings;
 import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
@@ -147,9 +148,9 @@ public abstract class BaseTestCase extends TestCase {
 	public void assertNoTables() throws SQLException {
 		Configuration configuration = new Configuration();
 		
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(configuration.getProperties());
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		ServiceRegistry serviceRegistry = builder.build();
 		
 		Settings testSettings = configuration.buildSettings(serviceRegistry);
 		

--- a/src/test/org/hibernate/tool/JDBCMetaDataBinderTestCase.java
+++ b/src/test/org/hibernate/tool/JDBCMetaDataBinderTestCase.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.reveng.TableIdentifier;
@@ -73,9 +74,9 @@ public abstract class JDBCMetaDataBinderTestCase extends BaseTestCase {
 	 */
 	protected void executeDDL(String[] sqls, boolean ignoreErrors) throws SQLException {		
 		Configuration configuration = new Configuration();
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(configuration.getProperties());
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		ServiceRegistry serviceRegistry = builder.build();
 		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
 		
 		if(!appliesTo( jdbcServices.getDialect() )) {

--- a/src/test/org/hibernate/tool/hbm2x/CachedMetaDataTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/CachedMetaDataTest.java
@@ -6,6 +6,7 @@ package org.hibernate.tool.hbm2x;
 
 import java.util.Iterator;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.JDBCReaderFactory;
 import org.hibernate.cfg.Settings;
@@ -119,7 +120,8 @@ public class CachedMetaDataTest extends JDBCMetaDataBinderTestCase {
 	
 	public void testCachedDialect() {
 		
-		ServiceRegistry serviceRegistry = cfg.getServiceRegistry();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+		ServiceRegistry serviceRegistry = builder.build();
 		Settings buildSettings = cfg.buildSettings(serviceRegistry);
 				
 		MetaDataDialect realMetaData = JDBCReaderFactory.newMetaDataDialect( serviceRegistry.getService(JdbcServices.class).getDialect(), cfg.getProperties() );

--- a/src/test/org/hibernate/tool/hbm2x/DefaultDatabaseCollectorTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/DefaultDatabaseCollectorTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.JDBCReaderFactory;
 import org.hibernate.cfg.Settings;
@@ -28,8 +29,6 @@ import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
-import org.hibernate.service.internal.StandardServiceRegistryImpl;
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
 
 /**
@@ -94,8 +93,8 @@ public class DefaultDatabaseCollectorTest extends JDBCMetaDataBinderTestCase {
 	 * but getTable uses non-quoted names )
 	 */
 	public void testQuotedNamesAndDefaultDatabaseCollector() {
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+		ServiceRegistry serviceRegistry = builder.build();
 		Settings buildSettings = cfg.buildSettings(serviceRegistry);
 				
 		MetaDataDialect realMetaData = JDBCReaderFactory.newMetaDataDialect( serviceRegistry.getService(JdbcServices.class).getDialect(), cfg.getProperties() );

--- a/src/test/org/hibernate/tool/hbm2x/Hbm2CfgTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/Hbm2CfgTest.java
@@ -57,11 +57,12 @@ public class Hbm2CfgTest extends NonReflectiveTestCase {
 	   
 
 	   srcCfg = new Configuration();
-	   srcCfg.setProperty( Environment.TRANSACTION_MANAGER_STRATEGY, "org.hibernate.console.FakeTransactionManagerLookup"); // Hack for seam-gen console configurations
+	   // FIXME was Environment.TRANSACTION_MANAGER_STRATEGY, and this is possibly / probably not a correct substitution
+	   srcCfg.setProperty( Environment.TRANSACTION_STRATEGY, "org.hibernate.console.FakeTransactionManagerLookup"); // Hack for seam-gen console configurations
 	   HibernateConfigurationExporter exp = new HibernateConfigurationExporter(srcCfg, getOutputDir());
 	   exp.start();
 	   
-	   assertNull(findFirstString( Environment.TRANSACTION_MANAGER_STRATEGY, file ));
+	   assertNull(findFirstString( Environment.TRANSACTION_STRATEGY, file ));
 	   
 	 
 	}

--- a/src/test/org/hibernate/tool/hbm2x/IncrementalSchemaReadingTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/IncrementalSchemaReadingTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.JDBCReaderFactory;
 import org.hibernate.cfg.Settings;
@@ -19,7 +20,6 @@ import org.hibernate.cfg.reveng.SchemaSelection;
 import org.hibernate.cfg.reveng.dialect.JDBCMetaDataDialect;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
 import org.hibernate.tool.hbmlint.detector.TableSelectorStrategy;
 
@@ -46,9 +46,9 @@ public class IncrementalSchemaReadingTest extends JDBCMetaDataBinderTestCase {
 	}
 	
 	public void testReadSchemaIncremental() {
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(cfg.getProperties());
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		ServiceRegistry serviceRegistry = builder.build();
 
 		Settings buildSettings = cfg.buildSettings(serviceRegistry);
 

--- a/src/test/org/hibernate/tool/hbm2x/query/QueryExporterTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/query/QueryExporterTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Environment;
 import org.hibernate.service.ServiceRegistryBuilder;
 import org.hibernate.tool.NonReflectiveTestCase;
@@ -59,9 +60,9 @@ public class QueryExporterTest extends NonReflectiveTestCase {
 	}
 	
 	protected void tearDown() throws Exception {
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(getCfg().getProperties());
-		SchemaExport export = new SchemaExport(builder.buildServiceRegistry(), getCfg());
+		SchemaExport export = new SchemaExport(builder.build(), getCfg());
 		export.drop( false, true );
 		
 		if (export.getExceptions() != null && export.getExceptions().size() > 0){

--- a/src/test/org/hibernate/tool/hbmlint/SchemaAnalyzerTest.java
+++ b/src/test/org/hibernate/tool/hbmlint/SchemaAnalyzerTest.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
 import org.hibernate.tool.hbm2x.HbmLintExporter;
 import org.hibernate.tool.hbmlint.detector.SchemaByMetaDataDetector;
@@ -37,9 +37,9 @@ public class SchemaAnalyzerTest extends JDBCMetaDataBinderTestCase {
 		configuration.buildMappings();
 	
 		SchemaByMetaDataDetector analyzer = new SchemaByMetaDataDetector();
-		ServiceRegistry serviceRegistry = new ServiceRegistryBuilder()
+		ServiceRegistry serviceRegistry = new StandardServiceRegistryBuilder()
 			.applySettings( configuration.getProperties() )
-			.buildServiceRegistry();
+			.build();
 		analyzer.initialize( configuration, configuration.buildSettings(serviceRegistry) );
 		
 		Iterator tableMappings = configuration.getTableMappings();

--- a/src/test/org/hibernate/tool/stat/StatisticsBrowserDemo.java
+++ b/src/test/org/hibernate/tool/stat/StatisticsBrowserDemo.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.Settings;
@@ -69,9 +70,9 @@ public class StatisticsBrowserDemo extends NonReflectiveTestCase {
 		Statement statement = null;
 		Connection con = null;
 		Settings settings = null;
-		ServiceRegistry serviceRegistry = new ServiceRegistryBuilder()
+		ServiceRegistry serviceRegistry = new StandardServiceRegistryBuilder()
 			.applySettings( getConfiguration().getProperties() )
-			.buildServiceRegistry();
+			.build();
     	
         try {
         	settings = getConfiguration().buildSettings(serviceRegistry);

--- a/src/test/org/hibernate/tool/test/DriverMetaDataTest.java
+++ b/src/test/org/hibernate/tool/test/DriverMetaDataTest.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.test;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Settings;
 import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
 import org.hibernate.cfg.reveng.ReverseEngineeringRuntimeInfo;
@@ -41,8 +42,8 @@ protected String[] getCreateSQL() {
 	public void testExportedKeys() {
 	
 		MetaDataDialect dialect = new JDBCMetaDataDialect();
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
-		ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+		ServiceRegistry serviceRegistry = builder.build();
 		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
 		Settings settings = cfg.buildSettings(serviceRegistry);
 		

--- a/src/test/org/hibernate/tool/test/DriverMetaDataTest.java
+++ b/src/test/org/hibernate/tool/test/DriverMetaDataTest.java
@@ -80,8 +80,8 @@ protected String[] getCreateSQL() {
 	public void testDataType() {
 		
 		MetaDataDialect dialect = new JDBCMetaDataDialect();
-
-		ServiceRegistry serviceRegistry = cfg.getServiceRegistry();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+		ServiceRegistry serviceRegistry = builder.build();
 		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
 		Settings settings = cfg.buildSettings(serviceRegistry);
 		
@@ -103,8 +103,8 @@ protected String[] getCreateSQL() {
 		
 	
 		MetaDataDialect dialect = new JDBCMetaDataDialect();
-		
-		ServiceRegistry serviceRegistry = cfg.getServiceRegistry();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+		ServiceRegistry serviceRegistry = builder.build();
 		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
 		Settings settings = cfg.buildSettings(serviceRegistry);
 		

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/OneToOneTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/OneToOneTest.java
@@ -15,6 +15,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 
 import org.hibernate.MappingException;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AnnotationConfiguration;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
@@ -23,7 +24,6 @@ import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
-import org.hibernate.service.ServiceRegistryBuilder;
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
 import org.hibernate.tool.hbm2ddl.SchemaValidator;
 import org.hibernate.tool.hbm2x.HibernateMappingExporter;
@@ -223,9 +223,9 @@ public class OneToOneTest extends JDBCMetaDataBinderTestCase {
 			.addFile( new File(getOutputDir(), "Right.hbm.xml"));
 		
 		configuration.buildMappings();
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(configuration.getProperties());
-		new SchemaValidator(builder.buildServiceRegistry(), configuration).validate();
+		new SchemaValidator(builder.build(), configuration).validate();
 		} finally {
 			Thread.currentThread().setContextClassLoader(oldLoader);			
 		}
@@ -286,9 +286,9 @@ public class OneToOneTest extends JDBCMetaDataBinderTestCase {
 		
 		configuration.buildMappings();
 		
-		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(configuration.getProperties());
-		new SchemaValidator(builder.buildServiceRegistry(), configuration).validate();
+		new SchemaValidator(builder.build(), configuration).validate();
         } finally {
         	Thread.currentThread().setContextClassLoader(oldLoader);
         }

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/OverrideBinderTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/OverrideBinderTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.Settings;
@@ -139,8 +140,8 @@ public class OverrideBinderTest extends JDBCMetaDataBinderTestCase {
 	
 	private OverrideRepository buildOverrideRepository() {
 		if(settings==null) {
-			ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
-			ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+			StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+			ServiceRegistry serviceRegistry = builder.build();
 			settings = new SettingsFactory() {
 				// trick to get hibernate.properties settings for defaultschema/catalog in here
 			}.buildSettings(Environment.getProperties(), serviceRegistry);

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/RevEngForeignKeyTests.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/RevEngForeignKeyTests.java
@@ -11,6 +11,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 
 import org.hibernate.MappingException;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.Settings;
@@ -222,10 +223,10 @@ public class RevEngForeignKeyTests extends JDBCMetaDataBinderTestCase {
 
 	private OverrideRepository buildOverrideRepository() {
 		if(settings==null) {
-			ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
+			StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 			//builder.configure();
 			builder.applySettings(Environment.getProperties());
-			ServiceRegistry serviceRegistry = builder.buildServiceRegistry();
+			ServiceRegistry serviceRegistry = builder.build();
 			
 			settings = new SettingsFactory() {
 				// trick to get hibernate.properties settings for defaultschema/catalog in here


### PR DESCRIPTION
This was a bit of an ambitious change as my first time messing with hibernate-tools source. I first fixed some of the pom versions that were causing issues with the existing - but then it wouldn't compile against Hibernate 4.0.0? Mostly build vs buildServiceRegistry issues in the service registry builder. So I went the whole hog and upgraded to Hibernate 4.3. There is one test failing and that is the AntHibernateToolTest around ejb and jpa... there have been some removals in Hibernate 4.3 that make these harder to get going again.

I'd love to see Hibernate Tools workable again, it is a part of our workflow so we need it. Happy to make any changes etc to this. Is anyone interested in this contribution?
