### PR TITLE
HBX-1749: Use @project.version@ instead of hardcoded version in the tests for hibernate-tools-maven

### DIFF
--- a/test/maven-plugin/src/it/hbm2ddl/pom.xml
+++ b/test/maven-plugin/src/it/hbm2ddl/pom.xml
@@ -14,7 +14,6 @@
 
         <java.version>1.8</java.version>
         <h2.version>1.4.195</h2.version>
-        <hibernate-tools-maven-plugin.version>6.0.0-SNAPSHOT</hibernate-tools-maven-plugin.version>
     </properties>
 
     <build>
@@ -22,7 +21,7 @@
             <plugin>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-tools-maven-plugin</artifactId>
-                <version>${hibernate-tools-maven-plugin.version}</version>
+                <version>@project.version@</version>
                 <executions>
                     <execution>
                         <id>Schema generation</id>

--- a/test/maven-plugin/src/it/hbm2java/pom.xml
+++ b/test/maven-plugin/src/it/hbm2java/pom.xml
@@ -14,7 +14,6 @@
 
         <java.version>1.8</java.version>
         <h2.version>1.4.195</h2.version>
-        <hibernate-tools-maven-plugin.version>6.0.0-SNAPSHOT</hibernate-tools-maven-plugin.version>
     </properties>
 
     <build>
@@ -22,7 +21,7 @@
             <plugin>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-tools-maven-plugin</artifactId>
-                <version>${hibernate-tools-maven-plugin.version}</version>
+                <version>@project.version@</version>
                 <executions>
                     <execution>
                         <id>Entity generation</id>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>