### PR TITLE
HBX-1681: Move class 'org.hibernate.tool.hbm2x.visitor.HBMTagForValueVisitor' to 'org.hibernate.tool.internal.export.hbm.HBMTagForValueVisitor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -44,7 +44,6 @@ import org.hibernate.persister.entity.UnionSubclassEntityPersister;
 import org.hibernate.tool.hbm2x.ExporterException;
 import org.hibernate.tool.hbm2x.visitor.EntityNameFromValueVisitor;
 import org.hibernate.tool.hbm2x.visitor.HBMTagForPersistentClassVisitor;
-import org.hibernate.tool.hbm2x.visitor.HBMTagForValueVisitor;
 import org.hibernate.tool.internal.util.SkipBackRefPropertyIterator;
 
 /**

--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HBMTagForValueVisitor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HBMTagForValueVisitor.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x.visitor;
+package org.hibernate.tool.internal.export.hbm;
 
 import org.hibernate.mapping.Any;
 import org.hibernate.mapping.Array;
@@ -14,6 +14,7 @@ import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.PrimitiveArray;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
+import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
 
 public class HBMTagForValueVisitor extends DefaultValueVisitor {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>