### PR TITLE
HBX-1677: Move interface 'org.hibernate.tool.hbm2x.MetaAttributeConstants' to 'org.hibernate.tool.internal.export.pojo.MetaAttributeConstants'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/BasicPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/BasicPOJOClass.java
@@ -21,7 +21,6 @@ import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Value;
-import org.hibernate.tool.hbm2x.MetaAttributeConstants;
 import org.hibernate.tool.hbm2x.MetaAttributeHelper;
 import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
 import org.hibernate.tool.internal.util.NameConverter;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/MetaAttributeConstants.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/MetaAttributeConstants.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.pojo;
 
 public interface MetaAttributeConstants {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>