### PR TITLE
HBX-1764: Remove unused import in 'org.hibernate.tool.ant.Hbm2JavaExporterTask'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
@@ -7,7 +7,6 @@ package org.hibernate.tool.ant;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
-import org.hibernate.tool.internal.export.pojo.POJOExporter;
 
 /**
  * @author max


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>