### PR TITLE
HBX-1744: Remove methods Exporter#getOutputDirectory() and Exporter#setOutputDirectory(File) from interface org.hibernate.tool.api.export.Exporter - Make AbstractExporter#getOutputDirectory() protected

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
@@ -58,7 +58,7 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 		return metadata;
 	}
 	
-	public File getOutputDirectory() {
+	protected File getOutputDirectory() {
 		return (File)getProperties().get(OUTPUT_FOLDER);
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>