### PR TITLE
HBX-1686: Create method 'StringUtil#isNotEmpty(String)' in class 'org.hibernate.tool.internal.util.StringUtil'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/util/StringUtil.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/util/StringUtil.java
@@ -58,4 +58,8 @@ public final class StringUtil {
         return str;
     }
 
+	public static boolean isNotEmpty(String string) {
+		return string != null && string.length() > 0;
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>