### PR TITLE
HBX-1738: Remove references to 'org.hibernate.tool.internal.reveng.OverrideRepository' from 'AbstractHbm2xMojo' and 'JDBCConfigurationTask'

### DIFF
--- a/maven/src/main/java/org/hibernate/mvn/AbstractHbm2xMojo.java
+++ b/maven/src/main/java/org/hibernate/mvn/AbstractHbm2xMojo.java
@@ -15,7 +15,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.OverrideRepository;
+import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
 
 public abstract class AbstractHbm2xMojo extends AbstractMojo {
 
@@ -57,19 +57,14 @@ public abstract class AbstractHbm2xMojo extends AbstractMojo {
     }
 
     private ReverseEngineeringStrategy setupReverseEngineeringStrategy() {
-        ReverseEngineeringStrategy strategy;
-        try {
-            strategy = ReverseEngineeringStrategy.class.cast(Class.forName(revengStrategy).newInstance());
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | ClassCastException e) {
-            throw new BuildException(revengStrategy + " not instanced.", e);
-        }
-
-        if (revengFile != null) {
-            OverrideRepository override = new OverrideRepository();
-            override.addFile(revengFile);
-            strategy = override.getReverseEngineeringStrategy(strategy);
-        }
-
+    	File[] revengFiles = null;
+    	if (revengFile != null) {
+    		revengFiles = new File[] { revengFile };
+    	}
+        ReverseEngineeringStrategy strategy = 
+        		ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
+        				revengStrategy, 
+        				revengFiles);
         ReverseEngineeringSettings settings =
                 new ReverseEngineeringSettings(strategy)
                         .setDefaultPackageName(packageName)
@@ -78,7 +73,6 @@ public abstract class AbstractHbm2xMojo extends AbstractMojo {
                         .setDetectOptimisticLock(detectOptimisticLock)
                         .setCreateCollectionForForeignKey(createCollectionForForeignKey)
                         .setCreateManyToOneForForeignKey(createManyToOneForForeignKey);
-
         strategy.setSettings(settings);
         return strategy;
     }

--- a/orm/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -15,8 +15,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.OverrideRepository;
+import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
 import org.hibernate.tool.internal.util.ReflectHelper;
 
 
@@ -50,19 +49,18 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 	}
 	
 	private ReverseEngineeringStrategy createReverseEngineeringStrategy() {
-		DefaultReverseEngineeringStrategy defaultStrategy = new DefaultReverseEngineeringStrategy();
-		
-		ReverseEngineeringStrategy strategy = defaultStrategy;
-				
-		if(revengFiles!=null) {
-			OverrideRepository or = new OverrideRepository();
-			
+		File[] revengFileList = null;
+		if (revengFiles != null ) {
 			String[] fileNames = revengFiles.list();
+			revengFileList = new File[fileNames.length];
 			for (int i = 0; i < fileNames.length; i++) {
-				or.addFile(new File(fileNames[i]) );
+				revengFileList[i] = new File(fileNames[i]);
 			}
-			strategy = or.getReverseEngineeringStrategy(defaultStrategy);			
 		}
+
+		ReverseEngineeringStrategy strategy = 
+				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
+						null, revengFileList);
 		
 		if(reverseEngineeringStrategyClass!=null) {
 			strategy = loadreverseEngineeringStrategy(reverseEngineeringStrategyClass, strategy);			
@@ -74,7 +72,6 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 			.setDetectOneToOne( detectOneToOne )
 			.setDetectOptimisticLock( detectOptimisticLock );
 	
-		defaultStrategy.setSettings(qqsettings);
 		strategy.setSettings(qqsettings);
 		
 		return strategy;

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactory.java
@@ -1,6 +1,9 @@
 package org.hibernate.tool.api.reveng;
 
+import java.io.File;
+
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tool.internal.util.ReflectHelper;
 
 public class ReverseEngineeringStrategyFactory {
@@ -20,6 +23,21 @@ public class ReverseEngineeringStrategyFactory {
 			result = (ReverseEngineeringStrategy)reverseEngineeringClass.newInstance();
 		} catch (ClassNotFoundException | IllegalAccessException | InstantiationException exception) {
 			throw new RuntimeException("An exporter of class '" + reverseEngineeringClassName + "' could not be created", exception);
+		}
+		return result;
+	}
+	
+	public static ReverseEngineeringStrategy createReverseEngineeringStrategy(
+			String reverseEngineeringClassName,
+			File[] revengFiles) {
+		ReverseEngineeringStrategy result = 
+				createReverseEngineeringStrategy(reverseEngineeringClassName);
+		if (revengFiles != null && revengFiles.length > 0) {
+			OverrideRepository overrideRepository = new OverrideRepository();
+			for (File file : revengFiles) {
+				overrideRepository.addFile(file);
+			}
+			result = overrideRepository.getReverseEngineeringStrategy(result);
 		}
 		return result;
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>