### PR TITLE
HBX-1537 Deploy Maven Site for Hibernate Tools Maven Plugin

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -14,8 +14,7 @@
 
   <name>Hibernate Tools Maven Plugin</name>
   <description>Maven plugin to provide hibernate-tools reverse engineering and code/schema generation abilities.</description>
-  <!-- TODO: Site to be migrated -->
-  <url>https://stadler.github.io/hibernate-tools-maven-plugin/</url>
+  <url>https://hibernate.github.io/hibernate-tools/</url>
 
   <issueManagement>
     <system>JIRA</system>
@@ -119,24 +118,23 @@
           </execution>
         </executions>
       </plugin>
-      <!-- TODO: To be integrated into hibernate-tools site -->
-      <!--<plugin>-->
-        <!--<groupId>com.github.github</groupId>-->
-        <!--<artifactId>site-maven-plugin</artifactId>-->
-        <!--<version>${site-maven-plugin.version}</version>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<goals>-->
-              <!--<goal>site</goal>-->
-            <!--</goals>-->
-            <!--<phase>site-deploy</phase>-->
-            <!--<configuration>-->
-              <!--<server>github</server>-->
-              <!--<message>Creating site for ${project.version}</message>-->
-            <!--</configuration>-->
-          <!--</execution>-->
-        <!--</executions>-->
-      <!--</plugin>-->
+      <plugin>
+        <groupId>com.github.github</groupId>
+        <artifactId>site-maven-plugin</artifactId>
+        <version>${site-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>site</goal>
+            </goals>
+            <phase>site-deploy</phase>
+            <configuration>
+              <server>github</server>
+              <message>Creating site for ${project.version}</message>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/maven-plugin/src/main/java/org/hibernate/mvn/AbstractHbm2xMojo.java
+++ b/maven-plugin/src/main/java/org/hibernate/mvn/AbstractHbm2xMojo.java
@@ -1,8 +1,6 @@
 package org.hibernate.mvn;
 
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.BuildException;
 import org.hibernate.cfg.reveng.OverrideRepository;
@@ -20,34 +18,52 @@ import java.util.Properties;
 public abstract class AbstractHbm2xMojo extends AbstractMojo {
 
     // For reveng strategy
+    /** The default package name to use when mappings for classes are created. */
     @Parameter
     private String packageName;
+
+    /** The name of a property file, e.g. hibernate.properties. */
     @Parameter
     private File revengFile;
+
     /** The class name of the reverse engineering strategy to use.
      * Extend the DefaultReverseEngineeringStrategy and override the corresponding methods, e.g.
      * to adapt the generate class names or to provide custom type mappings. */
     @Parameter(defaultValue = "org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy")
     private String revengStrategy;
+
+    /** If true, tables which are pure many-to-many link tables will be mapped as such.
+     * A pure many-to-many table is one which primary-key contains exactly two foreign-keys pointing
+     * to other entity tables and has no other columns. */
     @Parameter(defaultValue = "true")
     private boolean detectManyToMany;
+
+    /** If true, a one-to-one association will be created for each foreignkey found. */
     @Parameter(defaultValue = "true")
     private boolean detectOneToOne;
+
+    /** If true, columns named VERSION or TIMESTAMP with appropriate types will be mapped with the appropriate
+     * optimistic locking corresponding to &lt;version&gt; or &lt;timestamp&gt;. */
     @Parameter(defaultValue = "true")
     private boolean detectOptimisticLock;
+
+    /** If true, a collection will be mapped for each foreignkey. */
     @Parameter(defaultValue = "true")
     private boolean createCollectionForForeignKey;
+
+    /** If true, a many-to-one association will be created for each foreignkey found. */
     @Parameter(defaultValue = "true")
     private boolean createManyToOneForForeignKey;
 
     // For configuration
+    /** The name of a property file, e.g. hibernate.properties. */
     @Parameter(defaultValue = "${project.basedir}/src/main/hibernate/hibernate.properties")
     private File propertyFile;
 
     // Not exposed for now
     private boolean preferBasicCompositeIds = true;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void execute() {
         getLog().info("Starting " + this.getClass().getSimpleName() + "...");
         ReverseEngineeringStrategy strategy = setupReverseEngineeringStrategy();
         Properties properties = loadPropertiesFile();
@@ -89,7 +105,7 @@ public abstract class AbstractHbm2xMojo extends AbstractMojo {
         }
 
         Properties properties = new Properties();
-        try (FileInputStream is = new FileInputStream(propertyFile);) {
+        try (FileInputStream is = new FileInputStream(propertyFile)) {
             properties.load(is);
             return properties;
         } catch (FileNotFoundException e) {

--- a/maven-plugin/src/main/java/org/hibernate/mvn/Hbm2DdlMojo.java
+++ b/maven-plugin/src/main/java/org/hibernate/mvn/Hbm2DdlMojo.java
@@ -21,18 +21,44 @@ import static org.apache.maven.plugins.annotations.LifecyclePhase.GENERATE_RESOU
 @Mojo(name = "hbm2ddl", defaultPhase = GENERATE_RESOURCES)
 public class Hbm2DdlMojo extends AbstractHbm2xMojo {
 
+    /** The directory into which the DDLs will be generated. */
     @Parameter(defaultValue = "${project.build.directory}/generated-resources/")
     private File outputDirectory;
+
+    /** The default filename of the generated DDL script. */
     @Parameter(defaultValue = "schema.ddl")
     private String outputFileName;
+
+    /** The type of output to produce.
+     * <ul>
+     *   <li>DATABASE: Export to the database.</li>
+     *   <li>SCRIPT (default): Write to a script file.</li>
+     *   <li>STDOUT: Write to {@link System#out}.</li>
+     * </ul> */
     @Parameter(defaultValue = "SCRIPT")
     private Set<TargetType> targetTypes;
+
+    /**
+     * The DDLs statements to create.
+     * <ul>
+     *   <li>NONE: None - duh :P.</li>
+     *   <li>CREATE (default): Create only.</li>
+     *   <li>DROP: Drop only.</li>
+     *   <li>BOTH: Drop and then create.</li>
+     * </ul>
+     */
     @Parameter(defaultValue = "CREATE")
     private SchemaExport.Action schemaExportAction;
+
+    /** Set the end of statement delimiter. */
     @Parameter(defaultValue = ";")
     private String delimiter;
+
+    /** Should we format the sql strings? */
     @Parameter(defaultValue = "true")
     private boolean format;
+
+    /** Should we stop once an error occurs? */
     @Parameter(defaultValue = "true")
     private boolean haltOnError;
 

--- a/maven-plugin/src/main/java/org/hibernate/mvn/Hbm2JavaMojo.java
+++ b/maven-plugin/src/main/java/org/hibernate/mvn/Hbm2JavaMojo.java
@@ -17,12 +17,20 @@ import static org.apache.maven.plugins.annotations.LifecyclePhase.GENERATE_SOURC
 @Mojo(name = "hbm2java", defaultPhase = GENERATE_SOURCES)
 public class Hbm2JavaMojo extends AbstractHbm2xMojo {
 
+    /** The directory into which the JPA entities will be generated. */
     @Parameter(defaultValue = "${project.build.directory}/generated-sources/")
     private File outputDirectory;
+
+    /** Code will contain EJB 3 features, e.g. using annotations from javax.persistence
+     * and org.hibernate.annotations. */
     @Parameter(defaultValue = "false")
     private boolean ejb3;
+
+    /** Code will contain JDK 5 constructs such as generics and static imports. */
     @Parameter(defaultValue = "false")
     private boolean jdk5;
+
+    /** A path used for looking up user-edited templates. */
     @Parameter
     private String templatePath;
 


### PR DESCRIPTION
This PR configures githubs [site-maven-plugin](https://github.com/github/maven-plugins) to deploy the maven site to the hibernate-tools github page.

The site can be generated locally with `mvn site`. It provides documentation about all provided goals, parameters and defaults.
To deploy the site to the gh-pages branch of this repository use `mvn site-deploy`.

This remains to be tested by someone that can actually commit to this repository, because upon site-deploy it will commit to the gh-pages branch.

Let me know if you think there is more to be done before this can be merged.

See also https://hibernate.atlassian.net/browse/HBX-1537