### PR TITLE
HBX-1225 Proxy class should be used for referring property declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 	</developers>
 
 	<properties>
-		<hibernateversion>5.1.0.Final</hibernateversion>
+		<hibernateversion>5.1.1-SNAPSHOT</hibernateversion>
 		<hibernateJpaversion>1.0.0.Final</hibernateJpaversion>
 		<hibernateCommonsAnnotationsVersion>5.0.0.Final</hibernateCommonsAnnotationsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -813,5 +813,5 @@
 
 	</profiles>
 
-	<version>5.1.0.Alpha3</version>
+	<version>5.1.0-SNAPSHOT</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 	</developers>
 
 	<properties>
-		<hibernateversion>5.1.1-SNAPSHOT</hibernateversion>
+		<hibernateversion>5.1.0.Final</hibernateversion>
 		<hibernateJpaversion>1.0.0.Final</hibernateJpaversion>
 		<hibernateCommonsAnnotationsVersion>5.0.0.Final</hibernateCommonsAnnotationsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -813,5 +813,5 @@
 
 	</profiles>
 
-	<version>5.1.0-SNAPSHOT</version>
+	<version>5.1.0.Alpha3</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 	</developers>
 
 	<properties>
-		<hibernateversion>5.1.0.Final</hibernateversion>
+		<hibernateversion>5.1.1-SNAPSHOT</hibernateversion>
 		<hibernateJpaversion>1.0.0.Final</hibernateJpaversion>
 		<hibernateCommonsAnnotationsVersion>5.0.0.Final</hibernateCommonsAnnotationsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -813,5 +813,5 @@
 
 	</profiles>
 
-	<version>5.1.0.Alpha3</version>
+	<version>5.1.0-SNAPSHOT</version>
 </project>

--- a/src/java/org/hibernate/cfg/JDBCBinderException.java
+++ b/src/java/org/hibernate/cfg/JDBCBinderException.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.cfg;
 
+import java.io.ObjectStreamClass;
+
 import org.hibernate.HibernateException;
 
 /**
@@ -12,6 +14,9 @@ import org.hibernate.HibernateException;
  */
 public class JDBCBinderException extends HibernateException {
 
+	private static final long serialVersionUID = 
+			ObjectStreamClass.lookup(JDBCBinderException.class).getSerialVersionUID();
+	
 	/**
 	 * @param string
 	 * @param root

--- a/src/java/org/hibernate/cfg/reveng/ReverseEngineeringStrategyUtil.java
+++ b/src/java/org/hibernate/cfg/reveng/ReverseEngineeringStrategyUtil.java
@@ -143,7 +143,7 @@ final public class ReverseEngineeringStrategyUtil {
 				}
 				break;
 			case 'h':
-				if (prev == 'c' || prev == 's'){
+				if (prev != null && (prev == 'c' || prev == 's')){
 					singular += "es";
 					break;
 				}

--- a/src/java/org/hibernate/tool/Version.java
+++ b/src/java/org/hibernate/tool/Version.java
@@ -5,7 +5,7 @@ import org.apache.commons.logging.LogFactory;
 
 final public class Version {
 
-	public static final String VERSION = "5.1.0.Alpha3";
+	public static final String VERSION = "5.1.0.Alpha4";
 	
 	private static final Version instance = new Version();
 	

--- a/src/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/src/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -17,7 +17,8 @@ import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.Environment;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.PropertySet;
-import org.hibernate.MappingNotFoundException;
+import org.hibernate.boot.MappingNotFoundException;
+import org.hibernate.boot.jaxb.Origin;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.internal.util.StringHelper;
 
@@ -232,21 +233,13 @@ public class HibernateToolTask extends Task {
 		
 		if(re instanceof MappingNotFoundException) {
 			MappingNotFoundException mnf = (MappingNotFoundException)re;
-			if("resource".equals(mnf.getType())) {
-				return "A " + mnf.getType() + " located at " + mnf.getPath() + " was not found.\n" +
-						"Check the following:\n" +
-						"\n" +
-						"1) Is the spelling/casing correct ?\n" +
-						"2)	Is " + mnf.getPath() + " available via the classpath ?\n" +
-						"3) Does it actually exist ?\n";						
-			} else {
-				return "A " + mnf.getType() + " located at " + mnf.getPath() + " was not found.\n" +
+			Origin origin = mnf.getOrigin();
+			return "A " + origin.getType() + " located at " + origin.getName() + " was not found.\n" +
 				"Check the following:\n" +
 				"\n" +
 				"1) Is the spelling/casing correct ?\n" +
-				"2)	Do you permission to access " + mnf.getPath() + " ?\n" +
-				"3) Does it actually exist ?\n";	
-			}
+				"2)	Is " + mnf.getOrigin().getName() + " available via the classpath ?\n" +
+				"3) Does it actually exist ?\n";						
 		}
 
 		if(re instanceof ClassNotFoundException || re instanceof NoClassDefFoundError) {

--- a/src/java/org/hibernate/tool/hbm2x/Cfg2JavaTool.java
+++ b/src/java/org/hibernate/tool/hbm2x/Cfg2JavaTool.java
@@ -18,6 +18,7 @@ import org.hibernate.mapping.Array;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.IndexedCollection;
+import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.MetaAttributable;
 import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.PersistentClass;
@@ -159,6 +160,10 @@ public class Cfg2JavaTool {
 	}
 
 	public String getJavaTypeName(Property p, boolean useGenerics, ImportContext importContext) {
+		return getJavaTypeName(p, useGenerics, false, importContext);
+	}
+	
+	public String getJavaTypeName(Property p, boolean useGenerics, boolean preferProxies, ImportContext importContext) {
 		String overrideType = getMetaAsString( p, "property-type" );
 		if ( !StringHelper.isEmpty( overrideType ) ) {
 			String importType = importContext.importType(overrideType);			
@@ -170,13 +175,22 @@ public class Cfg2JavaTool {
 			}
 			return importType;
 		}
-		else {
-			String rawType = getRawTypeName( p, useGenerics, true, importContext );
-			if(rawType==null) {
-					throw new IllegalStateException("getJavaTypeName *must* return a value");				
+		
+		if (preferProxies && p.getValue() instanceof ManyToOne) {
+			ManyToOne m2one = (ManyToOne) p.getValue();
+			String referencedEntityName = m2one.getReferencedEntityName();
+			PersistentClass referencedEntity = m2one.getMappings().getClass(referencedEntityName);
+			if (referencedEntity != null && referencedEntity.getProxyInterfaceName() != null) {
+				String proxyInterfaceName = referencedEntity.getProxyInterfaceName();
+				return importContext.importType(proxyInterfaceName);
 			}
-			return importContext.importType(rawType);
 		}
+		
+		String rawType = getRawTypeName( p, useGenerics, true, importContext );
+		if(rawType==null) {
+				throw new IllegalStateException("getJavaTypeName *must* return a value");				
+		}
+		return importContext.importType(rawType);
 	}
 	
 	private static final Map<String,String> PRIMITIVES = 
@@ -277,7 +291,7 @@ public class Cfg2JavaTool {
 		StringBuffer buf = new StringBuffer();
 		while ( fields.hasNext() ) {
 			Property field = (Property)fields.next();
-			buf.append( getJavaTypeName( field, useGenerics, ic ) )
+			buf.append( getJavaTypeName( field, useGenerics, true, ic ) )
 					.append( " " )
 					.append( field.getName() );
 			if ( fields.hasNext() ) {

--- a/src/java/org/hibernate/tool/hbm2x/ExporterException.java
+++ b/src/java/org/hibernate/tool/hbm2x/ExporterException.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.tool.hbm2x;
 
+import java.io.ObjectStreamClass;
+
 /**
  * Exception to use in Exporters.
  * @author max
@@ -11,6 +13,9 @@ package org.hibernate.tool.hbm2x;
  */
 public class ExporterException extends RuntimeException {
 
+	private static final long serialVersionUID = 
+			ObjectStreamClass.lookup(ExporterException.class).getSerialVersionUID();
+	
 	public ExporterException() {
 		super();
 	}

--- a/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
+++ b/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
@@ -963,7 +963,7 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 				}
 
 				if(useGenerics) {
-					decl = c2j.getGenericCollectionDeclaration((Collection) p.getValue(), true, importContext);
+					decl = c2j.getGenericCollectionDeclaration((Collection) p.getValue(), true, true, importContext);
 				}
 				return initialization.getDefaultValue(comparator, decl, this);
 			} else {

--- a/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
+++ b/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
@@ -14,8 +14,10 @@ import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.IdentifierBag;
+import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.MetaAttributable;
 import org.hibernate.mapping.MetaAttribute;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.PrimitiveArray;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Selectable;
@@ -854,6 +856,15 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 	}
 	
 	public String getJavaTypeName(Property p, boolean useGenerics) {
+		if (p.getValue() instanceof ManyToOne) {
+			ManyToOne m2one = (ManyToOne) p.getValue();
+			String referencedEntityName = m2one.getReferencedEntityName();
+			PersistentClass referencedEntity = m2one.getMappings().getClass(referencedEntityName);
+			if (referencedEntity != null && referencedEntity.getProxyInterfaceName() != null) {
+				return referencedEntity.getProxyInterfaceName();
+			}
+		}
+		
 		return c2j.getJavaTypeName(p, useGenerics, this);
 	}
 	

