### PR TITLE
HBX-1706: Move class 'org.hibernate.tool.stat.StatisticsTreeModel' to 'org.hibernate.tool.internal.stat.StatisticsTreeModel'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/stat/StatisticsBrowser.java
+++ b/orm/src/main/java/org/hibernate/tool/api/stat/StatisticsBrowser.java
@@ -20,9 +20,9 @@ import javax.swing.event.TreeSelectionListener;
 import javax.swing.table.TableCellRenderer;
 
 import org.hibernate.stat.Statistics;
+import org.hibernate.tool.internal.stat.StatisticsTreeModel;
 import org.hibernate.tool.internal.util.BeanTableModel;
 import org.hibernate.tool.stat.StatisticsCellRenderer;
-import org.hibernate.tool.stat.StatisticsTreeModel;
 
 /**
  * Very rudimentary statistics browser.

--- a/orm/src/main/java/org/hibernate/tool/internal/stat/StatisticsTreeModel.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/stat/StatisticsTreeModel.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.stat;
+package org.hibernate.tool.internal.stat;
 
 import java.util.Map;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>