### PR TITLE
HBX-1605: Move class 'org.hibernate.cfg.binder.PrimaryKeyInfo' to 'org.hibernate.tool.internal.reveng.PrimaryKeyInfo'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
@@ -24,7 +24,6 @@ import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.binder.PrimaryKeyInfo;
 import org.hibernate.cfg.binder.PropertyBinder;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.MappingsDatabaseCollector;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/PrimaryKeyInfo.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/PrimaryKeyInfo.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.binder;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.Properties;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>