### PR TITLE
HBX-1620: Move class 'org.hibernate.cfg.reveng.AbstractDatabaseCollector' to 'org.hibernate.tool.internal.reveng.AbstractDatabaseCollector'

### DIFF
--- a/orm/src/main/java/org/hibernate/cfg/reveng/DefaultDatabaseCollector.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/DefaultDatabaseCollector.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
+import org.hibernate.tool.internal.reveng.AbstractDatabaseCollector;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 
 public class DefaultDatabaseCollector extends AbstractDatabaseCollector  {

--- a/orm/src/main/java/org/hibernate/cfg/reveng/MappingsDatabaseCollector.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/MappingsDatabaseCollector.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
+import org.hibernate.tool.internal.reveng.AbstractDatabaseCollector;
 
 public class MappingsDatabaseCollector extends AbstractDatabaseCollector {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/AbstractDatabaseCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/AbstractDatabaseCollector.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>