### PR TITLE
HBX-1707: Move class 'org.hibernate.tool.stat.StatisticsCellRenderer' to 'org.hibernate.tool.internal.stat.StatisticsCellRenderer'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/stat/StatisticsBrowser.java
+++ b/orm/src/main/java/org/hibernate/tool/api/stat/StatisticsBrowser.java
@@ -20,9 +20,9 @@ import javax.swing.event.TreeSelectionListener;
 import javax.swing.table.TableCellRenderer;
 
 import org.hibernate.stat.Statistics;
+import org.hibernate.tool.internal.stat.StatisticsCellRenderer;
 import org.hibernate.tool.internal.stat.StatisticsTreeModel;
 import org.hibernate.tool.internal.util.BeanTableModel;
-import org.hibernate.tool.stat.StatisticsCellRenderer;
 
 /**
  * Very rudimentary statistics browser.

--- a/orm/src/main/java/org/hibernate/tool/internal/stat/StatisticsCellRenderer.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/stat/StatisticsCellRenderer.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.stat;
+package org.hibernate.tool.internal.stat;
 
 import java.awt.Component;
 import java.text.SimpleDateFormat;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>