### PR TITLE
HBX-1703: Move class 'org.hibernate.tool.hbm2x.HibernateConfigurationExporter' to 'org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
@@ -5,7 +5,7 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.hbm2x.HibernateConfigurationExporter;
+import org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter;
 
 public class Hbm2CfgXmlExporterTask extends ExporterTask {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/cfg/HibernateConfigurationExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/cfg/HibernateConfigurationExporter.java
@@ -2,7 +2,7 @@
  * Created on 2004-12-03
  *
  */
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.cfg;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -22,7 +22,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
-import org.hibernate.tool.hbm2x.HibernateConfigurationExporter;
+import org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter;
 import org.hibernate.tool.internal.export.doc.DocExporter;
 import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
 import org.hibernate.tool.internal.export.pojo.POJOExporter;

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
@@ -11,7 +11,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.hbm2x.HibernateConfigurationExporter;
+import org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>