### PR TITLE
HBX-1671: Move class 'org.hibernate.tool.hbmlint.detector.InstrumentationDetector' to 'org.hibernate.tool.internal.export.lint.InstrumentationDetector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLint.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLint.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.tool.hbmlint.detector.InstrumentationDetector;
 import org.hibernate.tool.hbmlint.detector.SchemaByMetaDataDetector;
 import org.hibernate.tool.hbmlint.detector.ShadowedIdentifierDetector;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/InstrumentationDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/InstrumentationDetector.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbmlint.detector;
+package org.hibernate.tool.internal.export.lint;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.Metadata;
@@ -7,9 +7,6 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.engine.spi.Managed;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.tool.internal.export.lint.EntityModelDetector;
-import org.hibernate.tool.internal.export.lint.Issue;
-import org.hibernate.tool.internal.export.lint.IssueCollector;
 
 public class InstrumentationDetector extends EntityModelDetector {
 	

--- a/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
@@ -4,11 +4,11 @@ import java.io.File;
 
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.hbm2x.HbmLintExporter;
-import org.hibernate.tool.hbmlint.detector.InstrumentationDetector;
 import org.hibernate.tool.hbmlint.detector.ShadowedIdentifierDetector;
 import org.hibernate.tool.internal.export.lint.BadCachingDetector;
 import org.hibernate.tool.internal.export.lint.Detector;
 import org.hibernate.tool.internal.export.lint.HbmLint;
+import org.hibernate.tool.internal.export.lint.InstrumentationDetector;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>