### PR TITLE
HBX-1642: Move class 'org.hibernate.tool.hbm2x.doc.DocFile' to 'org.hibernate.tool.internal.export.doc.DocFile'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -17,7 +17,6 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.hbm2x.ExporterException;
 import org.hibernate.tool.hbm2x.GenericExporter;
 import org.hibernate.tool.hbm2x.TemplateProducer;
-import org.hibernate.tool.hbm2x.doc.DocFile;
 import org.hibernate.tool.hbm2x.doc.DocHelper;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
 import org.hibernate.tool.internal.export.AbstractExporter;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFile.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFile.java
@@ -1,7 +1,9 @@
-package org.hibernate.tool.hbm2x.doc;
+package org.hibernate.tool.internal.export.doc;
 
 import java.io.File;
 import java.util.List;
+
+import org.hibernate.tool.hbm2x.doc.DocFolder;
 
 /**
  * Represents a documentation file.

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFileManager.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFileManager.java
@@ -9,7 +9,6 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.hbm2x.doc.DocFile;
 import org.hibernate.tool.hbm2x.doc.DocFolder;
 import org.hibernate.tool.hbm2x.doc.DocHelper;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>