### PR TITLE
HBX-1739: Move class 'org.hibernate.tool.internal.export.pojo.POJOExporter' to 'org.hibernate.tool.api.export.PojoExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
@@ -7,7 +7,7 @@ package org.hibernate.tool.ant;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
-import org.hibernate.tool.internal.export.pojo.POJOExporter;
+import org.hibernate.tool.api.export.PojoExporter;
 
 /**
  * @author max

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -2,7 +2,8 @@ package org.hibernate.tool.api.export;
 
 public enum ExporterType {
 	
-	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
+	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
+	POJO ("org.hibernate.tool.api.export.PojoExporter");
 	
 	private String className;
 	

--- a/orm/src/main/java/org/hibernate/tool/api/export/PojoExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/PojoExporter.java
@@ -2,14 +2,14 @@
  * Created on 2004-12-01
  *
  */
-package org.hibernate.tool.internal.export.pojo;
+package org.hibernate.tool.api.export;
 
 import org.hibernate.tool.internal.export.common.GenericExporter;
 
 /**
  * @author max
  */
-public class POJOExporter extends GenericExporter {
+public class PojoExporter extends GenericExporter {
 
 	private static final String POJO_JAVACLASS_FTL = "pojo/Pojo.ftl";
 
@@ -18,7 +18,7 @@ public class POJOExporter extends GenericExporter {
     	setFilePattern("{package-name}/{class-name}.java");    	
 	}
 
-	public POJOExporter() {
+	public PojoExporter() {
 		init();		
 	}
     

--- a/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAOExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAOExporter.java
@@ -2,10 +2,10 @@ package org.hibernate.tool.internal.export.dao;
 
 import java.util.Map;
 
+import org.hibernate.tool.api.export.PojoExporter;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
-import org.hibernate.tool.internal.export.pojo.POJOExporter;
 
-public class DAOExporter extends POJOExporter {
+public class DAOExporter extends PojoExporter {
 
     private static final String DAO_DAOHOME_FTL = "dao/daohome.ftl";
 

--- a/orm/src/test/java/org/hibernate/tool/api/export/ExporterTypeTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/export/ExporterTypeTest.java
@@ -9,7 +9,10 @@ public class ExporterTypeTest {
 	@Test
 	public void testExporterType() {
 		Assert.assertEquals(
-				"org.hibernate.tool.internal.export.pojo.POJOExporter",
+				"org.hibernate.tool.internal.export.common.GenericExporter",
+				ExporterType.GENERIC.className());
+		Assert.assertEquals(
+				"org.hibernate.tool.api.export.PojoExporter",
 				ExporterType.POJO.className());
 	}
 

--- a/test/common/src/main/resources/org/hibernate/tool/ant/GenericExport/build.xml
+++ b/test/common/src/main/resources/org/hibernate/tool/ant/GenericExport/build.xml
@@ -32,7 +32,7 @@
 				filepattern="{package-name}/{class-name}.quote" />
 			
 			<hbmtemplate 
-				exporterclass="org.hibernate.tool.internal.export.pojo.POJOExporter" 
+				exporterclass="org.hibernate.tool.api.export.PojoExporter" 
 				filepattern="{package-name}/{class-name}.pojo" /> 
 			
 		</hibernatetool>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>