### PR TITLE
Remove methods Exporter#getTemplatePatch() and Exporter#setTemplatePath(String[]) from interface org.hibernate.tool.api.export.Exporter - Store templatePath in AbstractExporter#properties

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
@@ -5,5 +5,6 @@ public interface ExporterConstants {
 	public static final String METADATA_DESCRIPTOR = "org.hibernate.tool.api.export.ExporterConstants.MetadataDescriptor";
 	public static final String ARTIFACT_COLLECTOR = "org.hibernate.tool.api.export.ExporterConstants.ArtifactCollector";
 	public static final String OUTPUT_FOLDER = "org.hibernate.tool.api.export.ExporterConstants.OutputFolder";
+	public static final String TEMPLATE_PATH = "org.hibernate.tool.api.export.ExporterConstants.TemplatePath";
 
 }

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
@@ -31,7 +31,6 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 
 	protected Logger log = LoggerFactory.getLogger(this.getClass());
 	
-	private String[] templatePaths = new String[0];
 	private TemplateHelper vh;
 	private Properties properties = new Properties();
 	private Metadata metadata = null;
@@ -45,6 +44,7 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 		c2h = new Cfg2HbmTool();
 		c2j = new Cfg2JavaTool();
 		getProperties().put(ARTIFACT_COLLECTOR, new DefaultArtifactCollector());
+		getProperties().put(TEMPLATE_PATH, new String[0]);
 	}
 	
 	protected MetadataDescriptor getMetadataDescriptor() {
@@ -67,11 +67,11 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 	}
 	
 	public void setTemplatePath(String[] templatePaths) {
-		this.templatePaths = templatePaths;
+		getProperties().put(TEMPLATE_PATH, templatePaths);
 	}
 
 	public String[] getTemplatePath() {
-		return templatePaths;
+		return (String[])getProperties().get(TEMPLATE_PATH);
 	}
 	
 	public ArtifactCollector getArtifactCollector() {
@@ -175,9 +175,9 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 
 	protected void setupTemplates() {
 		if(log.isDebugEnabled()) {
-			log.debug(getClass().getName() + " outputdir:" + getOutputDirectory() + " path: " + toString(templatePaths) );
+			log.debug(getClass().getName() + " outputdir:" + getOutputDirectory() + " path: " + toString(getTemplatePath()) );
 		}
-		getTemplateHelper().init(getOutputDirectory(), templatePaths);		
+		getTemplateHelper().init(getOutputDirectory(), getTemplatePath());		
 	}
 	
 	protected void setTemplateHelper(TemplateHelper vh) {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -14,7 +14,6 @@ import org.hibernate.HibernateException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.common.AbstractExporter;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.common.TemplateProducer;
@@ -163,9 +162,12 @@ public class DocExporter extends AbstractExporter {
 				exporter.getProperties().putAll( getProperties() );
 				exporter.getProperties().put(ARTIFACT_COLLECTOR, getArtifactCollector());
 				exporter.getProperties().put(METADATA_DESCRIPTOR, getMetadataDescriptor());
-				exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, getOutputDirectory());
-				exporter.setTemplatePath( getTemplatePath() );
-
+				exporter.getProperties().put(OUTPUT_FOLDER, getOutputDirectory());
+				String[] tp = getTemplatePath();
+				if (tp != null) {
+					exporter.setTemplatePath(tp);
+				}
+ 
 				exporter.setTemplateName( "dot/entitygraph.dot.ftl" );
 				exporter.setFilePattern( "entities/entitygraph.dot" );
 				exporter.start();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>