### PR TITLE
HBX-1607: Move class 'org.hibernate.cfg.binder.PropertyBinder' to 'org.hibernate.tool.internal.reveng.PropertyBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
@@ -24,7 +24,6 @@ import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.binder.PropertyBinder;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.MappingsDatabaseCollector;
 import org.hibernate.cfg.reveng.RevEngUtils;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/PropertyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/PropertyBinder.java
@@ -1,10 +1,9 @@
-package org.hibernate.cfg.binder;
+package org.hibernate.tool.internal.reveng;
 
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.MetaAttributesBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>