### PR TITLE
HBX-1689: Move class 'org.hibernate.tool.ide.formatting.JavaFormatter' to 'org.hibernate.tool.api.java.Formatter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/JavaFormatterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/JavaFormatterTask.java
@@ -16,7 +16,7 @@ import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.FileSet;
-import org.hibernate.tool.ide.formatting.JavaFormatter;
+import org.hibernate.tool.api.java.Formatter;
 
 public class JavaFormatterTask extends Task {
 	
@@ -71,7 +71,7 @@ public class JavaFormatterTask extends Task {
 	
 		if(files.length>0) {
 			
-			JavaFormatter formatter = new JavaFormatter(settings);
+			Formatter formatter = new Formatter(settings);
 			for (int i = 0; i < files.length; i++) {
 				File file = files[i];			
 				try {

--- a/orm/src/main/java/org/hibernate/tool/api/java/Formatter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/java/Formatter.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ide.formatting;
+package org.hibernate.tool.api.java;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -15,11 +15,11 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.text.edits.TextEdit;
 
 
-public class JavaFormatter {
+public class Formatter {
 
 	private CodeFormatter codeFormatter;
 
-	public JavaFormatter(Map<Object, Object> settings) {
+	public Formatter(Map<Object, Object> settings) {
 		if(settings==null) {
 			// if no settings run with jdk 5 as default 
 			settings = new HashMap<Object, Object>();

--- a/test/nodb/src/test/java/org/hibernate/tool/ant/JavaFormatter/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/ant/JavaFormatter/TestCase.java
@@ -2,7 +2,7 @@ package org.hibernate.tool.ant.JavaFormatter;
 
 import java.io.File;
 
-import org.hibernate.tool.ide.formatting.JavaFormatter;
+import org.hibernate.tool.api.java.Formatter;
 import org.hibernate.tools.test.util.AntUtil;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
@@ -53,7 +53,7 @@ public class TestCase {
 				.findFirstString("public", simpleOne)
 				.contains("SimpleOne"));
 		
-		JavaFormatter formatter = new JavaFormatter(null);
+		Formatter formatter = new Formatter(null);
 		formatter.formatFile( simpleOne );
 		
 		Assert.assertTrue(FileUtil
@@ -90,7 +90,7 @@ public class TestCase {
 		
 		Assert.assertFalse(log.contains("Exception"));
 				
-		JavaFormatter formatter = new JavaFormatter(null);
+		Formatter formatter = new Formatter(null);
 		Assert.assertTrue(
 				"formatting should pass when using default settings", 
 				formatter.formatFile(simple5One));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>