### PR TITLE
HBX-1331 Extracting XML pretty printer strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ reverseoutput
 .classpath
 .project
 .settings
+
+.idea
+*.iml

--- a/main/src/java/org/hibernate/tool/hbm2x/XMLPrettyPrinter.java
+++ b/main/src/java/org/hibernate/tool/hbm2x/XMLPrettyPrinter.java
@@ -4,21 +4,14 @@
  */
 package org.hibernate.tool.hbm2x;
 
+import org.hibernate.tool.hbm2x.xml.XMLPrettyPrinterStrategyFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 
 /**
  * @author max
@@ -28,7 +21,7 @@ public final class XMLPrettyPrinter {
 
 	public static void prettyPrintFile(File file) throws IOException {
 		String input = readFile(file.getAbsolutePath(), Charset.defaultCharset());
-		String output = prettyFormat(input, 4);
+		String output = prettyFormat(input);
 		PrintWriter writer = new PrintWriter(file);
 		writer.print(output);
 		writer.flush();
@@ -40,17 +33,9 @@ public final class XMLPrettyPrinter {
 		return new String(encoded, encoding);
 	}
 
-	private static String prettyFormat(String input, int indent) {
+	private static String prettyFormat(String input) {
 	    try {
-	        Source xmlInput = new StreamSource(new StringReader(input));
-	        StringWriter stringWriter = new StringWriter();
-	        StreamResult xmlOutput = new StreamResult(stringWriter);
-	        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-	        transformerFactory.setAttribute("indent-number", indent);
-	        Transformer transformer = transformerFactory.newTransformer(); 
-	        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-	        transformer.transform(xmlInput, xmlOutput);
-	        return xmlOutput.getWriter().toString();
+			return XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy().prettyPrint(input);
 	    } catch (Exception e) {
 	        throw new RuntimeException(e); // simple exception handling, please review it
 	    }

--- a/main/src/java/org/hibernate/tool/hbm2x/xml/AbstractXMLPrettyPrinterStrategy.java
+++ b/main/src/java/org/hibernate/tool/hbm2x/xml/AbstractXMLPrettyPrinterStrategy.java
@@ -1,0 +1,39 @@
+package org.hibernate.tool.hbm2x.xml;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public abstract class AbstractXMLPrettyPrinterStrategy implements XMLPrettyPrinterStrategy {
+
+    protected Document newDocument(String xml, String encoding) throws SAXException, IOException, ParserConfigurationException {
+        final Document document = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(new InputSource(new ByteArrayInputStream(xml.getBytes(encoding))));
+        document.normalize();
+        return document;
+    }
+
+    protected void removeWhitespace(final Document document) throws XPathExpressionException {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList nodeList = (NodeList) xPath.evaluate("//text()[normalize-space()='']",
+                document,
+                XPathConstants.NODESET);
+
+        for (int i = 0; i < nodeList.getLength(); ++i) {
+            Node node = nodeList.item(i);
+            node.getParentNode().removeChild(node);
+        }
+    }
+}

--- a/main/src/java/org/hibernate/tool/hbm2x/xml/DOM3LSPrettyPrinterStrategy.java
+++ b/main/src/java/org/hibernate/tool/hbm2x/xml/DOM3LSPrettyPrinterStrategy.java
@@ -1,0 +1,64 @@
+package org.hibernate.tool.hbm2x.xml;
+
+import org.w3c.dom.DOMConfiguration;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSOutput;
+import org.w3c.dom.ls.LSSerializer;
+
+import java.io.StringWriter;
+
+public class DOM3LSPrettyPrinterStrategy extends AbstractXMLPrettyPrinterStrategy {
+    private boolean outputComments;
+
+    @Override
+    public String prettyPrint(String xml) throws Exception {
+        final Document document = newDocument(xml, "UTF-8");
+        final DOMImplementationLS domImplementationLS = getDomImplementationLS(document);
+        final LSSerializer lsSerializer = newLSSerializer(domImplementationLS);
+        final LSOutput lsOutput = newLSOutput(domImplementationLS);
+
+        final StringWriter stringWriter = new StringWriter();
+        lsOutput.setCharacterStream(stringWriter);
+        lsSerializer.write(document, lsOutput);
+        return stringWriter.toString();
+    }
+
+    protected DOMImplementationLS getDomImplementationLS(final Document document) {
+        final DOMImplementation domImplementation = document.getImplementation();
+        if (domImplementation.hasFeature("LS", "3.0") && domImplementation.hasFeature("Core", "2.0")) {
+            return (DOMImplementationLS) domImplementation.getFeature("LS", "3.0");
+        } else {
+            throw new RuntimeException("DOM 3.0 LS and/or DOM 2.0 Core not supported.");
+        }
+    }
+
+    protected LSSerializer newLSSerializer(final DOMImplementationLS domImplementationLS) {
+        final LSSerializer lsSerializer = domImplementationLS.createLSSerializer();
+        final DOMConfiguration domConfiguration = lsSerializer.getDomConfig();
+        if (domConfiguration.canSetParameter("format-pretty-print", Boolean.TRUE)) {
+            lsSerializer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
+            if (domConfiguration.canSetParameter("comments", isOutputComments())) {
+                lsSerializer.getDomConfig().setParameter("comments", isOutputComments());
+            }
+            return lsSerializer;
+        } else {
+            throw new RuntimeException("DOMConfiguration 'format-pretty-print' parameter isn't settable.");
+        }
+    }
+
+    protected LSOutput newLSOutput(DOMImplementationLS domImplementationLS) {
+        final LSOutput lsOutput = domImplementationLS.createLSOutput();
+        lsOutput.setEncoding("UTF-8");
+        return lsOutput;
+    }
+
+    public boolean isOutputComments() {
+        return outputComments;
+    }
+
+    public void setOutputComments(boolean outputComments) {
+        this.outputComments = outputComments;
+    }
+}

--- a/main/src/java/org/hibernate/tool/hbm2x/xml/TrAXPrettyPrinterStrategy.java
+++ b/main/src/java/org/hibernate/tool/hbm2x/xml/TrAXPrettyPrinterStrategy.java
@@ -1,0 +1,62 @@
+package org.hibernate.tool.hbm2x.xml;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.DocumentType;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+
+public class TrAXPrettyPrinterStrategy extends AbstractXMLPrettyPrinterStrategy {
+    private int indent = 4;
+    private boolean omitXmlDeclaration;
+
+    @Override
+    public String prettyPrint(String xml) throws Exception {
+        final Document document = newDocument(xml, "UTF-8");
+        removeWhitespace(document);
+
+        final Transformer transformer = newTransformer(document);
+
+        final StringWriter stringWriter = new StringWriter();
+        transformer.transform(new DOMSource(document), new StreamResult(stringWriter));
+        return stringWriter.toString();
+    }
+
+    protected Transformer newTransformer(final Document document) throws TransformerConfigurationException {
+        final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        //transformerFactory.setAttribute("indent-number", getIndent());
+        final Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, isOmitXmlDeclaration() ? "yes" : "no");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", String.valueOf(getIndent()));
+
+        final DocumentType doctype = document.getDoctype();
+        if (doctype != null) {
+            transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, doctype.getPublicId());
+            transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());
+        }
+        return transformer;
+    }
+
+    public int getIndent() {
+        return indent;
+    }
+
+    public void setIndent(int indent) {
+        this.indent = indent;
+    }
+
+    public boolean isOmitXmlDeclaration() {
+        return omitXmlDeclaration;
+    }
+
+    public void setOmitXmlDeclaration(boolean omitXmlDeclaration) {
+        this.omitXmlDeclaration = omitXmlDeclaration;
+    }
+}

--- a/main/src/java/org/hibernate/tool/hbm2x/xml/TrAXPrettyPrinterStrategy.java
+++ b/main/src/java/org/hibernate/tool/hbm2x/xml/TrAXPrettyPrinterStrategy.java
@@ -28,20 +28,35 @@ public class TrAXPrettyPrinterStrategy extends AbstractXMLPrettyPrinterStrategy 
     }
 
     protected Transformer newTransformer(final Document document) throws TransformerConfigurationException {
-        final TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        //transformerFactory.setAttribute("indent-number", getIndent());
+        final TransformerFactory transformerFactory = newTransformerFactory();
+
         final Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.METHOD, "xml");
         transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, isOmitXmlDeclaration() ? "yes" : "no");
-        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", String.valueOf(getIndent()));
+        try {
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", String.valueOf(getIndent()));
+        } catch (IllegalArgumentException ignored) {
+        }
 
         final DocumentType doctype = document.getDoctype();
         if (doctype != null) {
             transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, doctype.getPublicId());
             transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());
         }
+
         return transformer;
+    }
+
+    protected TransformerFactory newTransformerFactory() {
+        final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        try {
+            transformerFactory.setAttribute("indent-number", getIndent());
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        return transformerFactory;
     }
 
     public int getIndent() {

--- a/main/src/java/org/hibernate/tool/hbm2x/xml/XMLPrettyPrinterStrategy.java
+++ b/main/src/java/org/hibernate/tool/hbm2x/xml/XMLPrettyPrinterStrategy.java
@@ -1,0 +1,6 @@
+package org.hibernate.tool.hbm2x.xml;
+
+public interface XMLPrettyPrinterStrategy {
+
+    String prettyPrint(String xml) throws Exception;
+}

--- a/main/src/java/org/hibernate/tool/hbm2x/xml/XMLPrettyPrinterStrategyFactory.java
+++ b/main/src/java/org/hibernate/tool/hbm2x/xml/XMLPrettyPrinterStrategyFactory.java
@@ -1,0 +1,31 @@
+package org.hibernate.tool.hbm2x.xml;
+
+public final class XMLPrettyPrinterStrategyFactory {
+    public static final String PROPERTY_STRATEGY_IMPL = "org.hibernate.tool.hbm2x.xml.XMLPrettyPrinterStrategy.impl";
+
+    private static final XMLPrettyPrinterStrategy DEFAULT_STRATEGY = new TrAXPrettyPrinterStrategy();
+
+    private XMLPrettyPrinterStrategyFactory() {
+    }
+
+    public static XMLPrettyPrinterStrategy newXMLPrettyPrinterStrategy() {
+        XMLPrettyPrinterStrategy strategy = loadFromSystemProperty();
+        return strategy == null ? DEFAULT_STRATEGY : strategy;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static XMLPrettyPrinterStrategy loadFromSystemProperty() {
+        String strategyClass = System.getProperty(PROPERTY_STRATEGY_IMPL);
+
+        if (strategyClass != null) {
+            try {
+                Class<XMLPrettyPrinterStrategy> clazz = (Class<XMLPrettyPrinterStrategy>) Class.forName(strategyClass);
+                return clazz.newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return null;
+    }
+}

--- a/main/src/java/org/hibernate/tool/hbm2x/xml/XMLPrettyPrinterStrategyFactory.java
+++ b/main/src/java/org/hibernate/tool/hbm2x/xml/XMLPrettyPrinterStrategyFactory.java
@@ -1,7 +1,7 @@
 package org.hibernate.tool.hbm2x.xml;
 
 public final class XMLPrettyPrinterStrategyFactory {
-    public static final String PROPERTY_STRATEGY_IMPL = "org.hibernate.tool.hbm2x.xml.XMLPrettyPrinterStrategy.impl";
+    public static final String PROPERTY_STRATEGY_IMPL = "org.hibernate.tool.hbm2x.xml.XMLPrettyPrinterStrategy";
 
     private static final XMLPrettyPrinterStrategy DEFAULT_STRATEGY = new TrAXPrettyPrinterStrategy();
 


### PR DESCRIPTION
After removal of JTidy dependency XML formatting of the Hibernate mapping files with extra whitespace degraded. I extracted 2 strategies for XMLPrettyPrinter that have no external dependencies to solve this issue. Other strategies can be added if necessary and configured using system property. 