### PR TITLE
HBX-1669: Move class 'org.hibernate.tool.hbmlint.detector.BadCachingDetector' to 'org.hibernate.tool.internal.export.lint.BadCachingDetector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/BadCachingDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/BadCachingDetector.java
@@ -1,12 +1,11 @@
-package org.hibernate.tool.hbmlint.detector;
+package org.hibernate.tool.internal.export.lint;
 
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.hbm2x.visitor.EntityNameFromValueVisitor;
-import org.hibernate.tool.internal.export.lint.Issue;
-import org.hibernate.tool.internal.export.lint.IssueCollector;
+import org.hibernate.tool.hbmlint.detector.EntityModelDetector;
 
 public class BadCachingDetector extends EntityModelDetector {
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLint.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLint.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.tool.hbmlint.detector.BadCachingDetector;
 import org.hibernate.tool.hbmlint.detector.InstrumentationDetector;
 import org.hibernate.tool.hbmlint.detector.SchemaByMetaDataDetector;
 import org.hibernate.tool.hbmlint.detector.ShadowedIdentifierDetector;

--- a/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
@@ -4,9 +4,9 @@ import java.io.File;
 
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.hbm2x.HbmLintExporter;
-import org.hibernate.tool.hbmlint.detector.BadCachingDetector;
 import org.hibernate.tool.hbmlint.detector.InstrumentationDetector;
 import org.hibernate.tool.hbmlint.detector.ShadowedIdentifierDetector;
+import org.hibernate.tool.internal.export.lint.BadCachingDetector;
 import org.hibernate.tool.internal.export.lint.Detector;
 import org.hibernate.tool.internal.export.lint.HbmLint;
 import org.hibernate.tools.test.util.HibernateUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>