### PR TITLE
HBX-1691: Move class 'org.hibernate.tool.stat.AbstractTreeModel' to 'org.hibernate.tool.internal.util.AbstractTreeModel'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/util/AbstractTreeModel.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/util/AbstractTreeModel.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.stat; 
+package org.hibernate.tool.internal.util; 
 
 import javax.swing.event.EventListenerList;
 import javax.swing.event.TreeModelEvent;

--- a/orm/src/main/java/org/hibernate/tool/stat/StatisticsTreeModel.java
+++ b/orm/src/main/java/org/hibernate/tool/stat/StatisticsTreeModel.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.hibernate.stat.Statistics;
+import org.hibernate.tool.internal.util.AbstractTreeModel;
 import org.hibernate.internal.util.collections.IdentityMap;
 
 public class StatisticsTreeModel extends AbstractTreeModel {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>