### PR TITLE
HBX-1592: Move class 'org.hibernate.tool.util.TableNameQualifier' to 'org.hibernate.tool.internal.util.TableNameQualifier'

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/BasicColumnProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/BasicColumnProcessor.java
@@ -13,7 +13,7 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.JdbcBinderException;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/main/src/main/java/org/hibernate/cfg/reveng/DefaultDatabaseCollector.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/DefaultDatabaseCollector.java
@@ -10,7 +10,7 @@ import java.util.Map.Entry;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 
 public class DefaultDatabaseCollector extends AbstractDatabaseCollector  {
 

--- a/main/src/main/java/org/hibernate/cfg/reveng/DefaultReverseEngineeringStrategy.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/DefaultReverseEngineeringStrategy.java
@@ -23,7 +23,7 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/main/src/main/java/org/hibernate/cfg/reveng/ForeignKeyProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/ForeignKeyProcessor.java
@@ -17,7 +17,7 @@ import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.JdbcBinderException;
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/main/src/main/java/org/hibernate/cfg/reveng/IndexProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/IndexProcessor.java
@@ -15,7 +15,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.internal.reveng.JdbcBinderException;
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/main/src/main/java/org/hibernate/cfg/reveng/OverrideRepository.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/OverrideRepository.java
@@ -33,7 +33,7 @@ import org.hibernate.tool.internal.reveng.MetaAttributeHelper;
 import org.hibernate.tool.internal.reveng.OverrideBinder;
 import org.hibernate.tool.internal.reveng.TableFilter;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;

--- a/main/src/main/java/org/hibernate/tool/hbmlint/detector/SchemaByMetaDataDetector.java
+++ b/main/src/main/java/org/hibernate/tool/hbmlint/detector/SchemaByMetaDataDetector.java
@@ -35,7 +35,7 @@ import org.hibernate.tool.hbmlint.Issue;
 import org.hibernate.tool.hbmlint.IssueCollector;
 import org.hibernate.tool.internal.reveng.JdbcReaderFactory;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 
 public class SchemaByMetaDataDetector extends RelationalModelDetector {
 

--- a/main/src/main/java/org/hibernate/tool/internal/dialect/HSQLMetaDataDialect.java
+++ b/main/src/main/java/org/hibernate/tool/internal/dialect/HSQLMetaDataDialect.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 
 /**
  * @author Dmitry Geraskov

--- a/main/src/main/java/org/hibernate/tool/internal/dialect/JDBCMetaDataDialect.java
+++ b/main/src/main/java/org/hibernate/tool/internal/dialect/JDBCMetaDataDialect.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 
 /**
  * MetaData dialect that uses standard JDBC for reading metadata.

--- a/main/src/main/java/org/hibernate/tool/internal/dialect/OracleMetaDataDialect.java
+++ b/main/src/main/java/org/hibernate/tool/internal/dialect/OracleMetaDataDialect.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 
 /**
  * Oracle Specialised MetaData dialect that uses standard JDBC and querys on the

--- a/main/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
+++ b/main/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
@@ -56,7 +56,7 @@ import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
-import org.hibernate.tool.util.TableNameQualifier;
+import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.hibernate.type.ForeignKeyDirection;
 import org.hibernate.type.Type;
 import org.slf4j.Logger;

--- a/main/src/main/java/org/hibernate/tool/internal/util/TableNameQualifier.java
+++ b/main/src/main/java/org/hibernate/tool/internal/util/TableNameQualifier.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.util;
+package org.hibernate.tool.internal.util;
 
 public class TableNameQualifier {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>