### PR TITLE
HBX-1688: Remove occurrences of 'org.hibernate.tool.hbm2x.ExporterException' from class 'org.hibernate.tool.ide.formatting.JavaFormatter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/JavaFormatterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/JavaFormatterTask.java
@@ -16,7 +16,6 @@ import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.FileSet;
-import org.hibernate.tool.hbm2x.ExporterException;
 import org.hibernate.tool.ide.formatting.JavaFormatter;
 
 public class JavaFormatterTask extends Task {
@@ -83,7 +82,7 @@ public class JavaFormatterTask extends Task {
 					} else {
 						getProject().log(this, "Formatted " + file, Project.MSG_VERBOSE);
 					}
-				} catch(ExporterException ee) {
+				} catch(RuntimeException ee) {
 					failed++;
 					if(failOnError) {
 						throw new BuildException("Java formatting failed on " + file, ee);

--- a/orm/src/main/java/org/hibernate/tool/ide/formatting/JavaFormatter.java
+++ b/orm/src/main/java/org/hibernate/tool/ide/formatting/JavaFormatter.java
@@ -13,7 +13,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.text.edits.TextEdit;
-import org.hibernate.tool.hbm2x.ExporterException;
 
 
 public class JavaFormatter {
@@ -40,7 +39,7 @@ public class JavaFormatter {
 	 * @param codeFormatter
 	 * @return
 	 */
-	public boolean formatFile(File file) throws ExporterException {
+	public boolean formatFile(File file) {
 		IDocument doc = new Document();
 		try {
 			String contents = new String(org.eclipse.jdt.internal.compiler.util.Util.getFileCharContent(file, null));
@@ -65,10 +64,8 @@ public class JavaFormatter {
 				}
 			}
 			return true;
-		} catch (IOException e) {
-			throw new ExporterException("Could not format " + file, e);
-		} catch (BadLocationException e) {			
-			throw new ExporterException("Could not format " + file, e);
+		} catch (IOException | BadLocationException e) {
+			throw new RuntimeException("Could not format " + file, e);
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>