### PR TITLE
HBX-1694: Move class 'org.hibernate.tool.hbm2x.TemplateHelper' to 'org.hibernate.tool.internal.export.common.TemplateHelper'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
@@ -14,7 +14,6 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.tool.api.export.ArtifactCollector;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.hbm2x.TemplateHelper;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.export.pojo.Cfg2JavaTool;
 import org.slf4j.Logger;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateHelper.java
@@ -3,7 +3,7 @@
  *
 
  */
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.common;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateProducer.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateProducer.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.hibernate.tool.api.export.ArtifactCollector;
-import org.hibernate.tool.hbm2x.TemplateHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>