### PR TITLE
HBX-1628: Move class 'org.hibernate.cfg.reveng.MappingsDatabaseCollector' to 'org.hibernate.tool.internal.reveng.MappingsDatabaseCollector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcBinder.java
@@ -24,7 +24,6 @@ import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.reveng.MappingsDatabaseCollector;
 import org.hibernate.engine.OptimisticLockStyle;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.Mapping;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/MappingsDatabaseCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/MappingsDatabaseCollector.java
@@ -1,11 +1,10 @@
-package org.hibernate.cfg.reveng;
+package org.hibernate.tool.internal.reveng;
 
 import java.util.Iterator;
 
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.internal.reveng.AbstractDatabaseCollector;
 
 public class MappingsDatabaseCollector extends AbstractDatabaseCollector {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>