### PR TITLE
Replace deprecated 'new Boolean(String)' occurrences with 'Boolean.parseBoolean(String)'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/OverrideBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/OverrideBinder.java
@@ -312,11 +312,11 @@ public class OverrideBinder {
 		}					
 		if(manyToOne.hasAttribute("insert")) {
 			associationInfo = ensureInit(associationInfo);
-			associationInfo.setInsert(new Boolean(manyToOne.getAttribute("insert")));
+			associationInfo.setInsert(Boolean.parseBoolean(manyToOne.getAttribute("insert")));
 		}					
 		if(manyToOne.hasAttribute("update")) {
 			associationInfo = ensureInit(associationInfo);
-			associationInfo.setUpdate(new Boolean(manyToOne.getAttribute("update")));
+			associationInfo.setUpdate(Boolean.parseBoolean(manyToOne.getAttribute("update")));
 		}
 		return associationInfo;
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>