### PR TITLE
HBX-1638: Move class 'org.hibernate.tool.hbm2x.ExporterSettings' to 'org.hibernate.tool.internal.export.ExporterSettings'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/AbstractExporter.java
@@ -17,7 +17,6 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.hbm2x.Cfg2HbmTool;
 import org.hibernate.tool.hbm2x.Cfg2JavaTool;
 import org.hibernate.tool.hbm2x.ExporterException;
-import org.hibernate.tool.hbm2x.ExporterSettings;
 import org.hibernate.tool.hbm2x.TemplateHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/ExporterSettings.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/ExporterSettings.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export;
 
 public interface ExporterSettings {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>