### PR TITLE
HBX-1714: Make the build run on Java 9 and Java 10 - Use version 2.3.0 for jaxb-impl and jaxb-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,13 +166,13 @@
 		<dependency>
 		    <groupId>com.sun.xml.bind</groupId>
 		    <artifactId>jaxb-impl</artifactId>
-		    <version>2.2.11</version>
+		    <version>2.3.0</version>
 		</dependency>
 		
 		<dependency>
 		    <groupId>com.sun.xml.bind</groupId>
 		    <artifactId>jaxb-core</artifactId>
-		    <version>2.2.11</version>
+		    <version>2.3.0</version>
 		</dependency>
 	
 	</dependencies>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>