### PR TITLE
Remove unsupported '@SuppressWarnings("el-syntax")' from class 'org.hibernate.tool.hbm2x.Hbm2CfgTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
@@ -112,7 +112,6 @@ public class TestCase {
 		Assert.assertEquals(1, cfgexporter.getArtifactCollector().getFileCount("cfg.xml"));
 	}
 	
-	@SuppressWarnings("el-syntax")
 	@Test
 	public void testNoVelocityLeftOvers() {
         Assert.assertNull(FileUtil.findFirstString("${",new File(outputDir, "hibernate.cfg.xml")));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>