### PR TITLE
HBX-1627: Move class 'org.hibernate.cfg.reveng.DelegatingReverseEngineeringStrategy' to 'org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy'

### DIFF
--- a/orm/src/main/java/org/hibernate/cfg/reveng/OverrideRepository.java
+++ b/orm/src/main/java/org/hibernate/cfg/reveng/OverrideRepository.java
@@ -29,6 +29,7 @@ import org.hibernate.tool.api.reveng.AssociationInfo;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.MetaAttributeHelper;
 import org.hibernate.tool.internal.reveng.OverrideBinder;
 import org.hibernate.tool.internal.reveng.SQLTypeMapping;

--- a/orm/src/main/java/org/hibernate/tool/hbmlint/detector/TableSelectorStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/hbmlint/detector/TableSelectorStrategy.java
@@ -6,9 +6,9 @@ package org.hibernate.tool.hbmlint.detector;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.cfg.reveng.DelegatingReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
+import org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy;
 
 public class TableSelectorStrategy extends DelegatingReverseEngineeringStrategy {
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
@@ -1,4 +1,4 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.List;
 import java.util.Map;

--- a/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
@@ -8,12 +8,12 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.cfg.reveng.DelegatingReverseEngineeringStrategy;
 import org.hibernate.mapping.Column;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>