### PR TITLE
HBX-1597: Change the Maven group id to 'org.hibernate.tool' for the Hibernate Tools artifacts

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.hibernate</groupId>
+    <groupId>org.hibernate.tool</groupId>
     <artifactId>hibernate-tools-parent</artifactId>
     <version>6.0.0-SNAPSHOT</version>
   </parent>

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-           <groupId>org.hibernate</groupId>
+           <groupId>org.hibernate.tool</groupId>
            <artifactId>hibernate-tools-parent</artifactId>
            <version>6.0.0-SNAPSHOT</version>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <version>24</version>
     </parent>
     
-    <groupId>org.hibernate</groupId>
+    <groupId>org.hibernate.tool</groupId>
     <artifactId>hibernate-tools-parent</artifactId>
     <version>6.0.0-SNAPSHOT</version>
 
@@ -118,17 +118,17 @@
                 <version>${hibernate-core.version}</version>
             </dependency>
         	    <dependency>
-        		    <groupId>org.hibernate</groupId>
+        		    <groupId>org.hibernate.tool</groupId>
         		    <artifactId>hibernate-tools-orm</artifactId>
         		    <version>${project.version}</version>
         	    </dependency>
         		<dependency>
-        		    <groupId>org.hibernate</groupId>
+        		    <groupId>org.hibernate.tool</groupId>
         		    <artifactId>hibernate-tools-tests-common</artifactId>
         		    <version>${project.version}</version>
             	</dependency>
             	<dependency>
-        	        <groupId>org.hibernate</groupId>
+        	        <groupId>org.hibernate.tool</groupId>
         		    <artifactId>hibernate-tools-tests-utils</artifactId>
         		    <version>${project.version}</version>
         	    </dependency>

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
@@ -17,11 +17,11 @@
 
     <dependencies>
     	<dependency>
-    		<groupId>org.hibernate</groupId>
+    		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-orm</artifactId>
     	</dependency>
      	<dependency>
-    		<groupId>org.hibernate</groupId>
+    		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-utils</artifactId>
      	</dependency>
         <dependency>

--- a/test/h2/pom.xml
+++ b/test/h2/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
@@ -25,7 +25,7 @@
             <artifactId>h2</artifactId>
         </dependency>
     	<dependency>
-    		<groupId>org.hibernate</groupId>
+    		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
     </dependencies>

--- a/test/hsql/pom.xml
+++ b/test/hsql/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
@@ -26,7 +26,7 @@
             <artifactId>hsqldb</artifactId>
         </dependency>
     	<dependency>
-    		<groupId>org.hibernate</groupId>
+    		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
     </dependencies>

--- a/test/maven/pom.xml
+++ b/test/maven/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>

--- a/test/mssql/pom.xml
+++ b/test/mssql/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
@@ -25,7 +25,7 @@
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
     	<dependency>
-    		<groupId>org.hibernate</groupId>
+    		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
     </dependencies>

--- a/test/mysql/pom.xml
+++ b/test/mysql/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
@@ -25,7 +25,7 @@
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
     	<dependency>
-    		<groupId>org.hibernate</groupId>
+    		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
     </dependencies>

--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
@@ -18,11 +18,11 @@
 
     <dependencies>
     	    <dependency>
-    		    <groupId>org.hibernate</groupId>
+    		    <groupId>org.hibernate.tool</groupId>
     		    <artifactId>hibernate-tools-orm</artifactId>
     	    </dependency>
     	    <dependency>
-    		    <groupId>org.hibernate</groupId>
+    		    <groupId>org.hibernate.tool</groupId>
     		    <artifactId>hibernate-tools-tests-utils</artifactId>
     	    </dependency>
         <dependency>

--- a/test/nodb/src/test/java/org/hibernate/tool/VersionTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/VersionTest/TestCase.java
@@ -37,7 +37,7 @@ public class TestCase {
 			JarFile jarFile = new JarFile(new File(path));
 			JarEntry jarEntry = jarFile
 					.getJarEntry(
-							"META-INF/maven/org.hibernate/hibernate-tools-orm/pom.xml");
+							"META-INF/maven/org.hibernate.tool/hibernate-tools-orm/pom.xml");
 			InputStream stream = jarFile.getInputStream(jarEntry);
 			result = readFromInputStream(stream);
 			jarFile.close();

--- a/test/oracle/pom.xml
+++ b/test/oracle/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
@@ -25,7 +25,7 @@
             <artifactId>ojdbc8</artifactId>
         </dependency>
     	<dependency>
-    		<groupId>org.hibernate</groupId>
+    		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
     </dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.tool</groupId>
         <artifactId>hibernate-tools-tests-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
@@ -31,7 +31,7 @@
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.tool</groupId>
             <artifactId>hibernate-tools-orm</artifactId>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>