### PR TITLE
HBX-1745: Remove methods Exporter#getTemplatePath() and Exporter#setTemplatePath(String[]) from interface org.hibernate.tool.api.export.Exporter - Inline and remove method Exporter#getTemplatePath()

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
@@ -18,7 +18,6 @@ public interface Exporter {
 	 */
 	public void setTemplatePath(String[] templatePath);
 	
-	public String[] getTemplatePath();
 		
 	public Properties getProperties();
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
@@ -70,10 +70,6 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 		getProperties().put(TEMPLATE_PATH, templatePaths);
 	}
 
-	public String[] getTemplatePath() {
-		return (String[])getProperties().get(TEMPLATE_PATH);
-	}
-	
 	public ArtifactCollector getArtifactCollector() {
 		return (ArtifactCollector)getProperties().get(ARTIFACT_COLLECTOR);
 	}
@@ -118,8 +114,9 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 		if(getOutputDirectory()!=null) {
 			getTemplateHelper().removeFromContext("outputdir", getOutputDirectory());
 		}
-		if(getTemplatePath()!=null) {
-			getTemplateHelper().removeFromContext("template_path", getTemplatePath());			
+		String[] templatePath = (String[])getProperties().get(TEMPLATE_PATH);
+		if(templatePath!=null) {
+			getTemplateHelper().removeFromContext("template_path", templatePath);			
 		}
 		getTemplateHelper().removeFromContext("exporter", this);
 		getTemplateHelper().removeFromContext("artifacts", getArtifactCollector());
@@ -140,8 +137,9 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 		if(getOutputDirectory()!=null) {
 			getTemplateHelper().putInContext("outputdir", getOutputDirectory());
 		}
-		if(getTemplatePath()!=null) {
-			getTemplateHelper().putInContext("template_path", getTemplatePath());		
+		String[] templatePath = (String[])getProperties().get(TEMPLATE_PATH);
+		if(templatePath!=null) {
+			getTemplateHelper().putInContext("template_path", templatePath);		
 		}
 		if(getProperties()!=null) {
 			iterator = getProperties().entrySet().iterator();
@@ -174,10 +172,11 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 	}
 
 	protected void setupTemplates() {
+		String[] templatePath = (String[])getProperties().get(TEMPLATE_PATH);
 		if(log.isDebugEnabled()) {
-			log.debug(getClass().getName() + " outputdir:" + getOutputDirectory() + " path: " + toString(getTemplatePath()) );
+			log.debug(getClass().getName() + " outputdir:" + getOutputDirectory() + " path: " + toString(templatePath) );
 		}
-		getTemplateHelper().init(getOutputDirectory(), getTemplatePath());		
+		getTemplateHelper().init(getOutputDirectory(), templatePath);		
 	}
 	
 	protected void setTemplateHelper(TemplateHelper vh) {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -163,7 +163,7 @@ public class DocExporter extends AbstractExporter {
 				exporter.getProperties().put(ARTIFACT_COLLECTOR, getArtifactCollector());
 				exporter.getProperties().put(METADATA_DESCRIPTOR, getMetadataDescriptor());
 				exporter.getProperties().put(OUTPUT_FOLDER, getOutputDirectory());
-				String[] tp = getTemplatePath();
+				String[] tp = (String[])exporter.getProperties().get(TEMPLATE_PATH);
 				if (tp != null) {
 					exporter.setTemplatePath(tp);
 				}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>