### PR TITLE
HBX-1643: Move class 'org.hibernate.tool.hbm2x.doc.DocFolder' to 'org.hibernate.tool.internal.export.doc.DocFolder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -17,7 +17,6 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.hbm2x.ExporterException;
 import org.hibernate.tool.hbm2x.GenericExporter;
 import org.hibernate.tool.hbm2x.TemplateProducer;
-import org.hibernate.tool.hbm2x.doc.DocHelper;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
 import org.hibernate.tool.internal.export.AbstractExporter;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFileManager.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocFileManager.java
@@ -9,7 +9,6 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.hbm2x.doc.DocHelper;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
 
 /**

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x.doc;
+package org.hibernate.tool.internal.export.doc;
 
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>