### PR TITLE
HBX-1621: Move class 'org.hibernate.cfg.reveng.PrimaryKeyProcessor' to 'org.hibernate.tool.internal.reveng.PrimaryKeyProcessor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import org.hibernate.cfg.reveng.BasicColumnProcessor;
 import org.hibernate.cfg.reveng.ForeignKeyProcessor;
 import org.hibernate.cfg.reveng.IndexProcessor;
-import org.hibernate.cfg.reveng.PrimaryKeyProcessor;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.ForeignKey;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/PrimaryKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/PrimaryKeyProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,8 +15,6 @@ import org.hibernate.sql.Alias;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.JdbcBinderException;
-import org.hibernate.tool.internal.reveng.RevEngUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>