### PR TITLE
HBX-1744: Remove methods Exporter#getOutputDirectory() and Exporter#setOutputDirectory(File) from interface org.hibernate.tool.api.export.Exporter - Replace uses of Exporter#setOutputDirectory(File) with Exporter#getProperties()#put(ExporterConstants.OUTPUT_FOLDER,File)

### DIFF
--- a/maven/src/main/java/org/hibernate/mvn/Hbm2JavaMojo.java
+++ b/maven/src/main/java/org/hibernate/mvn/Hbm2JavaMojo.java
@@ -32,7 +32,7 @@ public class Hbm2JavaMojo extends AbstractHbm2xMojo {
     protected void executeExporter(MetadataDescriptor metadataDescriptor) {
         Exporter pojoExporter = ExporterFactory.createExporter(ExporterType.POJO);
         pojoExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-        pojoExporter.setOutputDirectory(outputDirectory);
+        pojoExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDirectory);
         if (templatePath != null) {
             getLog().info("Setting template path to: " + templatePath);
             pojoExporter.setTemplatePath(new String[]{templatePath});

--- a/orm/src/main/java/org/hibernate/tool/ant/ExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/ExporterTask.java
@@ -94,7 +94,7 @@ public abstract class ExporterTask {
 		prop.putAll(properties);
 		exporter.getProperties().putAll(prop);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getMetadataDescriptor());
-		exporter.setOutputDirectory( getDestdir() );
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, getDestdir());
 		exporter.setTemplatePath( getTemplatePath().list() );			
 		return exporter;
 	}

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
@@ -23,7 +23,7 @@ public class Hbm2DAOExporterTask extends Hbm2JavaExporterTask {
 		Exporter result = new DAOExporter();
 		result.getProperties().putAll(parent.getProperties());
 		result.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getMetadataDescriptor());
-		result.setOutputDirectory(parent.getDestDir());
+		result.getProperties().put(ExporterConstants.OUTPUT_FOLDER, getDestdir());
 		return result;
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -52,7 +52,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		Hbm2DDLExporter exporter = new Hbm2DDLExporter();
 		exporter.getProperties().putAll(parent.getProperties());
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getProperties());
-		exporter.setOutputDirectory(parent.getDestDir());
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, parent.getDestDir());
 		return exporter;
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -14,6 +14,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
+import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.common.AbstractExporter;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.common.TemplateProducer;
@@ -162,7 +163,7 @@ public class DocExporter extends AbstractExporter {
 				exporter.getProperties().putAll( getProperties() );
 				exporter.getProperties().put(ARTIFACT_COLLECTOR, getArtifactCollector());
 				exporter.getProperties().put(METADATA_DESCRIPTOR, getMetadataDescriptor());
-				exporter.setOutputDirectory(getOutputDirectory());
+				exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, getOutputDirectory());
 				exporter.setTemplatePath( getTemplatePath() );
 
 				exporter.setTemplateName( "dot/entitygraph.dot.ftl" );

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -69,11 +69,11 @@ public class TestCase {
 	public void testGenerateJava() throws SQLException, ClassNotFoundException {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);		
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();
 		exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.start();
 	}
@@ -82,7 +82,7 @@ public class TestCase {
 	public void testGenerateMappings() {
 		Exporter exporter = new HibernateMappingExporter();	
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();	
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "org/reveng/Child.hbm.xml"));
 		File file = new File(outputDir, "GeneralHbmSettings.hbm.xml");
@@ -101,7 +101,7 @@ public class TestCase {
 	public void testGenerateCfgXml() throws DocumentException {	
 		Exporter exporter = new HibernateConfigurationExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();				
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "hibernate.cfg.xml"));
 		SAXReader xmlReader =  new SAXReader();
