### PR TITLE
HBX-1652: Move class 'org.hibernate.tool.hbm2x.DAONewExporter' to 'org.hibernate.tool.internal.export.dao.DAONewExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAONewExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAONewExporter.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.dao;
 
 import java.io.File;
 import java.util.Map;
@@ -6,6 +6,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.hibernate.tool.hbm2x.GenericExporter;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
 
 /**


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>