### PR TITLE
HBX-1234  NullPointerException in ReverseEngineeringStrategyUtil#simplePluralize

### DIFF
--- a/src/java/org/hibernate/cfg/reveng/ReverseEngineeringStrategyUtil.java
+++ b/src/java/org/hibernate/cfg/reveng/ReverseEngineeringStrategyUtil.java
@@ -143,7 +143,7 @@ final public class ReverseEngineeringStrategyUtil {
 				}
 				break;
 			case 'h':
-				if (prev == 'c' || prev == 's'){
+				if (prev != null && (prev == 'c' || prev == 's')){
 					singular += "es";
 					break;
 				}

--- a/src/test/org/hibernate/cfg/reveng/ReverseEngineeringStrategyUtilTest.java
+++ b/src/test/org/hibernate/cfg/reveng/ReverseEngineeringStrategyUtilTest.java
@@ -1,0 +1,11 @@
+package org.hibernate.cfg.reveng;
+
+import junit.framework.TestCase;
+
+public class ReverseEngineeringStrategyUtilTest extends TestCase {
+
+  public void testSimplePluralizeWithSingleH() throws Exception {
+    String plural = ReverseEngineeringStrategyUtil.simplePluralize("h");
+    assertEquals("hs", plural);
+  }
+}


### PR DESCRIPTION
For strings with length == 1 ReverseEngineeringStrategyUtil#simplePluralize throws NullPointerException.


Replacement for pull request #48