@@ -127,7 +127,7 @@ public class TestCase {
 		HibernateConfigurationExporter exporter = 
 				new HibernateConfigurationExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.start();	
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "hibernate.cfg.xml"));
@@ -153,7 +153,7 @@ public class TestCase {
 	public void testGenerateDoc() {	
 		DocExporter exporter = new DocExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "index.html"));
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
@@ -67,8 +67,8 @@ public class TestCase {
 	public void testGenerateJava() throws Exception {	
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);	
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, createMetadataDescriptor());
-		exporter.setOutputDirectory(outputDir);
-		exporter.start();
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
+ 		exporter.start();
 		File myReturn = new File(outputDir, "org/reveng/MyReturn.java");
 		Assert.assertTrue(myReturn.exists());
 		File myReturnHistory = new File(outputDir, "org/reveng/MyReturnHistory.java");

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3/TestCase.java
@@ -46,7 +46,7 @@ public class TestCase {
 		exporter.getProperties().put(
 				ExporterConstants.METADATA_DESCRIPTOR, 
 				MetadataDescriptorFactory.createJdbcDescriptor(null, null, true));
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.setTemplatePath(new String[0]);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.getProperties().setProperty("jdk5", "true");

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
@@ -69,7 +69,7 @@ public class TestCase {
 						null);
 		exporter.getProperties().put(AvailableSettings.HBM2DDL_AUTO, "update");
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(destinationDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, destinationDir);
 		exporter.setFilename("queryresult.txt");
 		List<String> queries = new ArrayList<String>();
 		queries.add("from java.lang.Object");

--- a/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbmlint/HbmLintTest/TestCase.java
@@ -46,7 +46,7 @@ public class TestCase {
 	public void testExporter() {	
 		HbmLintExporter exporter = new HbmLintExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();
 	}
 	

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -169,10 +169,10 @@ public class TestCase {
         final File testFolder = temporaryFolder.getRoot();        
         Exporter exporter = new HibernateMappingExporter();	
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-        exporter.setOutputDirectory(testFolder);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, testFolder);
         Exporter javaExp = ExporterFactory.createExporter(ExporterType.POJO);
 		javaExp.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-        javaExp.setOutputDirectory(testFolder);
+		javaExp.getProperties().put(ExporterConstants.OUTPUT_FOLDER, testFolder);
         exporter.start();
         javaExp.start();      
         JavaUtil.compile(testFolder);        

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -149,10 +149,10 @@ public class TestCase {
 		final File testFolder = temporaryFolder.getRoot();
 		Exporter exporter = new HibernateMappingExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(testFolder);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, testFolder);
 		Exporter javaExp = ExporterFactory.createExporter(ExporterType.POJO);
 		javaExp.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		javaExp.setOutputDirectory(testFolder);
+		javaExp.getProperties().put(ExporterConstants.OUTPUT_FOLDER, testFolder);
 		exporter.start();
 		javaExp.start();
 		JavaUtil.compile(testFolder);

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -128,7 +128,7 @@ public class TestCase {
 		
 		HibernateMappingExporter hme = new HibernateMappingExporter();
 		hme.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hme.setOutputDirectory(outputDir);
+		hme.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hme.start();		
 		
 		assertFileAndExists( new File(outputDir, "Employee.hbm.xml") );

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
@@ -133,7 +133,7 @@ public class TestCase {
 		File outputDir = temporaryFolder.getRoot();
 		HibernateMappingExporter hme = new HibernateMappingExporter();
 		hme.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hme.setOutputDirectory(outputDir);
+		hme.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hme.start();		
 		assertFileAndExists( new File(outputDir, "Person.hbm.xml") );
 		assertFileAndExists( new File(outputDir, "AddressPerson.hbm.xml") );
@@ -145,7 +145,7 @@ public class TestCase {
 		Assert.assertEquals(7, outputDir.listFiles().length);	
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.setTemplatePath(new String[0]);
 		exporter.getProperties().setProperty("ejb3", "false");
 		exporter.getProperties().setProperty("jdk5", "false");
@@ -181,7 +181,7 @@ public class TestCase {
 		File outputDir = temporaryFolder.getRoot();
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.setTemplatePath(new String[0]);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.getProperties().setProperty("jdk5", "true");

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
@@ -76,7 +76,7 @@ public class TestCase {
 		File outputFolder = temporaryFolder.getRoot();
 		HibernateMappingExporter hme = new HibernateMappingExporter();
 		hme.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hme.setOutputDirectory(outputFolder);
+		hme.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputFolder);
 		hme.start();			
 		JUnitUtil.assertIsNonEmptyFile( new File(outputFolder, "Role.hbm.xml") );
 		JUnitUtil.assertIsNonEmptyFile( new File(outputFolder, "User.hbm.xml") );

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
@@ -70,8 +70,8 @@ public class TestCase {
 		File testFolder = temporaryFolder.getRoot();
         Exporter exporter = new HibernateMappingExporter();		
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-        exporter.setOutputDirectory(testFolder);
-		exporter.start();		
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, testFolder);
+ 		exporter.start();		
 		File[] files = new File[4];		
 		files[0] = new File(testFolder, "WithVersion.hbm.xml");
 		files[1] = new File(testFolder, "NoVersion.hbm.xml");

--- a/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
+++ b/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
@@ -54,7 +54,7 @@ public class TestCase {
 	public void testGenerateJava() throws IOException {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);	
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.start();
 		File etManyToManyComp1 = new File(outputDir, "EtManyToManyComp1.java");

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
@@ -74,7 +74,7 @@ public class TestCase {
 		properties.setProperty("dot.ignoreerror", Boolean.toString(ignoreDot));
 		exporter.getProperties().putAll(properties);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();
 	}
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/GenericExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/GenericExporterTest/TestCase.java
@@ -58,7 +58,7 @@ public class TestCase {
 	public void testSingleFileGeneration() {
 		GenericExporter ge = new GenericExporter();
 		ge.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		ge.setOutputDirectory(outputDir);
+		ge.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		ge.setTemplateName(resourcesLocation + "generic-test.ftl"); 
 		ge.setFilePattern("generictest.txt");
 		ge.start();
@@ -77,7 +77,7 @@ public class TestCase {
 	public void testFreeMarkerSyntaxFailureExpected() {
 		GenericExporter ge = new GenericExporter();
 		ge.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		ge.setOutputDirectory(outputDir);
+		ge.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		ge.setTemplateName(resourcesLocation + "freemarker.ftl");
 		ge.setFilePattern("{class-name}.ftltest");
 		ge.start();
@@ -92,7 +92,7 @@ public class TestCase {
 	public void testClassFileGeneration() {
 		GenericExporter ge = new GenericExporter();
 		ge.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		ge.setOutputDirectory(outputDir);
+		ge.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		ge.setTemplateName(resourcesLocation + "generic-class.ftl");
 		ge.setFilePattern("generic{class-name}.txt");
 		ge.start();
@@ -104,7 +104,7 @@ public class TestCase {
 	public void testPackageFileGeneration() {
 		GenericExporter ge = new GenericExporter();
 		ge.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		ge.setOutputDirectory(outputDir);
+		ge.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		ge.setTemplateName(resourcesLocation + "generic-class.ftl");
 		ge.setFilePattern("{package-name}/generic{class-name}.txt");
 		ge.start();
@@ -119,7 +119,7 @@ public class TestCase {
 	public void testForEachGeneration() {
 		GenericExporter ge = new GenericExporter();
 		ge.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		ge.setOutputDirectory(outputDir);
+		ge.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		ge.setTemplateName(resourcesLocation + "generic-class.ftl");
 		ge.setFilePattern("{package-name}/generic{class-name}.txt");
 		ge.setForEach("entity");
@@ -145,7 +145,7 @@ public class TestCase {
 	public void testForEachWithExceptionGeneration() {
 		GenericExporter ge = new GenericExporter();
 		ge.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		ge.setOutputDirectory(outputDir);
+		ge.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		ge.setTemplateName(resourcesLocation + "generic-exception.ftl");
 		ge.setFilePattern("{package-name}/generic{class-name}.txt");
 		try {
@@ -181,7 +181,7 @@ public class TestCase {
 		p.setProperty("hibernatetool.myTool.toolclass", "org.hibernate.tool.internal.export.pojo.Cfg2JavaTool");
 		ge.getProperties().putAll(p);
 		ge.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		ge.setOutputDirectory(outputDir);
+		ge.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		ge.setTemplateName(resourcesLocation + "generic-class.ftl");
 		ge.setFilePattern("{package-name}/generic{class-name}.txt");
 		ge.start();		

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
@@ -50,7 +50,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		artifactCollector = new DefaultArtifactCollector();
 		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.start();
@@ -60,7 +60,7 @@ public class TestCase {
 	public void testJDK5FailureExpectedOnJDK4() {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().setProperty("jdk5", "true");
 		artifactCollector = new DefaultArtifactCollector();
 		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
@@ -50,7 +50,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		cfgexporter = new HibernateConfigurationExporter();
 		cfgexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		cfgexporter.setOutputDirectory(outputDir);
+		cfgexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		cfgexporter.start();
 	}
 	
@@ -66,7 +66,7 @@ public class TestCase {
 	   exporter.getProperties().put(
 			   ExporterConstants.METADATA_DESCRIPTOR, 
 			   MetadataDescriptorFactory.createNativeDescriptor(null, null, properties));
-	   exporter.setOutputDirectory(outputDir);
+	   exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 	   exporter.start();
 	   File file = new File(outputDir, "hibernate.cfg.xml");
 	   Assert.assertNull(
@@ -85,7 +85,7 @@ public class TestCase {
 	   exporter.getProperties().put(
 			   ExporterConstants.METADATA_DESCRIPTOR, 
 			   MetadataDescriptorFactory.createNativeDescriptor(null, null, properties));
-	   exporter.setOutputDirectory(outputDir);
+	   exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 	   exporter.start();
 	   Assert.assertNotNull(
 			   FileUtil.findFirstString( Environment.HBM2DDL_AUTO, file ));
@@ -96,7 +96,7 @@ public class TestCase {
 	   exporter.getProperties().put(
 			   ExporterConstants.METADATA_DESCRIPTOR, 
 			   MetadataDescriptorFactory.createNativeDescriptor(null, null, properties));
-	   exporter.setOutputDirectory(outputDir);
+	   exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 	   exporter.start();
 	   Assert.assertNull(
 			   FileUtil.findFirstString( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, file ));

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
@@ -50,10 +50,10 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter javaExporter = ExporterFactory.createExporter(ExporterType.POJO);
 		javaExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		javaExporter.setOutputDirectory(outputDir);
+		javaExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		Exporter exporter = new DAOExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "false");
 		exporter.getProperties().setProperty("jdk5", "true");
 		exporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2EJBDaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2EJBDaoTest/TestCase.java
@@ -56,10 +56,10 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter javaExporter = ExporterFactory.createExporter(ExporterType.POJO);;
 		javaExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		javaExporter.setOutputDirectory(outputDir);
+		javaExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		Exporter exporter = new DAOExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.getProperties().setProperty("jdk5", "true");
 		exporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2HibernateDAOTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2HibernateDAOTest/TestCase.java
@@ -56,10 +56,10 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter javaExporter = ExporterFactory.createExporter(ExporterType.POJO);
 		javaExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		javaExporter.setOutputDirectory(outputDir);
+		javaExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		Exporter exporter = new DAOExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "false");
 		exporter.getProperties().setProperty("jdk5", "true");
 		exporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaConstructorTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaConstructorTest/TestCase.java
@@ -59,7 +59,7 @@ public class TestCase {
 		metadata = metadataDescriptor.createMetadata();
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();
 	}	
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaDidirectionalIndexedCollectionMappingTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaDidirectionalIndexedCollectionMappingTest/TestCase.java
@@ -44,7 +44,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();
 	}
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaEjb3Test/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaEjb3Test/TestCase.java
@@ -67,7 +67,7 @@ public class TestCase {
 		FileUtil.generateNoopComparator(outputDir);
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.setTemplatePath(new String[0]);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.getProperties().setProperty("jdk5", "true");

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaEqualsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaEqualsTest/TestCase.java
@@ -70,7 +70,7 @@ public class TestCase {
 				.createNativeDescriptor(null, new File[] { hbmXml }, properties);
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();
 		// copy interface EntityProxy.java
 		File file = new File(outputDir, "org/hibernate/tool/hbm2x/Hbm2JavaEquals/TestEntityProxy.java");

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaTest/TestCase.java
@@ -76,7 +76,7 @@ public class TestCase {
 		metadata = metadataDescriptor.createMetadata();
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		artifactCollector = new DefaultArtifactCollector();
 		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.start();
@@ -459,7 +459,7 @@ public class TestCase {
 		File genericsSource = new File(temporaryFolder.getRoot(), "genericssource");
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(genericsSource);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, genericsSource);
 		artifactCollector = new DefaultArtifactCollector();
 		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.getProperties().setProperty("jdk5", "true");

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
@@ -44,7 +44,7 @@ public class TestCase {
 		outputDir.mkdir();
 		HibernateMappingExporter exporter = new HibernateMappingExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		final File fooHbmXml = new File(outputDir, "Foo.hbm.xml");
 		Assert.assertFalse(fooHbmXml.exists());
 		exporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
@@ -60,7 +60,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter hbmexporter = new HibernateMappingExporter();	
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();		
 	}
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/PropertiesTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/PropertiesTest/TestCase.java
@@ -59,11 +59,11 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.setOutputDirectory(outputDir);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		Exporter hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		exporter.start();
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/AbstractTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/AbstractTest/TestCase.java
@@ -68,7 +68,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/BackrefTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/BackrefTest/TestCase.java
@@ -67,7 +67,7 @@ public class TestCase {
 		metadata = metadataDescriptor.createMetadata();
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/CompositeElementTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/CompositeElementTest/TestCase.java
@@ -69,7 +69,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
@@ -69,7 +69,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/FormulaTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/FormulaTest/TestCase.java
@@ -60,7 +60,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -76,7 +76,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 	
@@ -119,7 +119,7 @@ public class TestCase {
 		hgs.setCatalogName("mycatalog");		
 		Exporter gsExporter = new HibernateMappingExporter();
 		gsExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		gsExporter.setOutputDirectory(outputDir);
+		gsExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		( (HibernateMappingExporter)gsExporter).setGlobalSettings(hgs);
 		gsExporter.start();
 		File outputXml = new File(
@@ -149,7 +149,7 @@ public class TestCase {
 		hgs.setDefaultCascade("save-update");
 		Exporter gbsExporter = new HibernateMappingExporter();
 		gbsExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		gbsExporter.setOutputDirectory(outputDir);
+		gbsExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		( (HibernateMappingExporter)gbsExporter).setGlobalSettings(hgs);
 		gbsExporter.start();
 		File outputXml = new File(
@@ -265,7 +265,7 @@ public class TestCase {
 		hgs.setDefaultCascade("none");	
 		Exporter gbsExporter = new HibernateMappingExporter();
 		gbsExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		gbsExporter.setOutputDirectory(outputDir);
+		gbsExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		( (HibernateMappingExporter)gbsExporter).setGlobalSettings(hgs);
 		gbsExporter.start();
 		File outputXml = new File(
@@ -296,7 +296,7 @@ public class TestCase {
 		hgs.setAutoImport(false);		
 		Exporter gbsExporter = new HibernateMappingExporter();
 		gbsExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		gbsExporter.setOutputDirectory(outputDir);
+		gbsExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		( (HibernateMappingExporter)gbsExporter).setGlobalSettings(hgs);
 		gbsExporter.start();
 		File outputXml = new File(

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
@@ -68,7 +68,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
@@ -61,7 +61,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/TestCase.java
@@ -60,7 +60,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/TestCase.java
@@ -67,7 +67,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ManyToManyTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ManyToManyTest/TestCase.java
@@ -54,7 +54,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/MapAndAnyTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/MapAndAnyTest/TestCase.java
@@ -75,7 +75,7 @@ public class TestCase {
 		metadata = metadataDescriptor.createMetadata();
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/TestCase.java
@@ -55,7 +55,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();		
 	}
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
@@ -67,7 +67,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/TypeParamsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/TypeParamsTest/TestCase.java
@@ -69,7 +69,7 @@ public class TestCase {
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter hbmexporter = new HibernateMappingExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		hbmexporter.start();
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>