### PR TITLE
HBX-1653: Move class 'org.hibernate.tool.hbm2x.ConfigurationNavigator' to 'org.hibernate.tool.internal.export.common.ConfigurationNavigator'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/hbm2x/GenericExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/GenericExporter.java
@@ -13,6 +13,7 @@ import org.hibernate.mapping.Component;
 import org.hibernate.tool.hbm2x.pojo.ComponentPOJOClass;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
 import org.hibernate.tool.internal.export.common.AbstractExporter;
+import org.hibernate.tool.internal.export.common.ConfigurationNavigator;
 
 
 public class GenericExporter extends AbstractExporter {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/ConfigurationNavigator.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/ConfigurationNavigator.java
@@ -1,7 +1,7 @@
 /*
  * Created on 2004-12-01
  */
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.common;
 
 import java.util.Iterator;
 import java.util.Map;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
@@ -22,9 +22,9 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.tool.hbm2x.ConfigurationNavigator;
 import org.hibernate.tool.hbm2x.pojo.ComponentPOJOClass;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
+import org.hibernate.tool.internal.export.common.ConfigurationNavigator;
 import org.hibernate.tool.internal.export.pojo.Cfg2JavaTool;
 import org.hibernate.type.Type;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>