### PR TITLE
HBX-1633: Move class 'org.hibernate.tool.hbm2x.XMLPrettyPrinter' to 'org.hibernate.tool.internal.xml.XMLPrettyPrinter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/DefaultArtifactCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/DefaultArtifactCollector.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import org.hibernate.tool.api.export.ArtifactCollector;
 import org.hibernate.tool.hbm2x.ExporterException;
-import org.hibernate.tool.hbm2x.XMLPrettyPrinter;
+import org.hibernate.tool.internal.xml.XMLPrettyPrinter;
 
 /**
  * Callback class that all exporters are given to allow better feedback and

--- a/orm/src/main/java/org/hibernate/tool/internal/xml/XMLPrettyPrinter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/xml/XMLPrettyPrinter.java
@@ -2,7 +2,7 @@
  * Created on 17-Dec-2004
  *
  */
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.xml;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,8 +10,6 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
-import org.hibernate.tool.internal.xml.XMLPrettyPrinterStrategyFactory;
 
 /**
  * @author max


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>