### PR TITLE
HBX-1645: Rename package 'org.hibernate.tool.internal.export' to 'org.hibernate.tool.internal.export.common'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/hbm2x/GenericExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/GenericExporter.java
@@ -12,7 +12,7 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Component;
 import org.hibernate.tool.hbm2x.pojo.ComponentPOJOClass;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
-import org.hibernate.tool.internal.export.AbstractExporter;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
 
 
 public class GenericExporter extends AbstractExporter {

--- a/orm/src/main/java/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import org.hibernate.boot.Metadata;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.hbm2ddl.SchemaExport.Action;
-import org.hibernate.tool.internal.export.AbstractExporter;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
 

--- a/orm/src/main/java/org/hibernate/tool/hbm2x/HibernateConfigurationExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/HibernateConfigurationExporter.java
@@ -20,7 +20,7 @@ import java.util.TreeMap;
 import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
-import org.hibernate.tool.internal.export.AbstractExporter;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
 
 /**
  * @author max

--- a/orm/src/main/java/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -11,7 +11,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-import org.hibernate.tool.internal.export.AbstractExporter;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
 
 /** 
  * exporter for query execution.

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
@@ -1,7 +1,7 @@
 /*
  * Created on 21-Dec-2004
  */
-package org.hibernate.tool.internal.export;
+package org.hibernate.tool.internal.export.common;
 
 import java.io.File;
 import java.util.Iterator;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/DefaultArtifactCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/DefaultArtifactCollector.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.export;
+package org.hibernate.tool.internal.export.common;
 
 import java.io.File;
 import java.io.IOException;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/ExporterSettings.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/ExporterSettings.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.export;
+package org.hibernate.tool.internal.export.common;
 
 public interface ExporterSettings {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -18,7 +18,7 @@ import org.hibernate.tool.hbm2x.ExporterException;
 import org.hibernate.tool.hbm2x.GenericExporter;
 import org.hibernate.tool.hbm2x.TemplateProducer;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
-import org.hibernate.tool.internal.export.AbstractExporter;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
 
 /**
  * Exporter implementation that creates Hibernate Documentation.

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
@@ -9,7 +9,7 @@ import java.io.File;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.hbm2x.POJOExporter;
-import org.hibernate.tool.internal.export.DefaultArtifactCollector;
+import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaTest/TestCase.java
@@ -26,7 +26,7 @@ import org.hibernate.tool.hbm2x.pojo.ImportContext;
 import org.hibernate.tool.hbm2x.pojo.ImportContextImpl;
 import org.hibernate.tool.hbm2x.pojo.NoopImportContext;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
-import org.hibernate.tool.internal.export.DefaultArtifactCollector;
+import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/PropertiesTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/PropertiesTest/TestCase.java
@@ -18,7 +18,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.hbm2x.HibernateMappingExporter;
 import org.hibernate.tool.hbm2x.POJOExporter;
-import org.hibernate.tool.internal.export.DefaultArtifactCollector;
+import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>