### PR TITLE
HBX-1595: Move class org.hibernate.cfg.reveng.ForeignKeysInfo' to 'org.hibernate.tool.internal.reveng.ForeignKeysInfo'

### DIFF
--- a/orm/src/main/java/org/hibernate/cfg/reveng/ForeignKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/ForeignKeyProcessor.java
@@ -16,6 +16,7 @@ import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
 import org.hibernate.tool.internal.reveng.JdbcBinderException;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;

--- a/orm/src/main/java/org/hibernate/cfg/reveng/JDBCReader.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/JDBCReader.java
@@ -23,6 +23,7 @@ import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringRuntimeInfo;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
+import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
 
 public class JDBCReader {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/ForeignKeysInfo.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/ForeignKeysInfo.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,7 +31,7 @@ public class ForeignKeysInfo {
 		this.referencedColumns = refColumns;
 	}
 	
-	Map<String, List<ForeignKey>> process(ReverseEngineeringStrategy revengStrategy) {
+	public Map<String, List<ForeignKey>> process(ReverseEngineeringStrategy revengStrategy) {
 		Map<String, List<ForeignKey>> oneToManyCandidates = new HashMap<String, List<ForeignKey>>();
         Iterator<Entry<String, Table>> iterator = dependentTables.entrySet().iterator();
 		while (iterator.hasNext() ) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>