### PR TITLE
HBX-1702: Move class 'org.hibernate.tool.hbm2x.Hbm2DDLExporter' to 'org.hibernate.tool.internal.export.ddl.Hbm2DDLExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -5,7 +5,7 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.hbm2x.Hbm2DDLExporter;
+import org.hibernate.tool.internal.export.ddl.Hbm2DDLExporter;
 
 /**
  * @author max

--- a/orm/src/main/java/org/hibernate/tool/internal/export/ddl/Hbm2DDLExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/ddl/Hbm2DDLExporter.java
@@ -14,7 +14,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.ddl;
 
 import java.io.File;
 import java.util.EnumSet;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>