### PR TITLE
Revert "HBX-1739: Move class 'org.hibernate.tool.internal.export.pojo.POJOExporter' to 'org.hibernate.tool.api.export.PojoExporter'"

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
@@ -7,7 +7,7 @@ package org.hibernate.tool.ant;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
-import org.hibernate.tool.api.export.PojoExporter;
+import org.hibernate.tool.internal.export.pojo.POJOExporter;
 
 /**
  * @author max

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -2,8 +2,7 @@ package org.hibernate.tool.api.export;
 
 public enum ExporterType {
 	
-	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
-	POJO ("org.hibernate.tool.api.export.PojoExporter");
+	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
 	
 	private String className;
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAOExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/dao/DAOExporter.java
@@ -2,10 +2,10 @@ package org.hibernate.tool.internal.export.dao;
 
 import java.util.Map;
 
-import org.hibernate.tool.api.export.PojoExporter;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
+import org.hibernate.tool.internal.export.pojo.POJOExporter;
 
-public class DAOExporter extends PojoExporter {
+public class DAOExporter extends POJOExporter {
 
     private static final String DAO_DAOHOME_FTL = "dao/daohome.ftl";
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/pojo/POJOExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/pojo/POJOExporter.java
@@ -2,14 +2,14 @@
  * Created on 2004-12-01
  *
  */
-package org.hibernate.tool.api.export;
+package org.hibernate.tool.internal.export.pojo;
 
 import org.hibernate.tool.internal.export.common.GenericExporter;
 
 /**
  * @author max
  */
-public class PojoExporter extends GenericExporter {
+public class POJOExporter extends GenericExporter {
 
 	private static final String POJO_JAVACLASS_FTL = "pojo/Pojo.ftl";
 
@@ -18,7 +18,7 @@ public class PojoExporter extends GenericExporter {
     	setFilePattern("{package-name}/{class-name}.java");    	
 	}
 
-	public PojoExporter() {
+	public POJOExporter() {
 		init();		
 	}
     

--- a/orm/src/test/java/org/hibernate/tool/api/export/ExporterTypeTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/export/ExporterTypeTest.java
@@ -9,10 +9,7 @@ public class ExporterTypeTest {
 	@Test
 	public void testExporterType() {
 		Assert.assertEquals(
-				"org.hibernate.tool.internal.export.common.GenericExporter",
-				ExporterType.GENERIC.className());
-		Assert.assertEquals(
-				"org.hibernate.tool.api.export.PojoExporter",
+				"org.hibernate.tool.internal.export.pojo.POJOExporter",
 				ExporterType.POJO.className());
 	}
 

--- a/test/common/src/main/resources/org/hibernate/tool/ant/GenericExport/build.xml
+++ b/test/common/src/main/resources/org/hibernate/tool/ant/GenericExport/build.xml
@@ -32,7 +32,7 @@
 				filepattern="{package-name}/{class-name}.quote" />
 			
 			<hbmtemplate 
-				exporterclass="org.hibernate.tool.api.export.PojoExporter" 
+				exporterclass="org.hibernate.tool.internal.export.pojo.POJOExporter" 
 				filepattern="{package-name}/{class-name}.pojo" /> 
 			
 		</hibernatetool>


### PR DESCRIPTION
This reverts commit 1e6fabbf1b605ddf13dc8d769d8db323cdb8cd4b.