### PR TITLE
Move class 'org.hibernate.tool.hbm2x.QueryExporter' to 'org.hibernate.tool.internal.export.query.QueryExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.hbm2x.QueryExporter;
+import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.internal.util.StringHelper;
 
 public class QueryExporterTask extends ExporterTask {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/query/QueryExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/query/QueryExporter.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.query;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
@@ -14,7 +14,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
-import org.hibernate.tool.hbm2x.QueryExporter;
+import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>