### PR TITLE
HBX-1331 Adding XMLPrettyPrinter unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,9 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>
         <junit.version>4.12</junit.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <mockito.version>1.10.19</mockito.version>
+        <powermock.version>1.6.6</powermock.version>
         <hsqldb.version>2.3.3</hsqldb.version>
         <h2.version>1.4.194</h2.version>
         <hibernate-core.version>5.2.9.Final</hibernate-core.version>
@@ -56,6 +59,30 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -25,6 +25,26 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
 </project>

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/XMLPrettyPrinterTest.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/XMLPrettyPrinterTest.java
@@ -1,0 +1,97 @@
+package org.hibernate.tool.hbm2x;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.hibernate.tool.hbm2x.xml.XMLPrettyPrinterStrategy;
+import org.hibernate.tool.hbm2x.xml.XMLPrettyPrinterStrategyFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({XMLPrettyPrinter.class, XMLPrettyPrinterStrategyFactory.class})
+public class XMLPrettyPrinterTest {
+
+    private static final String FILE_NAME = "test.xml";
+    private static final String FILE_CONTENT = "<test></test>";
+    private static final String RESULT = "<test>\n</test>";
+
+    private File file;
+
+    @Mock
+    private XMLPrettyPrinterStrategy strategyMock;
+
+    @Mock
+    private PrintWriter printWriterMock;
+
+    @Before
+    public void setup() {
+        PowerMockito.mockStatic(Files.class);
+        PowerMockito.mockStatic(XMLPrettyPrinterStrategyFactory.class);
+
+        file = new File(FILE_NAME);
+    }
+
+    @Test
+    public void testInteractions() throws Exception {
+        ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
+        when(Files.readAllBytes(pathCaptor.capture())).thenReturn(FILE_CONTENT.getBytes());
+
+        when(strategyMock.prettyPrint(anyString())).thenReturn(RESULT);
+        when(XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy()).thenReturn(strategyMock);
+
+        PowerMockito.whenNew(PrintWriter.class).withArguments(file).thenReturn(printWriterMock);
+
+        XMLPrettyPrinter.prettyPrintFile(file);
+
+        PowerMockito.verifyStatic();
+        Files.readAllBytes(any(Path.class));
+
+        Path path = pathCaptor.getValue();
+        assertEquals(FILE_NAME, path.toFile().getName());
+
+        verify(strategyMock).prettyPrint(FILE_CONTENT);
+
+        PowerMockito.verifyNew(PrintWriter.class).withArguments(file);
+        verify(printWriterMock).print(RESULT);
+        verify(printWriterMock).flush();
+        verify(printWriterMock).close();
+        verifyNoMoreInteractions(printWriterMock);
+    }
+
+    @Test
+    public void testThrowsRuntimeExceptionWhenStrategyThrowsException() throws Exception {
+        when(Files.readAllBytes(any(Path.class))).thenReturn(FILE_CONTENT.getBytes());
+
+        Throwable exception = new IOException("Oops");
+        when(strategyMock.prettyPrint(anyString())).thenThrow(exception);
+        when(XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy()).thenReturn(strategyMock);
+
+        PowerMockito.whenNew(PrintWriter.class).withArguments(file).thenReturn(printWriterMock);
+
+        try {
+            XMLPrettyPrinter.prettyPrintFile(file);
+            fail("Should throw RuntimeException when strategy fails");
+        } catch (Exception ex) {
+            assertTrue(ex instanceof RuntimeException);
+            assertTrue(ex.getCause() instanceof IOException);
+            assertEquals("Oops", ex.getCause().getMessage());
+        }
+
+        verifyZeroInteractions(printWriterMock);
+    }
+
+}

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/xml/DOM3LSPrettyPrinterStrategyTest.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/xml/DOM3LSPrettyPrinterStrategyTest.java
@@ -1,0 +1,173 @@
+package org.hibernate.tool.hbm2x.xml;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.w3c.dom.DOMConfiguration;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSOutput;
+import org.w3c.dom.ls.LSSerializer;
+
+import org.hibernate.tool.test.support.ResultCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DOM3LSPrettyPrinterStrategyTest {
+
+    private static final String XML =
+            "<!DOCTYPE hibernate-mapping PUBLIC\n" +
+                    "\t\"-//Hibernate/Hibernate Mapping DTD 3.0//EN\"\n" +
+                    "\t\"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd\">\n" +
+                    "<hibernate-mapping package=\"org.hibernate.tool.hbm2x\"><class name=\"Foo\">\n" +
+                    "<id name=\"id\" type=\"integer\"><generator class=\"assigned\"/></id>\n" +
+                    "<property name=\"name\" type=\"string\" not-null=\"true\" length=\"100\"/>\n" +
+                    "</class></hibernate-mapping>";
+
+    private static final String DEFAULT_RESULT =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                    "<!DOCTYPE hibernate-mapping PUBLIC \"-//Hibernate/Hibernate Mapping DTD 3.0//EN\"\n" +
+                    "                                   \"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd\">\n" +
+                    "<hibernate-mapping package=\"org.hibernate.tool.hbm2x\">\n" +
+                    "    <class name=\"Foo\">\n" +
+                    "        <id name=\"id\" type=\"integer\">\n" +
+                    "            <generator class=\"assigned\"/>\n" +
+                    "        </id>\n" +
+                    "        <property length=\"100\" name=\"name\" not-null=\"true\" type=\"string\"/>\n" +
+                    "    </class>\n" +
+                    "</hibernate-mapping>\n";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private DOM3LSPrettyPrinterStrategy strategy;
+
+    @Spy
+    private DOM3LSPrettyPrinterStrategy strategySpy;
+
+    @Mock
+    private Document documentMock;
+
+    @Before
+    public void setup() {
+        this.strategy = new DOM3LSPrettyPrinterStrategy();
+    }
+
+    @Test
+    public void testGetDomImplementationLSSucceeds() throws Exception {
+        Document document = strategy.newDocument(XML, "UTF-8");
+
+        DOMImplementationLS domImplementationLS = strategy.getDomImplementationLS(document);
+
+        assertFalse("DOMImplementationLS should not be null", domImplementationLS == null);
+    }
+
+    @Test
+    public void testGetDomImplementationLSThrowsRuntimeExceptionWhenNoLS3_0Feature() {
+        DOMImplementation domImplementation = mock(DOMImplementation.class);
+        when(domImplementation.hasFeature("LS", "3.0")).thenReturn(false);
+        when(documentMock.getImplementation()).thenReturn(domImplementation);
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("DOM 3.0 LS and/or DOM 2.0 Core not supported.");
+
+        strategy.getDomImplementationLS(documentMock);
+    }
+
+    @Test
+    public void testGetDomImplementationLSThrowsRuntimeExceptionWhenNoCore2_0Feature() {
+        DOMImplementation domImplementation = mock(DOMImplementation.class);
+        when(domImplementation.hasFeature("core", "2.0")).thenReturn(false);
+        when(documentMock.getImplementation()).thenReturn(domImplementation);
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("DOM 3.0 LS and/or DOM 2.0 Core not supported.");
+
+        strategy.getDomImplementationLS(documentMock);
+    }
+
+    @Test
+    public void testNewSerializerSucceeds() throws Exception {
+        Document document = strategy.newDocument(XML, "UTF-8");
+        DOMImplementationLS domImplementationLS = strategy.getDomImplementationLS(document);
+
+        LSSerializer serializer = strategy.newLSSerializer(domImplementationLS);
+
+        assertFalse("LSSerializer shouldn't be null", serializer == null);
+    }
+
+    @Test
+    public void testNewSerializerThrowsExceptionWhenPrettyPrintParameterNotSettable() throws Exception {
+        DOMConfiguration domConfig = mock(DOMConfiguration.class);
+        when(domConfig.canSetParameter(eq("format-pretty-print"), anyBoolean())).thenReturn(false);
+
+        LSSerializer lsSerializer = mock(LSSerializer.class);
+        when(lsSerializer.getDomConfig()).thenReturn(domConfig);
+
+        DOMImplementationLS domImplementationLS = mock(DOMImplementationLS.class);
+        when(domImplementationLS.createLSSerializer()).thenReturn(lsSerializer);
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("DOMConfiguration 'format-pretty-print' parameter isn't settable.");
+
+        strategy.newLSSerializer(domImplementationLS);
+    }
+
+    @Test
+    public void testNewLSOutputSucceeds() throws Exception {
+        Document document = strategy.newDocument(XML, "UTF-8");
+        DOMImplementationLS domImplementationLS = strategy.getDomImplementationLS(document);
+
+        LSOutput lsOutput = strategy.newLSOutput(domImplementationLS);
+
+        assertFalse("LSOutput shouldn't be null", lsOutput == null);
+        assertEquals("UTF-8", lsOutput.getEncoding());
+    }
+
+    @Test
+    public void testPrettyPrintUsingDefaults() throws Exception {
+        ResultCaptor<Document> documentCaptor = givenDocumentResultCaptor();
+        ResultCaptor<DOMImplementationLS> implementationCaptor = givenDomImplementationLSResultCaptor();
+
+        String result = strategySpy.prettyPrint(XML);
+
+        verifyCommonInteractions(documentCaptor, implementationCaptor);
+
+        assertEquals(DEFAULT_RESULT, result);
+    }
+
+    private ResultCaptor<DOMImplementationLS> givenDomImplementationLSResultCaptor() {
+        ResultCaptor<DOMImplementationLS> implementationCaptor = new ResultCaptor<>();
+        doAnswer(implementationCaptor).when(strategySpy).getDomImplementationLS(any(Document.class));
+        return implementationCaptor;
+    }
+
+
+    private ResultCaptor<Document> givenDocumentResultCaptor() throws Exception {
+        ResultCaptor<Document> documentCaptor = new ResultCaptor<>();
+        doAnswer(documentCaptor).when(strategySpy).newDocument(anyString(), anyString());
+        return documentCaptor;
+    }
+
+    private void verifyCommonInteractions(ResultCaptor<Document> documentCaptor, ResultCaptor<DOMImplementationLS> implementationCaptor) throws Exception {
+        verify(strategySpy).newDocument(XML, "UTF-8");
+
+        Document document = documentCaptor.getResult();
+        verify(strategySpy).getDomImplementationLS(document);
+
+        DOMImplementationLS domImplementationLS = implementationCaptor.getResult();
+        verify(strategySpy).newLSSerializer(domImplementationLS);
+        verify(strategySpy).newLSOutput(domImplementationLS);
+    }
+}

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/xml/NoDefaultConstructorStrategy.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/xml/NoDefaultConstructorStrategy.java
@@ -1,0 +1,12 @@
+package org.hibernate.tool.hbm2x.xml;
+
+class NoDefaultConstructorStrategy implements XMLPrettyPrinterStrategy {
+
+    public NoDefaultConstructorStrategy(String foo) {
+    }
+
+    @Override
+    public String prettyPrint(String xml) throws Exception {
+        return xml;
+    }
+}

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/xml/TrAXPrettyPrinterStrategyTest.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/xml/TrAXPrettyPrinterStrategyTest.java
@@ -1,0 +1,187 @@
+package org.hibernate.tool.hbm2x.xml;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.w3c.dom.Document;
+import org.w3c.dom.DocumentType;
+
+import org.hibernate.tool.test.support.ResultCaptor;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXTransformerFactory;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TrAXPrettyPrinterStrategyTest {
+
+    private static final String XML =
+            "<!DOCTYPE hibernate-mapping PUBLIC\n" +
+                    "\t\"-//Hibernate/Hibernate Mapping DTD 3.0//EN\"\n" +
+                    "\t\"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd\">\n" +
+                    "<hibernate-mapping package=\"org.hibernate.tool.hbm2x\"><class name=\"Foo\">\n" +
+                    "<id name=\"id\" type=\"integer\"><generator class=\"assigned\"/></id>\n" +
+                    "<property name=\"name\" type=\"string\" not-null=\"true\" length=\"100\"/>\n" +
+                    "</class></hibernate-mapping>";
+
+    private static final String DEFAULT_RESULT =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                    "<!DOCTYPE hibernate-mapping PUBLIC \"-//Hibernate/Hibernate Mapping DTD 3.0//EN\" \"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd\">\n" +
+                    "<hibernate-mapping auto-import=\"true\" default-access=\"property\" default-cascade=\"none\" default-lazy=\"true\" package=\"org.hibernate.tool.hbm2x\">\n" +
+                    "    <class dynamic-insert=\"false\" dynamic-update=\"false\" mutable=\"true\" name=\"Foo\" optimistic-lock=\"version\" polymorphism=\"implicit\" select-before-update=\"false\">\n" +
+                    "        <id name=\"id\" type=\"integer\">\n" +
+                    "            <generator class=\"assigned\"/>\n" +
+                    "        </id>\n" +
+                    "        <property generated=\"never\" lazy=\"false\" length=\"100\" name=\"name\" not-null=\"true\" optimistic-lock=\"true\" type=\"string\" unique=\"false\"/>\n" +
+                    "    </class>\n" +
+                    "</hibernate-mapping>\n";
+
+    private static final String NO_XML_DECLARATION_RESULT =
+            "<!DOCTYPE hibernate-mapping PUBLIC \"-//Hibernate/Hibernate Mapping DTD 3.0//EN\" \"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd\">\n" +
+                    "<hibernate-mapping auto-import=\"true\" default-access=\"property\" default-cascade=\"none\" default-lazy=\"true\" package=\"org.hibernate.tool.hbm2x\">\n" +
+                    "    <class dynamic-insert=\"false\" dynamic-update=\"false\" mutable=\"true\" name=\"Foo\" optimistic-lock=\"version\" polymorphism=\"implicit\" select-before-update=\"false\">\n" +
+                    "        <id name=\"id\" type=\"integer\">\n" +
+                    "            <generator class=\"assigned\"/>\n" +
+                    "        </id>\n" +
+                    "        <property generated=\"never\" lazy=\"false\" length=\"100\" name=\"name\" not-null=\"true\" optimistic-lock=\"true\" type=\"string\" unique=\"false\"/>\n" +
+                    "    </class>\n" +
+                    "</hibernate-mapping>\n";
+
+    private static final String NON_DEFAULT_INDENT_RESULT =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                    "<!DOCTYPE hibernate-mapping PUBLIC \"-//Hibernate/Hibernate Mapping DTD 3.0//EN\" \"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd\">\n" +
+                    "<hibernate-mapping auto-import=\"true\" default-access=\"property\" default-cascade=\"none\" default-lazy=\"true\" package=\"org.hibernate.tool.hbm2x\">\n" +
+                    "        <class dynamic-insert=\"false\" dynamic-update=\"false\" mutable=\"true\" name=\"Foo\" optimistic-lock=\"version\" polymorphism=\"implicit\" select-before-update=\"false\">\n" +
+                    "                <id name=\"id\" type=\"integer\">\n" +
+                    "                        <generator class=\"assigned\"/>\n" +
+                    "                </id>\n" +
+                    "                <property generated=\"never\" lazy=\"false\" length=\"100\" name=\"name\" not-null=\"true\" optimistic-lock=\"true\" type=\"string\" unique=\"false\"/>\n" +
+                    "        </class>\n" +
+                    "</hibernate-mapping>\n";
+
+    private TrAXPrettyPrinterStrategy strategy;
+
+    @Spy
+    private TrAXPrettyPrinterStrategy strategySpy;
+
+    @Mock
+    private Document documentMock;
+
+    @Before
+    public void setup() {
+        this.strategy = new TrAXPrettyPrinterStrategy();
+    }
+
+    @Test
+    public void testNewTransformerFactoryReturnsSAXTransformerFactory() {
+        TransformerFactory transformerFactory = strategy.newTransformerFactory();
+        assertTrue(transformerFactory instanceof SAXTransformerFactory);
+    }
+
+    @Test
+    public void testNewTransformerDoesNotSetDocTypeOutputPropertiesWhenDocTypeNull() throws TransformerConfigurationException {
+        when(documentMock.getDoctype()).thenReturn(null);
+
+        Transformer transformer = strategy.newTransformer(documentMock);
+        assertFalse("Transformer shouldn't be null", transformer == null);
+        assertEquals(null, transformer.getOutputProperty(OutputKeys.DOCTYPE_PUBLIC));
+        assertEquals(null, transformer.getOutputProperty(OutputKeys.DOCTYPE_SYSTEM));
+    }
+
+    @Test
+    public void testNewTransformerSetsDocTypeOutputPropertiesWhenDocTypeSet() throws TransformerConfigurationException {
+        DocumentType documentType = mock(DocumentType.class);
+        when(documentType.getPublicId()).thenReturn("PUBLIC-ID");
+        when(documentType.getSystemId()).thenReturn("SYSTEM-ID");
+        when(documentMock.getDoctype()).thenReturn(documentType);
+
+        Transformer transformer = strategy.newTransformer(documentMock);
+        assertTrue("Transformer shouldn't be null", transformer != null);
+        assertEquals("PUBLIC-ID", transformer.getOutputProperty(OutputKeys.DOCTYPE_PUBLIC));
+        assertEquals("SYSTEM-ID", transformer.getOutputProperty(OutputKeys.DOCTYPE_SYSTEM));
+    }
+
+    @Test
+    public void testPrettyPrintUsingDefaults() throws Exception {
+        ResultCaptor<Document> documentCaptor = givenDocumentResultCaptor();
+        ResultCaptor<Transformer> transformerCaptor = givenTransformerResultCaptor();
+
+        String result = strategySpy.prettyPrint(XML);
+
+        verifyCommonInteractions(documentCaptor);
+        assertOutputProperties(transformerCaptor, "no", "4");
+
+        assertEquals(DEFAULT_RESULT, result);
+    }
+
+    @Test
+    public void testPrettyPrintOmittingXmlDeclaration() throws Exception {
+        ResultCaptor<Document> documentCaptor = givenDocumentResultCaptor();
+        ResultCaptor<Transformer> transformerCaptor = givenTransformerResultCaptor();
+
+        strategySpy.setOmitXmlDeclaration(true);
+
+        String result = strategySpy.prettyPrint(XML);
+
+        verifyCommonInteractions(documentCaptor);
+        assertOutputProperties(transformerCaptor, "yes", "4");
+
+        assertEquals(NO_XML_DECLARATION_RESULT, result);
+    }
+
+    @Test
+    public void testPrettyPrintWithNonDefaultIndent() throws Exception {
+        ResultCaptor<Document> documentCaptor = givenDocumentResultCaptor();
+        ResultCaptor<Transformer> transformerCaptor = givenTransformerResultCaptor();
+
+        strategySpy.setIndent(8);
+
+        String result = strategySpy.prettyPrint(XML);
+
+        verifyCommonInteractions(documentCaptor);
+        assertOutputProperties(transformerCaptor, "no", "8");
+
+        assertEquals(NON_DEFAULT_INDENT_RESULT, result);
+    }
+
+    private ResultCaptor<Document> givenDocumentResultCaptor() throws Exception {
+        ResultCaptor<Document> documentCaptor = new ResultCaptor<>();
+        doAnswer(documentCaptor).when(strategySpy).newDocument(anyString(), anyString());
+        return documentCaptor;
+    }
+
+    private ResultCaptor<Transformer> givenTransformerResultCaptor() throws TransformerConfigurationException {
+        ResultCaptor<Transformer> transformerCaptor = new ResultCaptor<>();
+        doAnswer(transformerCaptor).when(strategySpy).newTransformer(any(Document.class));
+        return transformerCaptor;
+    }
+
+    private void verifyCommonInteractions(ResultCaptor<Document> documentCaptor) throws Exception {
+        verify(strategySpy).newDocument(XML, "UTF-8");
+
+        Document document = documentCaptor.getResult();
+        verify(strategySpy).removeWhitespace(document);
+        verify(strategySpy).newTransformer(document);
+        verify(strategySpy).newTransformerFactory();
+    }
+
+    private void assertOutputProperties(ResultCaptor<Transformer> transformerCaptor, String expectedOmitXmlDeclaration, String expectedIndent) {
+        Transformer transformer = transformerCaptor.getResult();
+
+        assertTrue("Transform shouldn't be null", transformer != null);
+        assertEquals("xml", transformer.getOutputProperty(OutputKeys.METHOD));
+        assertEquals("UTF-8", transformer.getOutputProperty(OutputKeys.ENCODING));
+        assertEquals("yes", transformer.getOutputProperty(OutputKeys.INDENT));
+        assertEquals(expectedOmitXmlDeclaration, transformer.getOutputProperty(OutputKeys.OMIT_XML_DECLARATION));
+        assertEquals(expectedIndent, transformer.getOutputProperty("{http://xml.apache.org/xslt}indent-amount"));
+    }
+}

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/xml/XMLPrettyPrinterStrategyFactoryTest.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/xml/XMLPrettyPrinterStrategyFactoryTest.java
@@ -1,0 +1,61 @@
+package org.hibernate.tool.hbm2x.xml;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class XMLPrettyPrinterStrategyFactoryTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        System.clearProperty(XMLPrettyPrinterStrategyFactory.PROPERTY_STRATEGY_IMPL);
+    }
+
+    @Test
+    public void testStrategyKey() {
+        assertEquals("org.hibernate.tool.hbm2x.xml.XMLPrettyPrinterStrategy", XMLPrettyPrinterStrategyFactory.PROPERTY_STRATEGY_IMPL);
+    }
+
+    @Test
+    public void testDefaultStrategyIsTrAX() {
+        XMLPrettyPrinterStrategy strategy = XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy();
+        assertTrue(strategy instanceof TrAXPrettyPrinterStrategy);
+    }
+
+    @Test
+    public void testNonDefaultStrategyFromSystemPropertySucceeds() {
+        System.setProperty(XMLPrettyPrinterStrategyFactory.PROPERTY_STRATEGY_IMPL, "org.hibernate.tool.hbm2x.xml.DOM3LSPrettyPrinterStrategy");
+
+        XMLPrettyPrinterStrategy strategy = XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy();
+        assertTrue(strategy instanceof DOM3LSPrettyPrinterStrategy);
+    }
+
+    @Test
+    public void testStrategyFromSystemPropertyThrowsExceptionWhenClassNotFound() {
+        System.setProperty(XMLPrettyPrinterStrategyFactory.PROPERTY_STRATEGY_IMPL, "org.hibernate.tool.hbm2x.xml.BlahBlahStrategy");
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectCause(instanceOf(ClassNotFoundException.class));
+
+        XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy();
+    }
+
+    @Test
+    public void testStrategyFromSystemPropertyThrowsExceptionWhenNoDefaultConstructor() {
+        System.setProperty(XMLPrettyPrinterStrategyFactory.PROPERTY_STRATEGY_IMPL, "org.hibernate.tool.hbm2x.xml.NoDefaultConstructorStrategy");
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectCause(instanceOf(InstantiationException.class));
+
+        XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy();
+    }
+
+}

--- a/test/nodb/src/test/java/org/hibernate/tool/test/support/ResultCaptor.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/test/support/ResultCaptor.java
@@ -1,0 +1,19 @@
+package org.hibernate.tool.test.support;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class ResultCaptor<T> implements Answer {
+    private T result;
+
+    public T getResult() {
+        return result;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T answer(InvocationOnMock invocationOnMock) throws Throwable {
+        result = (T) invocationOnMock.callRealMethod();
+        return result;
+    }
+}


### PR DESCRIPTION
Hi @koentsje,

I created some unit tests for XMLPrettyPrinter strategies as you requested. Also, please note that those tests require new test dependencies: Hamcrest, Mockito and Powermock. Hamcrest is kind of nice to have, but the tests can easily be refactored not to use it. I do need Mockito and Powermock though. One more thing - I had to stick with Mockito 1.x because Powermock has issues with 2.x releases. Please let me know if you have any issues.
   