### PR TITLE
HBX-1670: Move class 'org.hibernate.tool.hbmlint.detector.EntityModelDetector' to 'org.hibernate.tool.internal.export.lint.EntityModelDetector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/hbmlint/detector/InstrumentationDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/hbmlint/detector/InstrumentationDetector.java
@@ -7,6 +7,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.engine.spi.Managed;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.tool.internal.export.lint.EntityModelDetector;
 import org.hibernate.tool.internal.export.lint.Issue;
 import org.hibernate.tool.internal.export.lint.IssueCollector;
 

--- a/orm/src/main/java/org/hibernate/tool/hbmlint/detector/ShadowedIdentifierDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/hbmlint/detector/ShadowedIdentifierDetector.java
@@ -2,6 +2,7 @@ package org.hibernate.tool.hbmlint.detector;
 
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.tool.internal.export.lint.EntityModelDetector;
 import org.hibernate.tool.internal.export.lint.Issue;
 import org.hibernate.tool.internal.export.lint.IssueCollector;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/BadCachingDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/BadCachingDetector.java
@@ -5,7 +5,6 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.hbm2x.visitor.EntityNameFromValueVisitor;
-import org.hibernate.tool.hbmlint.detector.EntityModelDetector;
 
 public class BadCachingDetector extends EntityModelDetector {
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/EntityModelDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/EntityModelDetector.java
@@ -1,11 +1,9 @@
-package org.hibernate.tool.hbmlint.detector;
+package org.hibernate.tool.internal.export.lint;
 
 import java.util.Iterator;
 
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.tool.internal.export.lint.Detector;
-import org.hibernate.tool.internal.export.lint.IssueCollector;
 
 public abstract class EntityModelDetector extends Detector {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>