### PR TITLE
HBX-1622: Move class 'org.hibernate.cfg.reveng.IndexProcessor' to 'org.hibernate.tool.internal.reveng.IndexProcessor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/IndexProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/IndexProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.sql.DatabaseMetaData;
 import java.util.ArrayList;
@@ -14,7 +14,6 @@ import org.hibernate.mapping.Index;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.internal.reveng.JdbcBinderException;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
@@ -15,7 +15,6 @@ import java.util.Set;
 
 import org.hibernate.cfg.reveng.BasicColumnProcessor;
 import org.hibernate.cfg.reveng.ForeignKeyProcessor;
-import org.hibernate.cfg.reveng.IndexProcessor;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.ForeignKey;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>