### PR TITLE
HBX-1785: Use 'jaxb-runtime' instead of 'jaxb-core' and 'jaxb-impl'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,15 +168,9 @@
 	</dependency>
 	
 		<dependency>
-		    <groupId>com.sun.xml.bind</groupId>
-		    <artifactId>jaxb-impl</artifactId>
-		    <version>2.3.0</version>
-		</dependency>
-		
-		<dependency>
-		    <groupId>com.sun.xml.bind</groupId>
-		    <artifactId>jaxb-core</artifactId>
-		    <version>2.3.0</version>
+		    <groupId>org.glassfish.jaxb</groupId>
+		    <artifactId>jaxb-runtime</artifactId>
+		    <version>2.3.2</version>
 		</dependency>
 	
 	</dependencies>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>