### PR TITLE
HBX-1668: Move class 'org.hibernate.tool.hbmlint.Detector' to 'org.hibernate.tool.internal.export.lint.Detector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/hbmlint/detector/EntityModelDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/hbmlint/detector/EntityModelDetector.java
@@ -4,7 +4,7 @@ import java.util.Iterator;
 
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.tool.hbmlint.Detector;
+import org.hibernate.tool.internal.export.lint.Detector;
 import org.hibernate.tool.internal.export.lint.IssueCollector;
 
 public abstract class EntityModelDetector extends Detector {

--- a/orm/src/main/java/org/hibernate/tool/hbmlint/detector/RelationalModelDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/hbmlint/detector/RelationalModelDetector.java
@@ -4,7 +4,7 @@ import java.util.Iterator;
 
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.hbmlint.Detector;
+import org.hibernate.tool.internal.export.lint.Detector;
 import org.hibernate.tool.internal.export.lint.IssueCollector;
 
 public abstract class RelationalModelDetector extends Detector {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/Detector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/Detector.java
@@ -1,7 +1,6 @@
-package org.hibernate.tool.hbmlint;
+package org.hibernate.tool.internal.export.lint;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.tool.internal.export.lint.IssueCollector;
 
 public abstract class Detector {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLint.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLint.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.tool.hbmlint.Detector;
 import org.hibernate.tool.hbmlint.detector.BadCachingDetector;
 import org.hibernate.tool.hbmlint.detector.InstrumentationDetector;
 import org.hibernate.tool.hbmlint.detector.SchemaByMetaDataDetector;

--- a/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
@@ -4,10 +4,10 @@ import java.io.File;
 
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.hbm2x.HbmLintExporter;
-import org.hibernate.tool.hbmlint.Detector;
 import org.hibernate.tool.hbmlint.detector.BadCachingDetector;
 import org.hibernate.tool.hbmlint.detector.InstrumentationDetector;
 import org.hibernate.tool.hbmlint.detector.ShadowedIdentifierDetector;
+import org.hibernate.tool.internal.export.lint.Detector;
 import org.hibernate.tool.internal.export.lint.HbmLint;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.junit.Assert;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>