### PR TITLE
HBX-1608: Move class 'org.hibernate.cfg.reveng.TableProcessor' to 'org.hibernate.tool.internal.reveng.TableProcessor'

### DIFF
--- a/orm/src/main/java/org/hibernate/cfg/reveng/JDBCReader.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/JDBCReader.java
@@ -24,6 +24,7 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringRuntimeInfo;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
+import org.hibernate.tool.internal.reveng.TableProcessor;
 
 public class JDBCReader {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/TableProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/TableProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.ArrayList;
 import java.util.Collection;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>