### PR TITLE
HBX-1740: Remove method Exporter#setMetadataDescriptor(MetadataExporter) from interface org.hibernate.tool.api.export.Exporter - Remove Exporter.setMetadataDescriptor(MetadataDescriptor)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
@@ -15,11 +15,6 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
  */
 public interface Exporter {
 	
-	/** 
-	 * @param metadataDescriptor An Hibernate {@link org.hibernate.tool.api.metadata.MetadataDescriptor} or subclass instance that defines the hibernate meta model to be exported.
-	 */
-	public void setMetadataDescriptor(MetadataDescriptor metadataDescriptor);
-		
 
 	public Metadata getMetadata();
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>