### PR TITLE
HBX-1792: Remove unneeded dependency on org.eclipse.core.runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,12 +158,6 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.core</groupId>
-			<artifactId>runtime</artifactId>
-			<version>3.10.0-v20140318-2214</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
 			<version>1.1.6</version>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>