### PR TITLE
HBX-1683: Move class 'org.hibernate.tool.hbm2x.visitor.JavaTypeFromValueVisitor' to 'org.hibernate.tool.internal.export.pojo.JavaTypeFromValueVisitor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/Cfg2JavaTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/Cfg2JavaTool.java
@@ -24,7 +24,6 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.hbm2x.ExporterException;
-import org.hibernate.tool.hbm2x.visitor.JavaTypeFromValueVisitor;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.util.NameConverter;
 import org.hibernate.tool.internal.util.StringUtil;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/JavaTypeFromValueVisitor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/JavaTypeFromValueVisitor.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x.visitor;
+package org.hibernate.tool.internal.export.pojo;
 
 import org.hibernate.HibernateException;
 import org.hibernate.mapping.Component;
@@ -10,7 +10,7 @@ import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
-import org.hibernate.tool.internal.export.pojo.Cfg2JavaTool;
+import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
 import org.hibernate.type.CompositeCustomType;
 import org.hibernate.type.CustomType;
 import org.hibernate.type.Type;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>