### PR TITLE
HBX-1558: Create class 'org.hibernate.tool.internal.reveng.MetaAttributeXmlHelper' and implement a version of 'org.hibernate.tool.internal.reveng.MetaAttributeHelper#loadMetaMap(Element)' using 'org.w3c.dom.Element'

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -100,6 +100,11 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
 		</dependency> 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/main/src/main/java/org/hibernate/tool/internal/reveng/MetaAttributeXmlHelper.java
+++ b/main/src/main/java/org/hibernate/tool/internal/reveng/MetaAttributeXmlHelper.java
@@ -1,0 +1,38 @@
+package org.hibernate.tool.internal.reveng;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.collections.MultiMap;
+import org.apache.commons.collections.map.MultiValueMap;
+import org.hibernate.tool.internal.reveng.MetaAttributeHelper.SimpleMetaAttribute;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class MetaAttributeXmlHelper {
+
+	 static MultiMap loadMetaMap(Element element) {
+		MultiMap result = new MultiValueMap();
+		List<Element> metaAttributeList = new ArrayList<Element>();
+		NodeList nodeList = element.getElementsByTagName("meta");
+		for (int i = 0; i < nodeList.getLength(); i++) {
+			metaAttributeList.add((Element)nodeList.item(i));
+		}
+		for (Iterator<Element> iter = metaAttributeList.iterator(); iter.hasNext();) {
+			Element metaAttribute = iter.next();
+			String attribute = metaAttribute.getAttributeNode("attribute").getValue();
+			String value = metaAttribute.getTextContent();
+			String inheritStr= metaAttribute.getAttributeNode("inherit").getValue();
+			boolean inherit = true;
+			if(inheritStr!=null) {
+				inherit = Boolean.valueOf(inheritStr).booleanValue(); 
+			}			
+			SimpleMetaAttribute ma = new SimpleMetaAttribute(value, inherit);
+			result.put(attribute, ma);
+		}
+		return result;
+
+	}
+
+}

--- a/main/src/test/java/org/hibernate/tool/internal/reveng/MetaAttributeXmlHelperTest.java
+++ b/main/src/test/java/org/hibernate/tool/internal/reveng/MetaAttributeXmlHelperTest.java
@@ -1,0 +1,36 @@
+package org.hibernate.tool.internal.reveng;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.apache.commons.collections.MultiMap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+public class MetaAttributeXmlHelperTest {
+	
+	private static String XML = 
+			"<element>                                         " +
+			"  <meta attribute='blah' inherit='true'>foo</meta>" +
+			"</element>                                        ";
+	
+	@Test
+	public void testLoadMetaMap() throws Exception {
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(new ByteArrayInputStream(XML.getBytes()));
+		MultiMap mm = MetaAttributeXmlHelper.loadMetaMap(document.getDocumentElement());
+		Assert.assertEquals(1, mm.size());
+		ArrayList<?> attributeList = (ArrayList<?>)mm.get("blah");
+		Assert.assertEquals(1, attributeList.size());
+		MetaAttributeHelper.SimpleMetaAttribute attribute = 
+				(MetaAttributeHelper.SimpleMetaAttribute)attributeList.get(0);
+		Assert.assertEquals(true, attribute.inheritable);
+		Assert.assertEquals("foo", attribute.value);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>