### PR TITLE
HBX-1673: Move class 'org.hibernate.tool.hbmlint.detector.RelationalModelDetector' to 'org.hibernate.tool.internal.export.lint.RelationalModelDetector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/hbmlint/detector/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/hbmlint/detector/SchemaByMetaDataDetector.java
@@ -30,6 +30,7 @@ import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.export.lint.Issue;
 import org.hibernate.tool.internal.export.lint.IssueCollector;
+import org.hibernate.tool.internal.export.lint.RelationalModelDetector;
 import org.hibernate.tool.internal.metadata.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.JDBCReader;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/RelationalModelDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/RelationalModelDetector.java
@@ -1,11 +1,9 @@
-package org.hibernate.tool.hbmlint.detector;
+package org.hibernate.tool.internal.export.lint;
 
 import java.util.Iterator;
 
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.internal.export.lint.Detector;
-import org.hibernate.tool.internal.export.lint.IssueCollector;
 
 public abstract class RelationalModelDetector extends Detector {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>