### PR TITLE
HBX-1704: Move class 'org.hibernate.tool.hbm2x.GenericExporter' to 'org.hibernate.tool.internal.export.common.GenericExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/GenericExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/GenericExporterTask.java
@@ -6,7 +6,7 @@ package org.hibernate.tool.ant;
 
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.hbm2x.GenericExporter;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.util.ReflectHelper;
 
 /**

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/GenericExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/GenericExporter.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.hbm2x;
+package org.hibernate.tool.internal.export.common;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -10,9 +10,6 @@ import java.util.StringTokenizer;
 
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Component;
-import org.hibernate.tool.internal.export.common.AbstractExporter;
-import org.hibernate.tool.internal.export.common.ConfigurationNavigator;
-import org.hibernate.tool.internal.export.common.TemplateProducer;
 import org.hibernate.tool.internal.export.pojo.ComponentPOJOClass;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAONewExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAONewExporter.java
@@ -6,7 +6,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.hibernate.tool.hbm2x.GenericExporter;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
 
 /**

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -14,8 +14,8 @@ import org.hibernate.HibernateException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.hbm2x.GenericExporter;
 import org.hibernate.tool.internal.export.common.AbstractExporter;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.common.TemplateProducer;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HibernateMappingExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HibernateMappingExporter.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.hibernate.boot.Metadata;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.tool.hbm2x.GenericExporter;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.common.TemplateProducer;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLintExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/HbmLintExporter.java
@@ -1,6 +1,6 @@
 package org.hibernate.tool.internal.export.lint;
 
-import org.hibernate.tool.hbm2x.GenericExporter;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 
 public class HbmLintExporter extends GenericExporter {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/POJOExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/POJOExporter.java
@@ -4,7 +4,7 @@
  */
 package org.hibernate.tool.internal.export.pojo;
 
-import org.hibernate.tool.hbm2x.GenericExporter;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 
 /**
  * @author max

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/GenericExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/GenericExporterTest/TestCase.java
@@ -12,7 +12,7 @@ import java.util.Properties;
 
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.version.Version;
-import org.hibernate.tool.hbm2x.GenericExporter;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>