### PR TITLE
HBX-1682: Move class 'org.hibernate.tool.hbm2x.visitor.HBMTagForPersistentClassVisitor' to 'org.hibernate.tool.internal.export.hbm.HBMTagForPersistentClassVisitor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -43,7 +43,6 @@ import org.hibernate.persister.entity.SingleTableEntityPersister;
 import org.hibernate.persister.entity.UnionSubclassEntityPersister;
 import org.hibernate.tool.hbm2x.ExporterException;
 import org.hibernate.tool.hbm2x.visitor.EntityNameFromValueVisitor;
-import org.hibernate.tool.hbm2x.visitor.HBMTagForPersistentClassVisitor;
 import org.hibernate.tool.internal.util.SkipBackRefPropertyIterator;
 
 /**

--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HBMTagForPersistentClassVisitor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HBMTagForPersistentClassVisitor.java
@@ -2,7 +2,7 @@
  * Created on 07-Dec-2004
  *
  */
-package org.hibernate.tool.hbm2x.visitor;
+package org.hibernate.tool.internal.export.hbm;
 
 import org.hibernate.mapping.JoinedSubclass;
 import org.hibernate.mapping.PersistentClassVisitor;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>