### PR TITLE
HBX-1641: Move class 'org.hibernate.tool.hbm2x.doc.DocFileManager' to 'org.hibernate.tool.internal.export.doc.DocFileManager'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -18,7 +18,6 @@ import org.hibernate.tool.hbm2x.ExporterException;
 import org.hibernate.tool.hbm2x.GenericExporter;
 import org.hibernate.tool.hbm2x.TemplateProducer;
 import org.hibernate.tool.hbm2x.doc.DocFile;
-import org.hibernate.tool.hbm2x.doc.DocFileManager;
 import org.hibernate.tool.hbm2x.doc.DocHelper;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
 import org.hibernate.tool.internal.export.AbstractExporter;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFileManager.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFileManager.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x.doc;
+package org.hibernate.tool.internal.export.doc;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -9,6 +9,9 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.mapping.Table;
+import org.hibernate.tool.hbm2x.doc.DocFile;
+import org.hibernate.tool.hbm2x.doc.DocFolder;
+import org.hibernate.tool.hbm2x.doc.DocHelper;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
 
 /**


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>