### PR TITLE
HBX-1660: Move class 'org.hibernate.tool.hbm2x.pojo.SkipBackRefPropertyIterator' to 'org.hibernate.tool.internal.util.SkipBackRefPropertyIterator'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
@@ -36,6 +36,7 @@ import org.hibernate.mapping.Value;
 import org.hibernate.tool.internal.export.pojo.BasicPOJOClass;
 import org.hibernate.tool.internal.export.pojo.Cfg2JavaTool;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
+import org.hibernate.tool.internal.util.SkipBackRefPropertyIterator;
 import org.hibernate.type.ForeignKeyDirection;
 
 public class EntityPOJOClass extends BasicPOJOClass {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -42,10 +42,10 @@ import org.hibernate.persister.entity.JoinedSubclassEntityPersister;
 import org.hibernate.persister.entity.SingleTableEntityPersister;
 import org.hibernate.persister.entity.UnionSubclassEntityPersister;
 import org.hibernate.tool.hbm2x.ExporterException;
-import org.hibernate.tool.hbm2x.pojo.SkipBackRefPropertyIterator;
 import org.hibernate.tool.hbm2x.visitor.EntityNameFromValueVisitor;
 import org.hibernate.tool.hbm2x.visitor.HBMTagForPersistentClassVisitor;
 import org.hibernate.tool.hbm2x.visitor.HBMTagForValueVisitor;
+import org.hibernate.tool.internal.util.SkipBackRefPropertyIterator;
 
 /**
  * @author David Channon and Max

--- a/orm/src/main/java/org/hibernate/tool/internal/util/SkipBackRefPropertyIterator.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/util/SkipBackRefPropertyIterator.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x.pojo;
+package org.hibernate.tool.internal.util;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>