### PR TITLE
HBX-1624: Move class 'org.hibernate.cfg.reveng.BasicColumnProcessor' to 'org.hibernate.tool.internal.reveng.BasicColumnProcessor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/BasicColumnProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/BasicColumnProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.sql.DatabaseMetaData;
 import java.util.Iterator;
@@ -11,8 +11,6 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.JdbcBinderException;
-import org.hibernate.tool.internal.reveng.RevEngUtils;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.slf4j.Logger;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.hibernate.cfg.reveng.BasicColumnProcessor;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.ForeignKey;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>