### PR TITLE
HBX-1606: Move class 'org.hibernate.cfg.binder.MetaAttributesBinder' to 'org.hibernate.tool.internal.reveng.MetaAttributesBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/cfg/binder/PropertyBinder.java
+++ b/orm/src/main/java/org/hibernate/cfg/binder/PropertyBinder.java
@@ -4,6 +4,7 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.MetaAttributesBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/MetaAttributesBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/MetaAttributesBinder.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.binder;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.Iterator;
 import java.util.Map;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>