### PR TITLE
Replace deprecated 'new Short(int)' occurrences with 'Short.valueOf(short)'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/JDBCMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/JDBCMetaDataDialect.java
@@ -70,7 +70,7 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 					element.put("INDEX_NAME", rs.getString("INDEX_NAME"));
 					element.put("COLUMN_NAME", rs.getString("COLUMN_NAME"));
 					element.put("NON_UNIQUE", Boolean.valueOf(rs.getBoolean("NON_UNIQUE")));
-					element.put("TYPE", new Short(rs.getShort("TYPE")));					 
+					element.put("TYPE", Short.valueOf(rs.getShort("TYPE")));					 
 					return element;					
 				}
 				protected Throwable handleSQLException(SQLException e) {
@@ -138,7 +138,7 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 					element.clear();
 					putTablePart(element, rs);
 					element.put("COLUMN_NAME", rs.getString("COLUMN_NAME"));
-					element.put("KEY_SEQ", new Short(rs.getShort("KEY_SEQ")));
+					element.put("KEY_SEQ", Short.valueOf(rs.getShort("KEY_SEQ")));
 					element.put("PK_NAME", rs.getString("PK_NAME"));
 					return element;					
 				}
@@ -187,7 +187,7 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 		element.put( "FKCOLUMN_NAME", rs.getString("FKCOLUMN_NAME"));
 		element.put( "PKCOLUMN_NAME", rs.getString("PKCOLUMN_NAME"));
 		element.put( "FK_NAME", rs.getString("FK_NAME"));
-		element.put( "KEY_SEQ", new Short(rs.getShort("KEY_SEQ")));
+		element.put( "KEY_SEQ", Short.valueOf(rs.getShort("KEY_SEQ")));
 	}
 	
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/OracleMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/OracleMetaDataDialect.java
@@ -286,7 +286,7 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 				protected Map<String, Object> convertRow(ResultSet rs) throws SQLException {
 					element.clear();
 					element.put("COLUMN_NAME", rs.getString(1));
-					element.put("TYPE", new Short((short) 1)); // CLUSTERED
+					element.put("TYPE", Short.valueOf((short) 1)); // CLUSTERED
 																// INDEX
 					element.put("NON_UNIQUE", Boolean.valueOf(rs.getString(2)));
 					element.put("TABLE_SCHEM", rs.getString(3));
@@ -379,7 +379,7 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 					element.clear();
 					element.put("TABLE_NAME", rs.getString(1));
 					element.put("COLUMN_NAME", rs.getString(2));
-					element.put("KEY_SEQ", new Short(rs.getShort(3)));
+					element.put("KEY_SEQ", Short.valueOf(rs.getShort(3)));
 					element.put("PK_NAME", rs.getString(4));
 					element.put("TABLE_SCHEM", rs.getString(5));
 					element.put("TABLE_CAT", null);
@@ -429,7 +429,7 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 					element.put("FKCOLUMN_NAME", rs.getString(5));
 					element.put("PKCOLUMN_NAME", rs.getString(6));
 					element.put("FK_NAME", rs.getString(7));
-					element.put("KEY_SEQ", new Short(rs.getShort(8)));
+					element.put("KEY_SEQ", Short.valueOf(rs.getShort(8)));
 					return element;
 				}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/PrimaryKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/PrimaryKeyProcessor.java
@@ -63,7 +63,7 @@ public class PrimaryKeyProcessor {
 					}	      		
 				}
 				
-				columns.add(new Object[] { new Short(seq), columnName});
+				columns.add(new Object[] { Short.valueOf(seq), columnName});
 			}
 		} finally {
 			if (primaryKeyIterator!=null) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>