### PR TITLE
HBX-1745: Remove methods Exporter#getTemplatePath() and Exporter#setTemplatePath(String[]) from interface org.hibernate.tool.api.export.Exporter - Inline and remove method Exporter#setTemplatePath(String[])

### DIFF
--- a/maven/src/main/java/org/hibernate/mvn/Hbm2JavaMojo.java
+++ b/maven/src/main/java/org/hibernate/mvn/Hbm2JavaMojo.java
@@ -35,7 +35,7 @@ public class Hbm2JavaMojo extends AbstractHbm2xMojo {
         pojoExporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDirectory);
         if (templatePath != null) {
             getLog().info("Setting template path to: " + templatePath);
-            pojoExporter.setTemplatePath(new String[]{templatePath});
+            pojoExporter.getProperties().put(ExporterConstants.TEMPLATE_PATH, new String[] {templatePath});
         }
         pojoExporter.getProperties().setProperty("ejb3", String.valueOf(ejb3));
         pojoExporter.getProperties().setProperty("jdk5", String.valueOf(jdk5));

--- a/orm/src/main/java/org/hibernate/tool/ant/ExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/ExporterTask.java
@@ -95,7 +95,7 @@ public abstract class ExporterTask {
 		exporter.getProperties().putAll(prop);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getMetadataDescriptor());
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, getDestdir());
-		exporter.setTemplatePath( getTemplatePath().list() );			
+		exporter.getProperties().put(ExporterConstants.TEMPLATE_PATH, getTemplatePath().list());
 		return exporter;
 	}
 }

--- a/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/Exporter.java
@@ -3,7 +3,6 @@
  */
 package org.hibernate.tool.api.export;
 
-import java.io.File;
 import java.util.Properties;
 
 /**
@@ -13,12 +12,6 @@ import java.util.Properties;
 public interface Exporter {
 	
 
-	/**
-	 * @param templatePath array of directories used sequentially to lookup templates
-	 */
-	public void setTemplatePath(String[] templatePath);
-	
-		
 	public Properties getProperties();
 	
 	/**

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/AbstractExporter.java
@@ -66,10 +66,6 @@ public abstract class AbstractExporter implements Exporter, ExporterConstants {
 		return properties;
 	}
 	
-	public void setTemplatePath(String[] templatePaths) {
-		getProperties().put(TEMPLATE_PATH, templatePaths);
-	}
-
 	public ArtifactCollector getArtifactCollector() {
 		return (ArtifactCollector)getProperties().get(ARTIFACT_COLLECTOR);
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocExporter.java
@@ -165,7 +165,7 @@ public class DocExporter extends AbstractExporter {
 				exporter.getProperties().put(OUTPUT_FOLDER, getOutputDirectory());
 				String[] tp = (String[])exporter.getProperties().get(TEMPLATE_PATH);
 				if (tp != null) {
-					exporter.setTemplatePath(tp);
+					exporter.getProperties().put(TEMPLATE_PATH, tp);
 				}
  
 				exporter.setTemplateName( "dot/entitygraph.dot.ftl" );

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3/TestCase.java
@@ -47,7 +47,7 @@ public class TestCase {
 				ExporterConstants.METADATA_DESCRIPTOR, 
 				MetadataDescriptorFactory.createJdbcDescriptor(null, null, true));
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
-		exporter.setTemplatePath(new String[0]);
+		exporter.getProperties().put(ExporterConstants.TEMPLATE_PATH, new String[0]);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.getProperties().setProperty("jdk5", "true");
 		exporter.start();

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
@@ -146,7 +146,7 @@ public class TestCase {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
-		exporter.setTemplatePath(new String[0]);
+		exporter.getProperties().put(ExporterConstants.TEMPLATE_PATH, new String[0]);
 		exporter.getProperties().setProperty("ejb3", "false");
 		exporter.getProperties().setProperty("jdk5", "false");
 		exporter.start();			
@@ -182,7 +182,7 @@ public class TestCase {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
-		exporter.setTemplatePath(new String[0]);
+		exporter.getProperties().put(ExporterConstants.TEMPLATE_PATH, new String[0]);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.getProperties().setProperty("jdk5", "true");
 		exporter.start();		

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaEjb3Test/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaEjb3Test/TestCase.java
@@ -68,7 +68,7 @@ public class TestCase {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
-		exporter.setTemplatePath(new String[0]);
+		exporter.getProperties().put(ExporterConstants.TEMPLATE_PATH, new String[0]);
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.getProperties().setProperty("jdk5", "true");
 		exporter.start();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>