### PR TITLE
HBX-1785: Use 'jaxb-runtime' instead of 'jaxb-core' and 'jaxb-impl'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,19 +25,20 @@
     </modules>
 
     <properties>
-	<ant.version>1.10.5</ant.version>
-	<commons-collections.version>3.2.2</commons-collections.version>
-	<commons-logging.version>1.2</commons-logging.version>
-	<eclipse-jdt-core.version>3.15.0</eclipse-jdt-core.version>
- 	<freemarker.version>2.3.28</freemarker.version>
+	    <ant.version>1.10.5</ant.version>
+	    <commons-collections.version>3.2.2</commons-collections.version>
+	    <commons-logging.version>1.2</commons-logging.version>
+	    <eclipse-jdt-core.version>3.15.0</eclipse-jdt-core.version>
+ 	    <freemarker.version>2.3.28</freemarker.version>
         <h2.version>1.4.197</h2.version>
-	<hibernate-commons-annotations.version>5.1.0.Final</hibernate-commons-annotations.version>
+	    <hibernate-commons-annotations.version>5.1.0.Final</hibernate-commons-annotations.version>
         <hibernate-core.version>5.3.7.Final</hibernate-core.version>
-	<javax.activation-api.version>1.2.0</javax.activation-api.version>
-	<javax.persistence-api.version>2.2</javax.persistence-api.version>
+	    <javax.activation-api.version>1.2.0</javax.activation-api.version>
+	    <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <hsqldb.version>2.3.3</hsqldb.version>
         <javaee-api.version>7.0</javaee-api.version>
-        <jaxb.version>2.3.0</jaxb.version>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
         <jaxen.version>1.1.6</jaxen.version>
         <junit.version>4.12</junit.version>
         <mysql.version>6.0.6</mysql.version>
@@ -153,19 +154,13 @@
 		    <dependency>
 			    <groupId>javax.xml.bind</groupId>
 			    <artifactId>jaxb-api</artifactId>
-			    <version>${jaxb.version}</version>
+			    <version>${jaxb-api.version}</version>
 			    <scope>runtime</scope>
 		    </dependency>
 		    <dependency>
-			    <groupId>com.sun.xml.bind</groupId>
-			    <artifactId>jaxb-impl</artifactId>
-			    <version>${jaxb.version}</version>
-			    <scope>runtime</scope>
-		    </dependency>
-		    <dependency>
-			    <groupId>com.sun.xml.bind</groupId>
-			    <artifactId>jaxb-core</artifactId>
-			    <version>${jaxb.version}</version>
+		        <groupId>org.glassfish.jaxb</groupId>
+		        <artifactId>jaxb-runtime</artifactId>
+			    <version>${jaxb-runtime.version}</version>
 			    <scope>runtime</scope>
 		    </dependency>
             <dependency>

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -39,12 +39,8 @@
         	<artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
-        	<groupId>com.sun.xml.bind</groupId>
-        	<artifactId>jaxb-impl</artifactId>
-        </dependency>
-        <dependency>
-        	<groupId>com.sun.xml.bind</groupId>
-        	<artifactId>jaxb-core</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
 		<dependency>
     		<groupId>javax.activation</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>