### PR TITLE
HBX-1744: Remove methods Exporter#getOutputDirectory() and Exporter#setOutputDirectory(File) from interface org.hibernate.tool.api.export.Exporter - Remove Exporter#setOutputDirectory(File) and AbstractExporter#setOutputDirectory(File)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
@@ -13,11 +13,6 @@ import java.util.Properties;
 public interface Exporter {
 	
 
-	/**
-	 * @param file basedirectory to be used for generated files.
-	 */
-	public void setOutputDirectory(File file);
-
 	public File getOutputDirectory();
 	
 	/**

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
@@ -62,10 +62,6 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 		return (File)getProperties().get(OUTPUT_FOLDER);
 	}
 
-	public void setOutputDirectory(File outputdir) {
-		getProperties().put(OUTPUT_FOLDER, outputdir);
-	}
-
 	public Properties getProperties() {
 		return properties;
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>