### PR TITLE
HBX-1743: Remove method Exporter#getArtifactCollector() from interface org.hibernate.tool.api.export.Exporter

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
@@ -30,12 +30,6 @@ public interface Exporter {
 	public Properties getProperties();
 	
 	/**
-	 * 
-	 * @return artifact collector
-	 */
-	public ArtifactCollector getArtifactCollector();
-	
-	/**
 	 * Called when exporter should start generating its output
 	 */
 	public void start();

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -14,7 +14,6 @@ import org.hibernate.HibernateException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.common.AbstractExporter;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.common.TemplateProducer;

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -64,7 +64,7 @@ public class TestCase {
 	private MetadataDescriptor metadataDescriptor = null;
 	private File outputDir = null;
 	private File resourcesDir = null;
-	private Exporter hbmexporter = null;
+	private HibernateMappingExporter hbmexporter = null;
 
 	@Before
 	public void setUp() throws Exception {

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
@@ -28,7 +28,6 @@ import org.dom4j.Element;
 import org.dom4j.XPath;
 import org.dom4j.io.SAXReader;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -57,7 +56,7 @@ public class TestCase {
 	private File outputDir = null;
 	private File resourcesDir = null;
 	
-	private Exporter hbmexporter = null;
+	private HibernateMappingExporter hbmexporter = null;
 
 	@Before
 	public void setUp() throws Exception {

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
@@ -19,7 +19,6 @@ import org.dom4j.Element;
 import org.dom4j.XPath;
 import org.dom4j.io.SAXReader;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -50,7 +49,7 @@ public class TestCase {
 	private File outputDir = null;
 	private File resourcesDir = null;
 	
-	private Exporter hbmexporter = null;
+	private HibernateMappingExporter hbmexporter = null;
 
 	@Before
 	public void setUp() throws Exception {

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ManyToManyTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ManyToManyTest/TestCase.java
@@ -19,7 +19,6 @@ import org.dom4j.Element;
 import org.dom4j.XPath;
 import org.dom4j.io.SAXReader;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -41,7 +40,7 @@ public class TestCase {
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 	
-	private Exporter hbmexporter = null;
+	private HibernateMappingExporter hbmexporter = null;
 	private File outputDir = null;
 	private File resourcesDir = null;
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/TestCase.java
@@ -18,7 +18,6 @@ import org.dom4j.Element;
 import org.dom4j.XPath;
 import org.dom4j.io.SAXReader;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -44,7 +43,7 @@ public class TestCase {
 	
 	private File outputDir = null;
 	private File resourcesDir = null;
-	private Exporter hbmexporter = null;
+	private HibernateMappingExporter hbmexporter = null;
 	
 	@Before
 	public void setUp() throws Exception {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>