--- a/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
+++ b/src/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
@@ -856,16 +856,7 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 	}
 	
 	public String getJavaTypeName(Property p, boolean useGenerics) {
-		if (p.getValue() instanceof ManyToOne) {
-			ManyToOne m2one = (ManyToOne) p.getValue();
-			String referencedEntityName = m2one.getReferencedEntityName();
-			PersistentClass referencedEntity = m2one.getMappings().getClass(referencedEntityName);
-			if (referencedEntity != null && referencedEntity.getProxyInterfaceName() != null) {
-				return referencedEntity.getProxyInterfaceName();
-			}
-		}
-		
-		return c2j.getJavaTypeName(p, useGenerics, this);
+		return c2j.getJavaTypeName(p, useGenerics, true, this);
 	}
 	
 	static private class DefaultInitializor {

--- a/src/java/org/hibernate/tool/hbm2x/visitor/JavaTypeFromValueVisitor.java
+++ b/src/java/org/hibernate/tool/hbm2x/visitor/JavaTypeFromValueVisitor.java
@@ -63,7 +63,7 @@ public class JavaTypeFromValueVisitor extends DefaultValueVisitor {
 	private Object acceptToOne(ToOne value) {
 		if (preferProxies) {
 			String referencedEntityName = value.getReferencedEntityName();
-			PersistentClass referencedEntity = value.getMappings().getClass(referencedEntityName);
+			PersistentClass referencedEntity = value.getMetadata().getEntityBinding(referencedEntityName);
 			if (referencedEntity != null && referencedEntity.getProxyInterfaceName() != null) {
 				return referencedEntity.getProxyInterfaceName();
 			}

--- a/src/java/org/hibernate/tool/hbm2x/visitor/JavaTypeFromValueVisitor.java
+++ b/src/java/org/hibernate/tool/hbm2x/visitor/JavaTypeFromValueVisitor.java
@@ -6,6 +6,7 @@ import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.Map;
 import org.hibernate.mapping.OneToMany;
 import org.hibernate.mapping.OneToOne;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.ToOne;
@@ -19,11 +20,17 @@ public class JavaTypeFromValueVisitor extends DefaultValueVisitor {
 
 	
 	private boolean preferRawTypeNames = true;
+	private boolean preferProxies = false;
 
 	public JavaTypeFromValueVisitor() {
 		super( true );
 	}
 	
+	public JavaTypeFromValueVisitor(boolean preferProxies) {
+		super(true);
+		this.preferProxies = preferProxies;
+	}
+
 	// special handling for Map's to avoid initialization of comparators that depends on the keys/values which might not be generated yet.
 	public Object accept(Map o) {
 		if ( o.isSorted() ) {
@@ -54,6 +61,14 @@ public class JavaTypeFromValueVisitor extends DefaultValueVisitor {
 	}
 	
 	private Object acceptToOne(ToOne value) {
+		if (preferProxies) {
+			String referencedEntityName = value.getReferencedEntityName();
+			PersistentClass referencedEntity = value.getMappings().getClass(referencedEntityName);
+			if (referencedEntity != null && referencedEntity.getProxyInterfaceName() != null) {
+				return referencedEntity.getProxyInterfaceName();
+			}
+		}
+		
 		return value.getReferencedEntityName(); // should get the cfg and lookup the persistenclass.			
 	}
 	

--- a/src/test/org/hibernate/cfg/reveng/ReverseEngineeringStrategyUtilTest.java
+++ b/src/test/org/hibernate/cfg/reveng/ReverseEngineeringStrategyUtilTest.java
@@ -1,0 +1,11 @@
+package org.hibernate.cfg.reveng;
+
+import junit.framework.TestCase;
+
+public class ReverseEngineeringStrategyUtilTest extends TestCase {
+
+  public void testSimplePluralizeWithSingleH() throws Exception {
+    String plural = ReverseEngineeringStrategyUtil.simplePluralize("h");
+    assertEquals("hs", plural);
+  }
+}

--- a/src/test/org/hibernate/tool/BaseTestCase.java
+++ b/src/test/org/hibernate/tool/BaseTestCase.java
@@ -8,7 +8,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -41,10 +41,10 @@ public abstract class BaseTestCase extends TestCase {
 	
 		private final File sourceDir;
 		private final File outputDir;
-		private final List<?> jars;
+		private final List<String> jars;
 		private URLClassLoader ucl;
 	
-		public ExecuteContext(File sourceDir, File outputDir, List<?> jars) {
+		public ExecuteContext(File sourceDir, File outputDir, List<String> jars) {
 			this.sourceDir = sourceDir;
 			this.outputDir = outputDir;
 			this.jars = jars;
@@ -55,7 +55,7 @@ public abstract class BaseTestCase extends TestCase {
 			TestHelper.compile(
 					sourceDir, 
 					outputDir, 
-					TestHelper.visitAllFiles( sourceDir, Collections.emptyList() ), 
+					TestHelper.visitAllFiles( sourceDir, new ArrayList<String>() ), 
 					"1.5",
 					TestHelper.buildClasspath( jars )
 			);

--- a/src/test/org/hibernate/tool/NonReflectiveTestCase.java
+++ b/src/test/org/hibernate/tool/NonReflectiveTestCase.java
@@ -10,6 +10,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.SessionImpl;
@@ -47,10 +48,15 @@ public abstract class NonReflectiveTestCase extends BaseTestCase {
 		MetadataSources mds = new MetadataSources();
 		addMappings(files, mds);
 		cfg = new Configuration(mds);
+		customiseConfiguration(cfg);
 		md = mds.buildMetadata();		
 		setDialect( Dialect.getDialect() );
 	}
 	
+	protected void customiseConfiguration(Configuration cfg2) {
+		
+	}
+
 	public String getCacheConcurrencyStrategy() {
 		return "nonstrict-read-write";
 	}

--- a/src/test/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3Test.java
+++ b/src/test/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3Test.java
@@ -43,7 +43,7 @@ public class JdbcHbm2JavaEjb3Test extends JDBCMetaDataBinderTestCase {
 		File file = new File("ejb3compilable");
 		file.mkdir();
 
-		ArrayList<Object> list = new ArrayList<Object>();
+		ArrayList<String> list = new ArrayList<String>();
 		List<String> jars = new ArrayList<String>();
 		jars.add("hibernate-jpa-2.1-api-1.0.0.Final.jar");
 		TestHelper.compile(getOutputDir(), file, TestHelper.visitAllFiles(getOutputDir(), list), "1.5", TestHelper.buildClasspath(jars));

--- a/src/test/org/hibernate/tool/hbm2x/Proxies.hbm.xml
+++ b/src/test/org/hibernate/tool/hbm2x/Proxies.hbm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="proxies">
+	<class name="ClassA">
+		<id name="id" type="long">
+			<generator class="native">
+				<param name="sequence">ClassA_seq</param>
+			</generator>
+		</id>
+		<many-to-one name="myClassB" class="ClassB" not-null="true" />
+	</class>
+	<class name="ClassB" proxy="ProxyB" abstract="true">
+		<id name="id" type="int">
+			<generator class="native">
+				<param name="sequence">ClassB_seq</param>
+			</generator>
+		</id>
+		<discriminator column="myType" />
+		<property name="name" type="string" />
+		<subclass name="ClassBSubA" discriminator-value="a" proxy="ProxyBSubA">
+			<property name="valueA" type="string" />
+		</subclass>
+		<subclass name="ClassBSubB" discriminator-value="iTunes" proxy="ProxyBSubB">
+			<property name="valueB" type="string" />
+		</subclass>
+	</class>
+</hibernate-mapping>

--- a/src/test/org/hibernate/tool/hbm2x/ProxiesTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/ProxiesTest.java
@@ -1,30 +1,9 @@
-/*
- * Created on 2004-12-01
- *
- */
 package org.hibernate.tool.hbm2x;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import org.hibernate.mapping.Component;
-import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.mapping.RootClass;
-import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.tool.NonReflectiveTestCase;
-import org.hibernate.tool.hbm2x.pojo.BasicPOJOClass;
 import org.hibernate.tool.hbm2x.pojo.EntityPOJOClass;
-import org.hibernate.tool.hbm2x.pojo.ImportContext;
-import org.hibernate.tool.hbm2x.pojo.ImportContextImpl;
-import org.hibernate.tool.hbm2x.pojo.NoopImportContext;
-import org.hibernate.tool.hbm2x.pojo.POJOClass;
-import org.hibernate.tool.test.TestHelper;
 
 /**
  * @author max
@@ -52,8 +31,7 @@ public class ProxiesTest extends NonReflectiveTestCase {
 	}
 
 	protected String[] getMappings() {
-		return new String[] { "Customer.hbm.xml", "Order.hbm.xml",
-				"LineItem.hbm.xml", "Product.hbm.xml", "HelloWorld.hbm.xml", "Train.hbm.xml", "Passenger.hbm.xml", "Proxies.hbm.xml" };
+		return new String[] { "Proxies.hbm.xml" };
 	}
 	
 	public void testProxies() {
@@ -64,7 +42,7 @@ public class ProxiesTest extends NonReflectiveTestCase {
 		
 		EntityPOJOClass pj = new EntityPOJOClass(classMapping, c2j);
 		String javaTypeName = pj.getJavaTypeName(property, true);
-		assertEquals("proxies.ProxyB", javaTypeName);
+		assertEquals("ProxyB", javaTypeName);
 	}
 	
 	

--- a/src/test/org/hibernate/tool/hbm2x/ProxiesTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/ProxiesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Created on 2004-12-01
+ *
+ */
+package org.hibernate.tool.hbm2x;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.mapping.Component;
+import org.hibernate.mapping.MetaAttribute;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.RootClass;
+import org.hibernate.mapping.SingleTableSubclass;
+import org.hibernate.tool.NonReflectiveTestCase;
+import org.hibernate.tool.hbm2x.pojo.BasicPOJOClass;
+import org.hibernate.tool.hbm2x.pojo.EntityPOJOClass;
+import org.hibernate.tool.hbm2x.pojo.ImportContext;
+import org.hibernate.tool.hbm2x.pojo.ImportContextImpl;
+import org.hibernate.tool.hbm2x.pojo.NoopImportContext;
+import org.hibernate.tool.hbm2x.pojo.POJOClass;
+import org.hibernate.tool.test.TestHelper;
+
+/**
+ * @author max
+ * 
+ */
+public class ProxiesTest extends NonReflectiveTestCase {
+
+	private ArtifactCollector artifactCollector;
+	
+	public ProxiesTest(String name) {
+		super( name, "hbm2javaoutput" );
+	}
+
+	protected void setUp() throws Exception {
+		super.setUp();
+
+		Exporter exporter = new POJOExporter( getCfg(), getOutputDir() );
+		artifactCollector = new ArtifactCollector();
+		exporter.setArtifactCollector(artifactCollector);
+		exporter.start();
+	}
+
+	protected String getBaseForMappings() {
+		return "org/hibernate/tool/hbm2x/";
+	}
+
+	protected String[] getMappings() {
+		return new String[] { "Customer.hbm.xml", "Order.hbm.xml",
+				"LineItem.hbm.xml", "Product.hbm.xml", "HelloWorld.hbm.xml", "Train.hbm.xml", "Passenger.hbm.xml", "Proxies.hbm.xml" };
+	}
+	
+	public void testProxies() {
+		Cfg2JavaTool c2j = new Cfg2JavaTool();
+
+		PersistentClass classMapping = getCfg().getClassMapping( "proxies.ClassA" );
+		Property property = classMapping.getProperty("myClassB");
+		
+		EntityPOJOClass pj = new EntityPOJOClass(classMapping, c2j);
+		String javaTypeName = pj.getJavaTypeName(property, true);
+		assertEquals("proxies.ProxyB", javaTypeName);
+	}
+	
+	
+}

--- a/src/test/org/hibernate/tool/hbm2x/ProxiesTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/ProxiesTest.java
@@ -1,9 +1,11 @@
 package org.hibernate.tool.hbm2x;
 
+import org.hibernate.boot.Metadata;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.tool.NonReflectiveTestCase;
 import org.hibernate.tool.hbm2x.pojo.EntityPOJOClass;
+import org.hibernate.tool.util.MetadataHelper;
 
 /**
  * @author max
@@ -36,8 +38,8 @@ public class ProxiesTest extends NonReflectiveTestCase {
 	
 	public void testProxies() {
 		Cfg2JavaTool c2j = new Cfg2JavaTool();
-
-		PersistentClass classMapping = getCfg().getClassMapping( "proxies.ClassA" );
+		Metadata metadata = MetadataHelper.getMetadata(getCfg());
+		PersistentClass classMapping = metadata.getEntityBinding("proxies.ClassA");
 		Property property = classMapping.getProperty("myClassB");
 		
 		EntityPOJOClass pj = new EntityPOJOClass(classMapping, c2j);

--- a/src/test/org/hibernate/tool/ide/completion/CompletionHelperTest.java
+++ b/src/test/org/hibernate/tool/ide/completion/CompletionHelperTest.java
@@ -31,7 +31,7 @@ public class CompletionHelperTest extends TestCase {
     }
 
     public void testGetCanonicalPath() {
-        List qts = new ArrayList();
+        List<EntityNameReference> qts = new ArrayList<EntityNameReference>();
         qts.add(new EntityNameReference("Article", "art"));
         qts.add(new EntityNameReference("art.descriptions", "descr"));
         qts.add(new EntityNameReference("descr.name", "n"));
@@ -49,7 +49,7 @@ public class CompletionHelperTest extends TestCase {
     }
 
     public void testStackOverflowInGetCanonicalPath() {
-        List qts = new ArrayList();
+        List<EntityNameReference> qts = new ArrayList<EntityNameReference>();
         qts.add(new EntityNameReference("Article", "art"));
         qts.add(new EntityNameReference("art.stores", "store"));
         qts.add(new EntityNameReference("store.articles", "art"));

--- a/src/test/org/hibernate/tool/ide/completion/HqlAnalyzerTest.java
+++ b/src/test/org/hibernate/tool/ide/completion/HqlAnalyzerTest.java
@@ -113,12 +113,12 @@ public class HqlAnalyzerTest extends TestCase {
 
     public void doTestVisibleSubQueries(String query, int size) {
     	char[] cs = query.replaceAll("\\|", "").toCharArray();
-    	List visible = new HQLAnalyzer().getVisibleSubQueries(cs, query.indexOf("|"));
+    	List<SubQuery> visible = new HQLAnalyzer().getVisibleSubQueries(cs, query.indexOf("|"));
         assertEquals("Invalid visible query size", size, visible.size());
     }
 
     private void doTestSubQueries(String query, int size) {    	
-    	List l = new HQLAnalyzer().getSubQueries(query.toCharArray(), 0).subQueries;
+    	List<SubQuery> l = new HQLAnalyzer().getSubQueries(query.toCharArray(), 0).subQueries;
         assertEquals("Incorrent subqueries count", size, l.size());
     }
 
@@ -242,11 +242,11 @@ public class HqlAnalyzerTest extends TestCase {
 
     private void doTestVisibleTables(String query, String[] types, String aliases[]) {
         char[] toCharArray = query.replaceAll("\\|", "").toCharArray();
-		List qts = new HQLAnalyzer().getVisibleEntityNames(toCharArray, getCaretPosition(query));
+		List<EntityNameReference> qts = new HQLAnalyzer().getVisibleEntityNames(toCharArray, getCaretPosition(query));
         assertEquals("Incorrect table count", types.length, qts.size());
         int i = 0;
-        for (Iterator iter = qts.iterator(); iter.hasNext();) {
-			EntityNameReference qt = (EntityNameReference) iter.next();
+        for (Iterator<EntityNameReference> iter = qts.iterator(); iter.hasNext();) {
+			EntityNameReference qt = iter.next();
 			assertEquals("Incorrect query table type [" + i + "]", types[i], qt.getEntityName());
             assertEquals("Incorrect query table alias [" + i + "]", aliases[i++], qt.getAlias());
         }

--- a/src/test/org/hibernate/tool/ide/completion/Model.java
+++ b/src/test/org/hibernate/tool/ide/completion/Model.java
@@ -21,6 +21,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.tool.util.MetadataHelper;
 
 /**
  * @author leon
@@ -39,7 +40,7 @@ public class Model {
                 addInputStream(Model.class.getResourceAsStream("ProductOwnerAddress.hbm.xml")).
                 addInputStream(Model.class.getResourceAsStream("City.hbm.xml")).
         		addInputStream(Model.class.getResourceAsStream("StoreCity.hbm.xml"));
-        cfg.buildMappings();
+        MetadataHelper.getMetadata(cfg);
         return cfg;
     }
     

--- a/src/test/org/hibernate/tool/ide/completion/Product.java
+++ b/src/test/org/hibernate/tool/ide/completion/Product.java
@@ -33,11 +33,11 @@ public class Product {
 
     private BigDecimal price;
 
-    private Set stores;
+    private Set<Store> stores;
 
     private ProductOwner owner;
 
-	private Set otherOwners;
+	private Set<ProductOwner> otherOwners;
 
     public Product() {
     }
@@ -74,11 +74,11 @@ public class Product {
         this.price = price;
     }
 
-    public Set getStores() {
+    public Set<Store> getStores() {
         return stores;
     }
 
-    public void setStores(Set stores) {
+    public void setStores(Set<Store> stores) {
         this.stores = stores;
     }
 
@@ -90,11 +90,11 @@ public class Product {
         return owner;
     }
     
-    public Set getOtherOwners() {
+    public Set<ProductOwner> getOtherOwners() {
     	return otherOwners;
     }
 
-    public void setOtherOwners(Set otherOwners) {
+    public void setOtherOwners(Set<ProductOwner> otherOwners) {
 		this.otherOwners = otherOwners;
 	}
  }

--- a/src/test/org/hibernate/tool/proxies/ClassA.java
+++ b/src/test/org/hibernate/tool/proxies/ClassA.java
@@ -1,0 +1,24 @@
+package org.hibernate.tool.proxies;
+
+public class ClassA {
+
+	private int id;
+	private ClassB myClassB;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public ClassB getMyClassB() {
+		return myClassB;
+	}
+
+	public void setMyClassB(ClassB myClassB) {
+		this.myClassB = myClassB;
+	}
+	
+}

--- a/src/test/org/hibernate/tool/proxies/ClassB.java
+++ b/src/test/org/hibernate/tool/proxies/ClassB.java
@@ -1,0 +1,24 @@
+package org.hibernate.tool.proxies;
+
+public abstract class ClassB implements ProxyB {
+
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+}

--- a/src/test/org/hibernate/tool/proxies/ClassBSubA.java
+++ b/src/test/org/hibernate/tool/proxies/ClassBSubA.java
@@ -1,0 +1,15 @@
+package org.hibernate.tool.proxies;
+
+public class ClassBSubA extends ClassB implements ProxyBSubA {
+
+	private String valueA;
+
+	public String getValueA() {
+		return valueA;
+	}
+
+	public void setValueA(String valueA) {
+		this.valueA = valueA;
+	}
+	
+}

--- a/src/test/org/hibernate/tool/proxies/ClassBSubB.java
+++ b/src/test/org/hibernate/tool/proxies/ClassBSubB.java
@@ -1,0 +1,15 @@
+package org.hibernate.tool.proxies;
+
+public class ClassBSubB extends ClassB implements ProxyBSubB {
+
+	private String valueB;
+
+	public String getValueB() {
+		return valueB;
+	}
+
+	public void setValueB(String valueB) {
+		this.valueB = valueB;
+	}
+	
+}

--- a/src/test/org/hibernate/tool/proxies/ClassC.java
+++ b/src/test/org/hibernate/tool/proxies/ClassC.java
@@ -1,0 +1,24 @@
+package org.hibernate.tool.proxies;
+
+public class ClassC {
+
+	private int id;
+	private ProxyB myClassB;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public ProxyB getMyClassB() {
+		return myClassB;
+	}
+
+	public void setMyClassB(ProxyB myClassB) {
+		this.myClassB = myClassB;
+	}
+	
+}

--- a/src/test/org/hibernate/tool/proxies/ManyToOneProxies.hbm.xml
+++ b/src/test/org/hibernate/tool/proxies/ManyToOneProxies.hbm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.tool.proxies">
+	<class name="ClassA">
+		<id name="id" type="int" />
+		<many-to-one name="myClassB" class="ClassB" not-null="true" />
+	</class>
+	<class name="ClassB" proxy="ProxyB" abstract="true">
+		<id name="id" type="int" />
+		<discriminator column="myType" />
+		<property name="name" type="string" />
+		<subclass name="ClassBSubA" discriminator-value="a" proxy="ProxyBSubA">
+			<property name="valueA" type="string" />
+		</subclass>
+		<subclass name="ClassBSubB" discriminator-value="iTunes"
+			proxy="ProxyBSubB">
+			<property name="valueB" type="string" />
+		</subclass>
+	</class>
+	<class name="ClassC">
+		<id name="id" type="int" />
+		<many-to-one name="myClassB" class="ClassB" not-null="true" />
+	</class>
+</hibernate-mapping>

--- a/src/test/org/hibernate/tool/proxies/ManyToOneProxyTest.java
+++ b/src/test/org/hibernate/tool/proxies/ManyToOneProxyTest.java
@@ -1,0 +1,131 @@
+package org.hibernate.tool.proxies;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.Settings;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.NonReflectiveTestCase;
+
+public class ManyToOneProxyTest extends NonReflectiveTestCase {
+
+	public ManyToOneProxyTest(String name) {
+		super(name, "manytooneproxy");
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		buildSessionFactory();
+	}
+	
+	@Override
+	protected void tearDown() throws Exception {
+		Statement statement = null;
+		Connection con = null;
+		Settings settings = null;
+		ServiceRegistry serviceRegistry = new StandardServiceRegistryBuilder()
+			.applySettings( getConfiguration().getProperties() )
+			.build();
+    	
+        try {
+        	settings = getConfiguration().buildSettings(serviceRegistry);
+        	con = serviceRegistry.getService(JdbcServices.class).getConnectionProvider().getConnection();
+        	statement = con.createStatement();
+        	statement.execute("drop table ClassA");
+        	statement.execute("drop table ClassC");
+        	statement.execute("drop table ClassB");
+        	con.commit();
+        } catch (SQLException e) {
+        	System.err.println(e);
+        } finally {
+        	if (statement!=null) statement.close();
+        	serviceRegistry.getService(JdbcServices.class).getConnectionProvider().closeConnection(con);
+        }
+        
+		super.tearDown();
+	}
+
+	public void testFailWhenManyToOnePropertyTypeIsntProxy() {
+		Session session = openSession();
+		try {
+			/* Create some objects in the database to later retrieve */
+			ClassA a = new ClassA();
+			a.setId(1);
+			
+			ClassB b = new ClassBSubA();
+			b.setId(1);
+			a.setMyClassB(b);
+			
+			session.save(b);
+			session.save(a);
+			
+			/* Clear the session so we can retrieve */
+			session.flush();
+			session.clear();
+	
+			/* Retrieve the object. Throws an IllegalArgumentException as it tries to set the lazy proxy to the
+			 * property with the concrete basetype.
+			 */
+			try {
+				a = (ClassA) session.get(ClassA.class, 1);
+			} catch (HibernateException e) {
+				assertTrue("Unexpected exception type thrown: " + e.getCause(), e.getCause() instanceof IllegalArgumentException);
+				return;
+			}
+			
+			assertTrue("An exception was expected to be thrown.", false);
+		} finally {
+			session.close();
+		}
+	}
+
+	public void testSuccessWhenManyToOnePropertyTypeIsProxy() {
+		Session session = openSession();
+		try {
+			/* Create some objects in the database to later retrieve */
+			ClassC c = new ClassC();
+			c.setId(2);
+			
+			ClassB b = new ClassBSubA();
+			b.setId(2);
+			c.setMyClassB(b);
+			
+			session.save(b);
+			session.save(c);
+			
+			/* Clear the session so we can retrieve */
+			session.flush();
+			session.clear();
+	
+			/* Retrieve the object. Throws an IllegalArgumentException as it tries to set the lazy proxy to the
+			 * property with the concrete basetype.
+			 */
+			try {
+				c = (ClassC) session.get(ClassC.class, 2);
+			} catch (HibernateException e) {
+				assertTrue("Didn't expect an exception to be thrown: " + e.getCause(), false);
+				return;
+			}
+		} finally {
+			session.close();
+		}
+	}
+	
+	protected String getBaseForMappings() {
+		return "org/hibernate/tool/proxies/";
+	}
+
+	@Override
+	protected String[] getMappings() {
+		return new String[] { "ManyToOneProxies.hbm.xml" };
+	}
+
+}

--- a/src/test/org/hibernate/tool/proxies/ProxyB.java
+++ b/src/test/org/hibernate/tool/proxies/ProxyB.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.proxies;
+
+public interface ProxyB {
+
+}

--- a/src/test/org/hibernate/tool/proxies/ProxyBSubA.java
+++ b/src/test/org/hibernate/tool/proxies/ProxyBSubA.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.proxies;
+
+public interface ProxyBSubA extends ProxyB {
+
+}

--- a/src/test/org/hibernate/tool/proxies/ProxyBSubB.java
+++ b/src/test/org/hibernate/tool/proxies/ProxyBSubB.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.proxies;
+
+public interface ProxyBSubB extends ProxyB {
+
+}

--- a/src/test/org/hibernate/tool/stat/Group.java
+++ b/src/test/org/hibernate/tool/stat/Group.java
@@ -9,7 +9,7 @@ import java.util.Set;
  */
 public class Group {
 	private String name;
-	private Set users = new HashSet();
+	private Set<User> users = new HashSet<User>();
 	Group() {}
 	public Group(String n) {
 		name = n;
@@ -20,10 +20,10 @@ public class Group {
 	public void setName(String name) {
 		this.name = name;
 	}
-	public Set getUsers() {
+	public Set<User> getUsers() {
 		return users;
 	}
-	public void setUsers(Set users) {
+	public void setUsers(Set<User> users) {
 		this.users = users;
 	}
 	public void addUser(User user) {

--- a/src/test/org/hibernate/tool/test/TestHelper.java
+++ b/src/test/org/hibernate/tool/test/TestHelper.java
@@ -20,11 +20,10 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.eclipse.jdt.internal.compiler.batch.Main;
+import org.hibernate.internal.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.eclipse.jdt.internal.compiler.batch.Main;
-import org.hibernate.cfg.reveng.JDBCReader;
-import org.hibernate.internal.util.StringHelper;
 import org.xml.sax.SAXException;
 
 /**
@@ -47,7 +46,7 @@ public final class TestHelper {
 	 */
 	public static boolean compile(File srcdir, File outputdir) {
 
-		List files = visitAllFiles( srcdir, new ArrayList() );
+		List<String> files = visitAllFiles( srcdir, new ArrayList<String>() );
 
 		return compile( srcdir, outputdir, files );
 
@@ -59,7 +58,7 @@ public final class TestHelper {
 	 * @param srcFiles
 	 * @return
 	 */
-	public static boolean compile(File srcdir, File outputdir, List srcFiles) {
+	public static boolean compile(File srcdir, File outputdir, List<String> srcFiles) {
 		return compile( srcdir, outputdir, srcFiles, "1.4", "" );
 	}
 
@@ -74,8 +73,8 @@ public final class TestHelper {
 	 * @param classPath
 	 * @return
 	 */
-	public static boolean compile(File srcdir, File outputdir, List srcFiles, String jdktarget, String classPath) {
-		List togglesList = new ArrayList();
+	public static boolean compile(File srcdir, File outputdir, List<String> srcFiles, String jdktarget, String classPath) {
+		List<String> togglesList = new ArrayList<String>();
 		togglesList.add( "-" + jdktarget ); // put this here so DAOs compile
 		togglesList.add( "-noExit" );
 		//togglesList.add( "-noWarn" );
@@ -90,10 +89,8 @@ public final class TestHelper {
 			togglesList.add( classPath );
 		}
 
-		String[] toggles = (String[]) togglesList
-				.toArray( new String[togglesList.size()] );
-		String[] strings = (String[]) srcFiles.toArray( new String[srcFiles
-				.size()] );
+		String[] toggles = togglesList.toArray( new String[togglesList.size()] );
+		String[] strings = srcFiles.toArray( new String[srcFiles.size()] );
 		String[] arguments = new String[toggles.length + strings.length];
 		System.arraycopy( toggles, 0, arguments, 0, toggles.length );
 		System
@@ -103,8 +100,12 @@ public final class TestHelper {
 		StringWriter out = new StringWriter();
 		StringWriter err = new StringWriter();
 
-		Main main = new Main( new PrintWriter( out ), new PrintWriter( err ),
-				false );
+		Main main = new Main( 
+				new PrintWriter( out ), 
+				new PrintWriter( err ),
+				false, 
+				null, 
+				null);
 		main.compile( arguments );
 		if ( main.globalErrorsCount > 0 ) {
 			throw new RuntimeException( out.toString() + err.toString() );
@@ -137,7 +138,7 @@ public final class TestHelper {
 	 * @return
 	 */
 
-	public static List visitAllFiles(File dir, List files, String ext) {
+	public static List<String> visitAllFiles(File dir, List<String> files, String ext) {
 		if ( dir.isDirectory() ) {
 			String[] children = dir.list();
 			for (int i = 0; i < children.length; i++) {
@@ -153,7 +154,7 @@ public final class TestHelper {
 		return files;
 	}
 
-	public static List visitAllFiles(File dir, List file) {
+	public static List<String> visitAllFiles(File dir, List<String> file) {
 		return visitAllFiles( dir, file, ".java" );
 	}
 
@@ -207,8 +208,8 @@ public final class TestHelper {
 		return db;
 	}
 
-	private static List buildClasspathFiles(List jars) {
-		List classpath = new ArrayList();
+	private static List<File> buildClasspathFiles(List<String> jars) {
+		List<File> classpath = new ArrayList<File>();
 		String dir = System.getProperty("org.hibernate.tool.test.libdir", "lib" + File.separator + "testlibs");
 		if(dir==null) {
 			throw new IllegalStateException("System property org.hibernate.tool.test.libdir must be set to run tests that compile with a custom classpath");
@@ -216,9 +217,9 @@ public final class TestHelper {
 		
 		File libdir = new File(dir);
 		
-		Iterator iterator = jars.iterator();
+		Iterator<String> iterator = jars.iterator();
 		while ( iterator.hasNext() ) {
-			String jar = (String) iterator.next();
+			String jar = iterator.next();
 			File f = new File(libdir, jar);
 			if(!f.exists()) {
 				throw new IllegalStateException(f + " not found. Check if system property org.hibernate.tool.test.libdir is set correctly.");
@@ -229,13 +230,13 @@ public final class TestHelper {
 		return classpath;
 	}
 
-	public static String buildClasspath(List jars) {
-		List files = buildClasspathFiles(jars);
+	public static String buildClasspath(List<String> jars) {
+		List<File> files = buildClasspathFiles(jars);
 		StringBuffer classpath = new StringBuffer();
 		
-		Iterator iterator = files.iterator();
+		Iterator<File> iterator = files.iterator();
 		while (iterator.hasNext()) {
-			File f = (File) iterator.next();
+			File f = iterator.next();
 			classpath.append(f);
 			if(iterator.hasNext()) {
 				classpath.append(File.pathSeparatorChar);
@@ -245,17 +246,17 @@ public final class TestHelper {
 		return classpath.toString();
 	}
 	
-	public static URL[] buildClasspathURLS(List jars, File outputDir) throws MalformedURLException {
-		List files = buildClasspathFiles(jars);
-		List classpath = new ArrayList();
+	public static URL[] buildClasspathURLS(List<String> jars, File outputDir) throws MalformedURLException {
+		List<File> files = buildClasspathFiles(jars);
+		List<URL> classpath = new ArrayList<URL>();
 		
 		if(outputDir!=null) {
-			classpath.add(outputDir.toURL());
+			classpath.add(outputDir.toURI().toURL());
 		}
-		Iterator iterator = files.iterator();
+		Iterator<File> iterator = files.iterator();
 		while (iterator.hasNext()) {
-			File f = (File) iterator.next();
-			classpath.add(f.toURL());			
+			File f = iterator.next();
+			classpath.add(f.toURI().toURL());			
 		}
 		
 		return (URL[]) classpath.toArray(new URL[classpath.size()]);

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/ManyToManyTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/ManyToManyTest.java
@@ -18,6 +18,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
 import org.hibernate.tool.hbm2x.HibernateMappingExporter;
+import org.hibernate.tool.util.MetadataHelper;
 
 /**
  * @author max
@@ -108,12 +109,12 @@ public class ManyToManyTest extends JDBCMetaDataBinderTestCase {
 
 	public void testBuildMappings() {
 		
-		localCfg.buildMappings();
+		MetadataHelper.getMetadata(cfg);
 	}
 	
 	public void testGenerateAndReadable() {
 		
-		cfg.buildMappings();
+		MetadataHelper.getMetadata(cfg);
 		
 		HibernateMappingExporter hme = new HibernateMappingExporter(cfg, getOutputDir());
 		hme.start();		
@@ -135,7 +136,7 @@ public class ManyToManyTest extends JDBCMetaDataBinderTestCase {
 		    .addFile( new File(getOutputDir(), "Project.hbm.xml") )
 			.addFile( new File(getOutputDir(), "WorksOnContext.hbm.xml") );
 		
-		configuration.buildMappings();
+		MetadataHelper.getMetadata(configuration);
 		
 	}
 	

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/NoPrimaryKeyTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/NoPrimaryKeyTest.java
@@ -8,6 +8,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
+import org.hibernate.tool.util.MetadataHelper;
 
 
 
@@ -34,7 +35,7 @@ public class NoPrimaryKeyTest extends JDBCMetaDataBinderTestCase {
 	}
 	
 	public void testMe() throws Exception {
-		cfg.buildMappings();
+		MetadataHelper.getMetadata(cfg);
 	}
 	
 	public static Test suite() {

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/OneToOneTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/OneToOneTest.java
@@ -15,7 +15,6 @@ import org.hibernate.MappingException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.mapping.OneToOne;
@@ -28,6 +27,7 @@ import org.hibernate.tool.hbm2ddl.SchemaValidator;
 import org.hibernate.tool.hbm2x.HibernateMappingExporter;
 import org.hibernate.tool.hbm2x.POJOExporter;
 import org.hibernate.tool.test.TestHelper;
+import org.hibernate.tool.util.MetadataHelper;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -174,13 +174,13 @@ public class OneToOneTest extends JDBCMetaDataBinderTestCase {
 	
 	public void testBuildMappings() {
 		
-		localCfg.buildMappings();
+		MetadataHelper.getMetadata(localCfg);
 		
 	}
 	
 	public void testGenerateMappingAndReadable() throws MalformedURLException {
 		
-		cfg.buildMappings();
+		MetadataHelper.getMetadata(cfg);
 		
 		HibernateMappingExporter hme = new HibernateMappingExporter(cfg, getOutputDir());
 		hme.start();		
@@ -201,15 +201,15 @@ public class OneToOneTest extends JDBCMetaDataBinderTestCase {
 		exporter.getProperties().setProperty("jdk5", "false");
 		exporter.start();		
 		
-		ArrayList list = new ArrayList();
-		List jars = new ArrayList();
+		ArrayList<String> list = new ArrayList<String>();
+		List<String> jars = new ArrayList<String>();
 		//addAnnotationJars(jars);
 		TestHelper.compile(
 				getOutputDir(), getOutputDir(), TestHelper.visitAllFiles( getOutputDir(), list ), "1.5",
 				TestHelper.buildClasspath( jars )
 		);
         
-		URL[] urls = new URL[] { getOutputDir().toURL() };
+		URL[] urls = new URL[] { getOutputDir().toURI().toURL() };
         ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
 		URLClassLoader ucl = new URLClassLoader(urls, oldLoader );
 		try {
@@ -235,7 +235,7 @@ public class OneToOneTest extends JDBCMetaDataBinderTestCase {
 	
 	public void testGenerateAnnotatedClassesAndReadable() throws MappingException, ClassNotFoundException, MalformedURLException {
 		
-		cfg.buildMappings();
+		MetadataHelper.getMetadata(cfg);
 		POJOExporter exporter = new POJOExporter(cfg, getOutputDir() );
 		exporter.setTemplatePath(new String[0]);
 		exporter.getProperties().setProperty("ejb3", "true");
@@ -250,8 +250,8 @@ public class OneToOneTest extends JDBCMetaDataBinderTestCase {
 		assertFileAndExists( new File(getOutputDir(), "MultiPerson.java") );
 		
 		assertEquals(9, getOutputDir().listFiles().length);
-		ArrayList list = new ArrayList();
-		List jars = new ArrayList();
+		ArrayList<String> list = new ArrayList<String>();
+		List<String> jars = new ArrayList<String>();
 		
 		
 		jars.add( "hibernate-core-5.0.0.CR2.jar" );
@@ -261,37 +261,38 @@ public class OneToOneTest extends JDBCMetaDataBinderTestCase {
 				getOutputDir(), getOutputDir(), TestHelper.visitAllFiles( getOutputDir(), list ), "1.5",
 				TestHelper.buildClasspath( jars )
 		); 
-        URL[] urls = new URL[] { getOutputDir().toURL() };
+        URL[] urls = new URL[] { getOutputDir().toURI().toURL() };
         ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
 		URLClassLoader ucl = new URLClassLoader(urls, oldLoader );
-        Class personClass = ucl.loadClass("Person");
-        Class multiPersonClass = ucl.loadClass("MultiPerson");
-        Class addressMultiPerson = ucl.loadClass("AddressMultiPerson");
-        Class addressMultiPersonId = ucl.loadClass("AddressMultiPersonId");
-        Class addressPerson = ucl.loadClass("AddressPerson");
-        Class multiPersonIdClass = ucl.loadClass("MultiPersonId");
-        Class middleClass = ucl.loadClass("MiddleTable");
-        Class rightClass = ucl.loadClass("LeftTable");
-        Class leftClass = ucl.loadClass("RightTable");
+        Class<?> personClass = ucl.loadClass("Person");
+        Class<?> multiPersonClass = ucl.loadClass("MultiPerson");
+        Class<?> addressMultiPerson = ucl.loadClass("AddressMultiPerson");
+        Class<?> addressMultiPersonId = ucl.loadClass("AddressMultiPersonId");
+        Class<?> addressPerson = ucl.loadClass("AddressPerson");
+        Class<?> multiPersonIdClass = ucl.loadClass("MultiPersonId");
+        Class<?> middleClass = ucl.loadClass("MiddleTable");
+        Class<?> rightClass = ucl.loadClass("LeftTable");
+        Class<?> leftClass = ucl.loadClass("RightTable");
+
         try {
-        Thread.currentThread().setContextClassLoader(ucl);
-		
-		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
-		ServiceRegistry serviceRegistry = builder.build();
-		
-		MetadataSources mds = new MetadataSources(serviceRegistry);
-		mds.addAnnotatedClass(personClass)
-			.addAnnotatedClass(multiPersonClass)
-			.addAnnotatedClass(addressMultiPerson)
-			.addAnnotatedClass(addressMultiPersonId)
-			.addAnnotatedClass(addressPerson)
-			.addAnnotatedClass(multiPersonIdClass)
-			.addAnnotatedClass(middleClass)
-			.addAnnotatedClass(rightClass)
-			.addAnnotatedClass(leftClass);
-		Metadata metadata = mds.buildMetadata();
-		
-		new SchemaValidator().validate(metadata, serviceRegistry);
+	        Thread.currentThread().setContextClassLoader(ucl);
+			
+			StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+			ServiceRegistry serviceRegistry = builder.build();
+			
+			MetadataSources mds = new MetadataSources(serviceRegistry);
+			mds.addAnnotatedClass(personClass)
+				.addAnnotatedClass(multiPersonClass)
+				.addAnnotatedClass(addressMultiPerson)
+				.addAnnotatedClass(addressMultiPersonId)
+				.addAnnotatedClass(addressPerson)
+				.addAnnotatedClass(multiPersonIdClass)
+				.addAnnotatedClass(middleClass)
+				.addAnnotatedClass(rightClass)
+				.addAnnotatedClass(leftClass);
+			Metadata metadata = mds.buildMetadata();
+			
+			new SchemaValidator().validate(metadata, serviceRegistry);
         } finally {
         	Thread.currentThread().setContextClassLoader(oldLoader);
         }

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/OracleCompositeIdOrderTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/OracleCompositeIdOrderTest.java
@@ -8,13 +8,18 @@ import java.util.Iterator;
 
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.Oracle9Dialect;
+import org.hibernate.dialect.Oracle10gDialect;
+import org.hibernate.dialect.Oracle12cDialect;
+import org.hibernate.dialect.Oracle8iDialect;
+import org.hibernate.dialect.Oracle9iDialect;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
+import org.hibernate.tool.util.MetadataHelper;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -108,7 +113,10 @@ public class OracleCompositeIdOrderTest extends JDBCMetaDataBinderTestCase {
     }
      
      public boolean appliesTo(Dialect dialect) {
- 		return dialect instanceof Oracle9Dialect;
+ 		return dialect instanceof Oracle8iDialect || 
+ 			   dialect instanceof Oracle9iDialect ||
+ 			   dialect instanceof Oracle10gDialect ||
+ 			   dialect instanceof Oracle12cDialect;
  	}
  	
      
@@ -128,12 +136,12 @@ public class OracleCompositeIdOrderTest extends JDBCMetaDataBinderTestCase {
         assertEquals(tab.getPrimaryKey().getColumn(0).getName(), "SCHEDULE_KEY");
         assertEquals(tab.getPrimaryKey().getColumn(1).getName(), "REQUEST_KEY");
         
-        cfg.buildMappings();
+        MetadataHelper.getMetadata(cfg);
         
         PersistentClass course = cfg.getMetadata().getEntityBinding(toClassName(identifier("Course") ) );
         
         assertEquals(2,course.getIdentifier().getColumnSpan() );
-        Iterator columnIterator = course.getIdentifier().getColumnIterator();
+        Iterator<Selectable> columnIterator = course.getIdentifier().getColumnIterator();
         assertEquals(((Column)(columnIterator.next())).getName(), "SCHEDULE_KEY");
         assertEquals(((Column)(columnIterator.next())).getName(), "REQUEST_KEY");
         

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/OracleViewsTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/OracleViewsTest.java
@@ -9,7 +9,10 @@ import java.sql.SQLException;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.reveng.dialect.OracleMetaDataDialect;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.Oracle9Dialect;
+import org.hibernate.dialect.Oracle10gDialect;
+import org.hibernate.dialect.Oracle12cDialect;
+import org.hibernate.dialect.Oracle8iDialect;
+import org.hibernate.dialect.Oracle9iDialect;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
@@ -54,7 +57,10 @@ public class OracleViewsTest extends JDBCMetaDataBinderTestCase {
 	}
 
 	public boolean appliesTo(Dialect dialect) {
-		return dialect instanceof Oracle9Dialect;
+ 		return dialect instanceof Oracle8iDialect || 
+  			   dialect instanceof Oracle9iDialect ||
+  			   dialect instanceof Oracle10gDialect ||
+  			   dialect instanceof Oracle12cDialect;
 	}
 	
 	protected void configure(JDBCMetaDataConfiguration configuration) {

--- a/src/test/org/hibernate/tool/test/jdbc2cfg/TernarySchemaTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/TernarySchemaTest.java
@@ -18,6 +18,7 @@ import org.hibernate.mapping.Set;
 import org.hibernate.tool.JDBCMetaDataBinderTestCase;
 import org.hibernate.tool.hbm2x.HibernateMappingExporter;
 import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
+import org.hibernate.tool.util.MetadataHelper;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -95,9 +96,13 @@ public class TernarySchemaTest extends JDBCMetaDataBinderTestCase {
 				.getMetadata().getEntityBindings().iterator());
 
 		final PersistentClass role = cfg.getMetadata().getEntityBinding("Role");
+		assertNotNull(role);
 		PersistentClass userroles = cfg.getMetadata().getEntityBinding("Userroles");
+		assertNotNull(userroles);
 		PersistentClass user = cfg.getMetadata().getEntityBinding("User");
+		assertNotNull(user);
 		PersistentClass plainRole = cfg.getMetadata().getEntityBinding("Plainrole");
+		assertNotNull(plainRole);
 		
 
 		Property property = role.getProperty("users");
@@ -126,8 +131,7 @@ public class TernarySchemaTest extends JDBCMetaDataBinderTestCase {
 	
 	public void testGeneration() {
 		
-	
-		cfg.buildMappings();
+		MetadataHelper.getMetadata(cfg);
 		
 		HibernateMappingExporter hme = new HibernateMappingExporter(cfg, getOutputDir());
 		hme.start();		
@@ -143,7 +147,7 @@ public class TernarySchemaTest extends JDBCMetaDataBinderTestCase {
 		    .addFile( new File(getOutputDir(), "User.hbm.xml") )
 		    .addFile( new File(getOutputDir(), "Plainrole.hbm.xml"));
 		
-		configuration.buildMappings();
+		MetadataHelper.getMetadata(configuration);
 		
 		assertMultiSchema(configuration);
 	}
@@ -152,8 +156,8 @@ public class TernarySchemaTest extends JDBCMetaDataBinderTestCase {
 		
 		super.configure(configuration);
 		 DefaultReverseEngineeringStrategy c = new DefaultReverseEngineeringStrategy() {
-			 public List getSchemaSelections() {
-				 List selections = new ArrayList();
+			 public List<SchemaSelection> getSchemaSelections() {
+				 List<SchemaSelection> selections = new ArrayList<SchemaSelection>();
 				 selections.add(new SchemaSelection(null, "PUBLIC"));
 				 selections.add(new SchemaSelection(null, "otherschema"));
 				 selections.add(new SchemaSelection(null, "thirdschema"));


### PR DESCRIPTION
Property type referencing a PersistentClass should be its proxy, if it has one as Hibernate will attempt to set the property with an instance of the proxy, that is not an instance of the property type until the proxy is resolved.

I've resolved this issue by implementing the approach noted in a comment in JavaTypeFromValueVisitor: should get the cfg and lookup the persistenclass.

So JavaTypeFromValueVisitor now needs to know the Configuration, so it can look up PersistentClasses. This means that Cfg2JavaTool needs to know the Configuration. There are a few classes that use Cfg2JavaTool, but they all had pretty easy access to Configuration, so I passed it along.

The ConfigurationNavigator also refers to Cfg2JavaTool but wasn't _so_ easy to pass Configuration through, so I've left it not doing it. This does not cause a problem for this case.