### PR TITLE
HBX-1744: Remove methods Exporter#getOutputDirectory() and Exporter#setOutputDirectory(File) from interface org.hibernate.tool.api.export.Exporter - Remove Exporter#getOutputDirectory()

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
@@ -13,8 +13,6 @@ import java.util.Properties;
 public interface Exporter {
 	
 
-	public File getOutputDirectory();
-	
 	/**
 	 * @param templatePath array of directories used sequentially to lookup templates
 	 */


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>