### PR TITLE
HBX-1678: Move class 'org.hibernate.tool.hbm2x.HbmLintExporter' to 'org.hibernate.tool.internal.export.lint.HbmLintExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/HbmLintExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/HbmLintExporterTask.java
@@ -1,7 +1,7 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.hbm2x.HbmLintExporter;
+import org.hibernate.tool.internal.export.lint.HbmLintExporter;
 
 public class HbmLintExporterTask extends ExporterTask {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLintExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLintExporter.java
@@ -1,6 +1,6 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.lint;
 
-import org.hibernate.tool.internal.export.lint.HbmLint;
+import org.hibernate.tool.hbm2x.GenericExporter;
 
 public class HbmLintExporter extends GenericExporter {
 

--- a/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
@@ -3,10 +3,10 @@ package org.hibernate.tool.hbmlint.HbmLintTest;
 import java.io.File;
 
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.hbm2x.HbmLintExporter;
 import org.hibernate.tool.internal.export.lint.BadCachingDetector;
 import org.hibernate.tool.internal.export.lint.Detector;
 import org.hibernate.tool.internal.export.lint.HbmLint;
+import org.hibernate.tool.internal.export.lint.HbmLintExporter;
 import org.hibernate.tool.internal.export.lint.InstrumentationDetector;
 import org.hibernate.tool.internal.export.lint.ShadowedIdentifierDetector;
 import org.hibernate.tools.test.util.HibernateUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>