### PR TITLE
HBX-1637: Move class 'org.hibernate.tool.hbm2x.AbstractExporter' to 'org.hibernate.tool.internal.export.AbstractExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/DocExporter.java
@@ -18,6 +18,7 @@ import org.hibernate.tool.hbm2x.doc.DocFile;
 import org.hibernate.tool.hbm2x.doc.DocFileManager;
 import org.hibernate.tool.hbm2x.doc.DocHelper;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
+import org.hibernate.tool.internal.export.AbstractExporter;
 
 /**
  * Exporter implementation that creates Hibernate Documentation.

--- a/orm/src/main/java/org/hibernate/tool/hbm2x/GenericExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/GenericExporter.java
@@ -12,6 +12,7 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Component;
 import org.hibernate.tool.hbm2x.pojo.ComponentPOJOClass;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
+import org.hibernate.tool.internal.export.AbstractExporter;
 
 
 public class GenericExporter extends AbstractExporter {

--- a/orm/src/main/java/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import org.hibernate.boot.Metadata;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.hbm2ddl.SchemaExport.Action;
+import org.hibernate.tool.internal.export.AbstractExporter;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
 

--- a/orm/src/main/java/org/hibernate/tool/hbm2x/HibernateConfigurationExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/HibernateConfigurationExporter.java
@@ -20,6 +20,7 @@ import java.util.TreeMap;
 import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
+import org.hibernate.tool.internal.export.AbstractExporter;
 
 /**
  * @author max

--- a/orm/src/main/java/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -11,6 +11,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.tool.internal.export.AbstractExporter;
 
 /** 
  * exporter for query execution.

--- a/orm/src/main/java/org/hibernate/tool/internal/export/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/AbstractExporter.java
@@ -1,7 +1,7 @@
 /*
  * Created on 21-Dec-2004
  */
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export;
 
 import java.io.File;
 import java.util.Iterator;
@@ -14,7 +14,11 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.tool.api.export.ArtifactCollector;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.internal.export.DefaultArtifactCollector;
+import org.hibernate.tool.hbm2x.Cfg2HbmTool;
+import org.hibernate.tool.hbm2x.Cfg2JavaTool;
+import org.hibernate.tool.hbm2x.ExporterException;
+import org.hibernate.tool.hbm2x.ExporterSettings;
+import org.hibernate.tool.hbm2x.TemplateHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>