### PR TITLE
HBX-1573: Move interface 'org.hibernate.cfg.reveng.ProgressListener' to 'org.hibernate.tool.api.reveng.ProgressListener'

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/BasicColumnProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/BasicColumnProcessor.java
@@ -9,6 +9,7 @@ import org.hibernate.cfg.JDBCBinderException;
 import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
+import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.util.TableNameQualifier;

--- a/main/src/main/java/org/hibernate/cfg/reveng/ForeignKeyProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/ForeignKeyProcessor.java
@@ -14,6 +14,7 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
+import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.util.TableNameQualifier;
 import org.slf4j.Logger;

--- a/main/src/main/java/org/hibernate/cfg/reveng/JDBCReader.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/JDBCReader.java
@@ -19,6 +19,7 @@ import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
+import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringRuntimeInfo;
 
 public class JDBCReader {

--- a/main/src/main/java/org/hibernate/cfg/reveng/TableProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/TableProcessor.java
@@ -12,6 +12,7 @@ import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
+import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/main/src/main/java/org/hibernate/tool/api/reveng/ProgressListener.java
+++ b/main/src/main/java/org/hibernate/tool/api/reveng/ProgressListener.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.api.reveng;
 
 public interface ProgressListener {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>