### PR TITLE
HBX-1693: Move class 'org.hibernate.tool.hbm2x.TemplateProducer' to 'org.hibernate.tool.internal.export.common.TemplateProducer'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/hbm2x/GenericExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/hbm2x/GenericExporter.java
@@ -12,6 +12,7 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Component;
 import org.hibernate.tool.internal.export.common.AbstractExporter;
 import org.hibernate.tool.internal.export.common.ConfigurationNavigator;
+import org.hibernate.tool.internal.export.common.TemplateProducer;
 import org.hibernate.tool.internal.export.pojo.ComponentPOJOClass;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateProducer.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateProducer.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.common;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.hibernate.tool.api.export.ArtifactCollector;
+import org.hibernate.tool.hbm2x.TemplateHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -15,8 +15,8 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.hbm2x.GenericExporter;
-import org.hibernate.tool.hbm2x.TemplateProducer;
 import org.hibernate.tool.internal.export.common.AbstractExporter;
+import org.hibernate.tool.internal.export.common.TemplateProducer;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
 
 /**

--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HibernateMappingExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HibernateMappingExporter.java
@@ -11,7 +11,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.tool.hbm2x.GenericExporter;
-import org.hibernate.tool.hbm2x.TemplateProducer;
+import org.hibernate.tool.internal.export.common.TemplateProducer;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
 
 /**


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>