### PR TITLE
HBX-1750: Remove unneeded '<version>${project.version}</version>' specification in hibernate-tools-orm dependency in maven/pom.xml

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -70,7 +70,6 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-tools</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <!-- Maven Plugins -->
     <dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>