### PR TITLE
HBX-1680: Move class 'org.hibernate.tool.hbm2x.MetaAttributeHelper' to 'org.hibernate.tool.internal.export.pojo.MetaAttributeHelper'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/BasicPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/BasicPOJOClass.java
@@ -21,7 +21,6 @@ import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Value;
-import org.hibernate.tool.hbm2x.MetaAttributeHelper;
 import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
 import org.hibernate.tool.internal.util.NameConverter;
 import org.hibernate.tuple.GenerationTiming;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/Cfg2JavaTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/Cfg2JavaTool.java
@@ -24,7 +24,6 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.hbm2x.ExporterException;
-import org.hibernate.tool.hbm2x.MetaAttributeHelper;
 import org.hibernate.tool.hbm2x.visitor.JavaTypeFromValueVisitor;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.util.NameConverter;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/MetaAttributeHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/MetaAttributeHelper.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.pojo;
 
 import java.util.Collection;
 import java.util.Iterator;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>