### PR TITLE
HBX-1651: Move class 'org.hibernate.tool.hbm2x.DAOExporter' to 'org.hibernate.tool.internal.export.dao.DAOExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
@@ -1,7 +1,7 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.hbm2x.DAOExporter;
+import org.hibernate.tool.internal.export.dao.DAOExporter;
 
 /**
  * @author Dennis Byrne

--- a/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAOExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAOExporter.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.dao;
 
 import java.util.Map;
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
@@ -8,7 +8,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.hbm2x.DAOExporter;
+import org.hibernate.tool.internal.export.dao.DAOExporter;
 import org.hibernate.tool.internal.export.pojo.POJOExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2EJBDaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2EJBDaoTest/TestCase.java
@@ -14,7 +14,7 @@ import javax.persistence.Persistence;
 
 import org.apache.commons.logging.Log;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.hbm2x.DAOExporter;
+import org.hibernate.tool.internal.export.dao.DAOExporter;
 import org.hibernate.tool.internal.export.pojo.POJOExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2HibernateDAOTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2HibernateDAOTest/TestCase.java
@@ -14,7 +14,7 @@ import javax.persistence.Persistence;
 import org.apache.commons.logging.Log;
 import org.hibernate.Version;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.hbm2x.DAOExporter;
+import org.hibernate.tool.internal.export.dao.DAOExporter;
 import org.hibernate.tool.internal.export.pojo.POJOExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>