### PR TITLE
HBX-1692: Move class 'org.hibernate.tool.stat.BeanTableModel' to 'orghibernate.tool.internal.util.BeanTableModel'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/util/BeanTableModel.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/util/BeanTableModel.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.stat;
+package org.hibernate.tool.internal.util;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;

--- a/orm/src/main/java/org/hibernate/tool/stat/StatisticsBrowser.java
+++ b/orm/src/main/java/org/hibernate/tool/stat/StatisticsBrowser.java
@@ -20,6 +20,7 @@ import javax.swing.event.TreeSelectionListener;
 import javax.swing.table.TableCellRenderer;
 
 import org.hibernate.stat.Statistics;
+import org.hibernate.tool.internal.util.BeanTableModel;
 
 /**
  * Very rudimentary statistics browser.


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>