### PR TITLE
HBX-1742: Remove method Exporter#setArtifactCollector(ArtifactCollector) from interface org.hibernate.tool.api.export.Exporter - Remove Exporter#setArtifactCollector(...) and AbstractExporter#setArtifactCollector(...)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
@@ -31,12 +31,6 @@ public interface Exporter {
 	
 	/**
 	 * 
-	 * @param collector Instance to be consulted when adding a new file.
-	 */
-	public void setArtifactCollector(org.hibernate.tool.api.export.ArtifactCollector collector);
-	
-	/**
-	 * 
 	 * @return artifact collector
 	 */
 	public ArtifactCollector getArtifactCollector();

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
@@ -79,10 +79,6 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 		return templatePaths;
 	}
 	
-	public void setArtifactCollector(ArtifactCollector collector) {
-		getProperties().put(ARTIFACT_COLLECTOR, collector);
-	}
-	
 	public ArtifactCollector getArtifactCollector() {
 		return (ArtifactCollector)getProperties().get(ARTIFACT_COLLECTOR);
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -161,8 +161,8 @@ public class DocExporter extends AbstractExporter {
 			try {
 				GenericExporter exporter = new GenericExporter();
 				exporter.getProperties().putAll( getProperties() );
-				exporter.setArtifactCollector( getArtifactCollector() );
-				exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, getMetadataDescriptor());
+				exporter.getProperties().put(ARTIFACT_COLLECTOR, getArtifactCollector());
+				exporter.getProperties().put(METADATA_DESCRIPTOR, getMetadataDescriptor());
 				exporter.setOutputDirectory(getOutputDirectory());
 				exporter.setTemplatePath( getTemplatePath() );
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
@@ -52,7 +52,7 @@ public class TestCase {
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.setOutputDirectory(outputDir);
 		artifactCollector = new DefaultArtifactCollector();
-		exporter.setArtifactCollector(artifactCollector);
+		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.start();
 	}
 
@@ -63,7 +63,7 @@ public class TestCase {
 		exporter.setOutputDirectory(outputDir);
 		exporter.getProperties().setProperty("jdk5", "true");
 		artifactCollector = new DefaultArtifactCollector();
-		exporter.setArtifactCollector(artifactCollector);
+		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.start();
 		testFileExistence();
 		testNoVelocityLeftOvers();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaTest/TestCase.java
@@ -78,7 +78,7 @@ public class TestCase {
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.setOutputDirectory(outputDir);
 		artifactCollector = new DefaultArtifactCollector();
-		exporter.setArtifactCollector(artifactCollector);
+		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.start();
 	}
 
@@ -461,7 +461,7 @@ public class TestCase {
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.setOutputDirectory(genericsSource);
 		artifactCollector = new DefaultArtifactCollector();
-		exporter.setArtifactCollector(artifactCollector);
+		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.getProperties().setProperty("jdk5", "true");
 		exporter.start();
 		File genericsTarget = new File(temporaryFolder.getRoot(), "genericstarget" );

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/PropertiesTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/PropertiesTest/TestCase.java
@@ -60,11 +60,11 @@ public class TestCase {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.setOutputDirectory(outputDir);
-		exporter.setArtifactCollector(artifactCollector);
+		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		Exporter hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.setOutputDirectory(outputDir);
-		hbmexporter.setArtifactCollector(artifactCollector);
+		hbmexporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.start();
 		hbmexporter.start();
 	}	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>