### PR TITLE
Update for Hibernate 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ reverseoutput
 .classpath
 .project
 .settings
+/target

--- a/pom.xml
+++ b/pom.xml
@@ -150,19 +150,19 @@
         <dependency>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.8.0.v_C03</version>
+            <version>3.9.1.v20130905-0837</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>
 			<groupId>org.eclipse</groupId>
 			<artifactId>text</artifactId>
-			<version>3.2.0-v20060605-1400</version>
+			<version>3.3.0-v20070606-0010</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.core</groupId>
 			<artifactId>runtime</artifactId>
-			<version>3.2.0-v20060603</version>
+			<version>3.9.0-v20130326-1255</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -254,7 +254,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-clean-plugin</artifactId>
-				<version>2.4.1</version>
+				<version>2.5</version>
 				<configuration>
 					<filesets>
 						<fileset>
@@ -290,7 +290,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.4</version>
+				<version>1.7</version>
 				<executions>
 					<execution>
 						<phase>process-resources</phase>
@@ -309,7 +309,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.5</version>
+				<version>1.8</version>
 				<executions>
 					<execution>
 						<id>add-test-source</id>
@@ -351,7 +351,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.1</version>
+				<version>3.1</version>
 				<configuration>
 					<includes>
 						<include>**/*.java</include>
@@ -363,7 +363,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.2</version>
+				<version>2.4</version>
 				<configuration>
 					<archive>
 				<!--		<manifestEntries>
@@ -381,7 +381,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.5</version>
+				<version>2.9.1</version>
 				<configuration>
 					<stylesheetfile>${basedir}/src/javadoc/jdstyle.css</stylesheetfile>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 	</developers>
 
 	<properties>
-		<hibernateversion>4.0.0.Final</hibernateversion>
+		<hibernateversion>4.2.0.Final</hibernateversion>
 		<hibernateJpaversion>1.0.0.Final</hibernateJpaversion>
 		<hibernateCommonsAnnotationsVersion>3.2.0.Final</hibernateCommonsAnnotationsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -204,6 +204,11 @@
 		<type>jar</type>
 		<scope>compile</scope>
 	</dependency>
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.2.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
 		<dependency>
 			<groupId>org.eclipse.equinox</groupId>
 			<artifactId>common</artifactId>
-			<version>3.2.0-v20060603</version>
+			<version>3.6.200-v20130402-1505</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/src/java/org/hibernate/cfg/JDBCBinder.java
+++ b/src/java/org/hibernate/cfg/JDBCBinder.java
@@ -159,6 +159,7 @@ public class JDBCBinder {
 			String className = revengStrategy.tableToClassName( tableIdentifier );
 			log.debug("Building entity " + className + " based on " + tableIdentifier);
 			rc.setEntityName( className );
+			rc.setJpaEntityName( StringHelper.unqualify( className ) );
 			rc.setClassName( className );
 			rc.setProxyInterfaceName( rc.getEntityName() ); // TODO: configurable ?
 			rc.setLazy(true);

--- a/src/java/org/hibernate/cfg/reveng/OverrideRepository.java
+++ b/src/java/org/hibernate/cfg/reveng/OverrideRepository.java
@@ -17,6 +17,7 @@ import org.apache.commons.collections.MultiMap;
 import org.dom4j.Document;
 import org.hibernate.MappingException;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.xml.ErrorLogger;
 import org.hibernate.internal.util.xml.XMLHelper;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
@@ -140,9 +141,9 @@ public class OverrideRepository  {
 
 	public OverrideRepository addInputStream(InputStream xmlInputStream) throws MappingException {
 		try {
-			List errors = new ArrayList();
-			org.dom4j.Document doc = xmlHelper.createSAXReader( "XML InputStream", errors, entityResolver ).read( new InputSource( xmlInputStream ) );
-			if ( errors.size() != 0 ) throw new MappingException( "invalid override definition", ( Throwable ) errors.get( 0 ) );
+			ErrorLogger errorLogger = new ErrorLogger( "XML InputStream" );
+			org.dom4j.Document doc = xmlHelper.createSAXReader( errorLogger, entityResolver ).read( new InputSource( xmlInputStream ) );
+			if ( errorLogger.hasErrors() ) throw new MappingException( "invalid override definition", ( Throwable ) errorLogger.getErrors().get( 0 ) );
 			add( doc );
 			return this;
 		}


### PR DESCRIPTION
So that these are all in the same place, here's a pull request for the 4.2 branch. There were a couple of changes required to get it working with Hibernate 4.2; the jpaEntityName needed to be set when creating PersistentClass, and the error reporting in the XMLHelper has changed.
