### PR TITLE
HBX-1685: Move class 'org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor' to 'org.hibernate.tool.internal.export.common.DefaultValueVisitor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/DefaultValueVisitor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/DefaultValueVisitor.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x.visitor;
+package org.hibernate.tool.internal.export.common;
 
 import org.hibernate.mapping.Any;
 import org.hibernate.mapping.Array;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/EntityNameFromValueVisitor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/EntityNameFromValueVisitor.java
@@ -14,7 +14,6 @@ import org.hibernate.mapping.PrimitiveArray;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.ToOne;
-import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
 
 public class EntityNameFromValueVisitor extends DefaultValueVisitor {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HBMTagForValueVisitor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HBMTagForValueVisitor.java
@@ -14,7 +14,7 @@ import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.PrimitiveArray;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
-import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
+import org.hibernate.tool.internal.export.common.DefaultValueVisitor;
 
 public class HBMTagForValueVisitor extends DefaultValueVisitor {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/BasicPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/BasicPOJOClass.java
@@ -21,7 +21,7 @@ import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Value;
-import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
+import org.hibernate.tool.internal.export.common.DefaultValueVisitor;
 import org.hibernate.tool.internal.util.NameConverter;
 import org.hibernate.tuple.GenerationTiming;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/JavaTypeFromValueVisitor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/JavaTypeFromValueVisitor.java
@@ -10,7 +10,7 @@ import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
-import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
+import org.hibernate.tool.internal.export.common.DefaultValueVisitor;
 import org.hibernate.type.CompositeCustomType;
 import org.hibernate.type.CustomType;
 import org.hibernate.type.Type;

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
@@ -16,7 +16,7 @@ import org.hibernate.mapping.Set;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.SchemaSelection;
-import org.hibernate.tool.hbm2x.visitor.DefaultValueVisitor;
+import org.hibernate.tool.internal.export.common.DefaultValueVisitor;
 import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>