### PR TITLE
HBX-1643: Move class 'org.hibernate.tool.hbm2x.doc.DocFolder' to 'org.hibernate.tool.internal.export.doc.DocFolder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFile.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFile.java
@@ -3,8 +3,6 @@ package org.hibernate.tool.internal.export.doc;
 import java.io.File;
 import java.util.List;
 
-import org.hibernate.tool.hbm2x.doc.DocFolder;
-
 /**
  * Represents a documentation file.
  * 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFileManager.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFileManager.java
@@ -9,7 +9,6 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.hbm2x.doc.DocFolder;
 import org.hibernate.tool.hbm2x.doc.DocHelper;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFolder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFolder.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x.doc;
+package org.hibernate.tool.internal.export.doc;
 
 import java.io.File;
 import java.util.ArrayList;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>