### PR TITLE
Fix incorrect @ManyToOne FetchType HBX1233

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>freemarker</groupId>
+			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>2.3.8</version>
+			<version>2.3.9</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/src/java/org/hibernate/cfg/JDBCBinder.java
+++ b/src/java/org/hibernate/cfg/JDBCBinder.java
@@ -392,6 +392,7 @@ public class JDBCBinder {
 
         if(FetchMode.JOIN.toString().equalsIgnoreCase(fetchMode)) {
         	value.setFetchMode(FetchMode.JOIN);
+            value.setLazy(false);
         }
         else if(FetchMode.SELECT.toString().equalsIgnoreCase(fetchMode)) {
         	value.setFetchMode(FetchMode.SELECT);

--- a/src/test/org/hibernate/tool/hbm2x/CustomReverseEngineerStrategyTest.java
+++ b/src/test/org/hibernate/tool/hbm2x/CustomReverseEngineerStrategyTest.java
@@ -1,0 +1,98 @@
+/*
+ * Created on 2015-06-26 Copied from JdbcHbm2JavaEjb3Test and adjusted.
+ *
+ */
+package org.hibernate.tool.hbm2x;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.hibernate.cfg.JDBCMetaDataConfiguration;
+import org.hibernate.tool.JDBCMetaDataBinderTestCase;
+import org.hibernate.tool.ant.JDBCConfigurationTask;
+import org.hibernate.tool.test.TestHelper;
+
+/**
+ * @author daren
+ *
+ *
+ */
+public class CustomReverseEngineerStrategyTest extends JDBCMetaDataBinderTestCase {
+
+    protected void setUp() throws Exception {
+        //Taken from ancestors with minor adjustment.
+        assertNoTables(); // If fails may need to remove create table statements from testdb.log and testdb.script
+
+        if (getOutputDir() != null) {
+            getOutputDir().mkdirs();
+        }
+
+        if (cfg == null) { // only do if we haven't done it before - to save time!
+
+            try {
+                executeDDL(getDropSQL(), true);
+            } catch (SQLException se) {
+                System.err.println("Error while dropping - normally ok.");
+                se.printStackTrace();
+            }
+
+            JDBCConfigurationTask jdbcConfigurationTask = new JDBCConfigurationTask();
+            jdbcConfigurationTask.setReverseStrategy(CustomReverseEngineeringStrategy.class.getName());
+            jdbcConfigurationTask.init();
+            cfg = (JDBCMetaDataConfiguration) jdbcConfigurationTask.getConfiguration();
+            String[] sqls = getCreateSQL();
+            executeDDL(sqls, false);
+            cfg.readFromJDBC();
+        }
+
+        cfg.buildMappings(); //Rebuild the mappings to add the new entities.
+        POJOExporter exporter = new POJOExporter(getConfiguration(), getOutputDir());
+        exporter.setTemplatePath(new String[0]);
+        exporter.getProperties().setProperty("ejb3", "true");
+        exporter.getProperties().setProperty("jdk5", "true");
+        exporter.start();
+    }
+
+    public void testFileExistence() {
+        assertFileAndExists(new File(getOutputDir().getAbsolutePath() + "/Postcode.java"));
+        assertFileAndExists(new File(getOutputDir().getAbsolutePath() + "/Address.java"));
+    }
+
+    public void testUniqueConstraints() {
+        assertNotNull(findFirstString("@OneToMany(fetch=FetchType.LAZY", new File(getOutputDir(), "Postcode.java")));
+        assertNotNull(findFirstString("@ManyToOne(fetch=FetchType.EAGER)", new File(getOutputDir(), "Address.java")));
+    }
+
+    public void testCompile() {
+
+        File file = new File(getOutputDir().getAbsolutePath() + "/target");
+        file.mkdir();
+
+        ArrayList list = new ArrayList();
+        List jars = new ArrayList();
+//        jars.add("hibernate-jpa-2.0-api-1.0.1.Final.jar");
+
+        TestHelper.compile(getOutputDir(), file, TestHelper.visitAllFiles(getOutputDir(), list), "1.5", TestHelper.buildClasspath(jars));
+        assertFileAndExists(new File(file.getAbsoluteFile() + "/Postcode.class"));
+        assertFileAndExists(new File(file.getAbsolutePath() + "/Address.class"));
+        TestHelper.deleteDir(file);
+    }
+
+    protected String[] getCreateSQL() {
+
+        return new String[]{
+            "create table postcode ( id char not null, code varchar(20), name varchar(20), primary key (id), constraint o1 unique (code), constraint o2 unique (name) )",
+            "create table address ( id char not null, street varchar(20), suburb varchar(20), postcodeid char not null, primary key (id), foreign key (postcodeid) references postcode(id) )"
+        };
+    }
+
+    protected String[] getDropSQL() {
+
+        return new String[]{
+            "drop table address",
+            "drop table postcode"
+        };
+    }
+
+}

--- a/src/test/org/hibernate/tool/hbm2x/CustomReverseEngineeringStrategy.java
+++ b/src/test/org/hibernate/tool/hbm2x/CustomReverseEngineeringStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Hibernate.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.cfg.reveng.AssociationInfo;
+import org.hibernate.cfg.reveng.DelegatingReverseEngineeringStrategy;
+import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
+import org.hibernate.mapping.ForeignKey;
+
+/**
+ *
+ * @author daren
+ */
+public class CustomReverseEngineeringStrategy extends DelegatingReverseEngineeringStrategy {
+
+    public CustomReverseEngineeringStrategy(ReverseEngineeringStrategy delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public AssociationInfo foreignKeyToAssociationInfo(ForeignKey foreignKey) {
+
+        return new AssociationInfo() {
+
+            @Override
+            public String getCascade() {
+                //persist,merge,delete,refresh,all
+                return null;
+            }
+
+            @Override
+            public String getFetch() {
+                //DEFAULT JOIN=eager SELECT=lazy
+                return "join";
+            }
+
+            @Override
+            public Boolean getUpdate() {
+                return null;
+            }
+
+            @Override
+            public Boolean getInsert() {
+                return null;
+            }
+        };
+    }
+
+}

--- a/src/test/org/hibernate/tool/hbm2x/Hbm2XAllTests.java
+++ b/src/test/org/hibernate/tool/hbm2x/Hbm2XAllTests.java
@@ -25,6 +25,7 @@ public class Hbm2XAllTests {
 		suite.addTestSuite(DefaultSchemaCatalogTest.class);
 		suite.addTestSuite(HashcodeEqualsTest.class);
 		suite.addTestSuite(JdbcHbm2JavaEjb3Test.class);
+		suite.addTestSuite(CustomReverseEngineerStrategyTest.class);
 		//suite.addTestSuite(DocExporterTest.class);
 		suite.addTestSuite(Hbm2EJBDaoTest.class);
 		suite


### PR DESCRIPTION
The @ManyToOne association is generated with the FetchType.LAZY when
AssociationInfo is configured with 'join'. AssociationInfo is configured
via a custom ReverseEngineeringStrategy.foreignKeyToAssociationInfo().

-Bump freemarker version so sources are accessible(no dependency changes).
-Add new tests.
