### PR TITLE
HBX-1618: Move class 'org.hibernate.cfg.reveng.RevEngUtils' to 'org.hibernate.tool.internal.reveng.RevEngUtils'

### DIFF
--- a/orm/src/main/java/org/hibernate/cfg/reveng/BasicColumnProcessor.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/BasicColumnProcessor.java
@@ -12,6 +12,7 @@ import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.JdbcBinderException;
+import org.hibernate.tool.internal.reveng.RevEngUtils;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;

--- a/orm/src/main/java/org/hibernate/cfg/reveng/ForeignKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/ForeignKeyProcessor.java
@@ -18,6 +18,7 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
 import org.hibernate.tool.internal.reveng.JdbcBinderException;
+import org.hibernate.tool.internal.reveng.RevEngUtils;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/orm/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
@@ -16,6 +16,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.JdbcBinderException;
+import org.hibernate.tool.internal.reveng.RevEngUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
@@ -26,7 +26,6 @@ import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.MappingsDatabaseCollector;
-import org.hibernate.cfg.reveng.RevEngUtils;
 import org.hibernate.engine.OptimisticLockStyle;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.Mapping;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/MetaAttributesBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/MetaAttributesBinder.java
@@ -3,7 +3,6 @@ package org.hibernate.tool.internal.reveng;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.hibernate.cfg.reveng.RevEngUtils;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.Property;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevEngUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevEngUtils.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>