### PR TITLE
HBX-1623: Move class 'org.hibernate.cfg.reveng.ForeignKeyProcessor' to 'org.hibernate.tool.internal.reveng.ForeignKeyProcessor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/ForeignKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/ForeignKeyProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -16,9 +16,6 @@ import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
-import org.hibernate.tool.internal.reveng.JdbcBinderException;
-import org.hibernate.tool.internal.reveng.RevEngUtils;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
@@ -14,7 +14,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.hibernate.cfg.reveng.BasicColumnProcessor;
-import org.hibernate.cfg.reveng.ForeignKeyProcessor;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.ForeignKey;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>