### PR TITLE
HBX-1793: Update org.eclipse.jdt.core dependency version to 3.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,15 +28,15 @@
 	    <ant.version>1.10.5</ant.version>
 	    <commons-collections.version>3.2.2</commons-collections.version>
 	    <commons-logging.version>1.2</commons-logging.version>
-	    <eclipse-jdt-core.version>3.15.0</eclipse-jdt-core.version>
+	    <eclipse-jdt-core.version>3.16.0</eclipse-jdt-core.version>
  	    <freemarker.version>2.3.28</freemarker.version>
         <h2.version>1.4.197</h2.version>
 	    <hibernate-commons-annotations.version>5.1.0.Final</hibernate-commons-annotations.version>
         <hibernate-core.version>5.3.7.Final</hibernate-core.version>
-	    <javax.activation-api.version>1.2.0</javax.activation-api.version>
-	    <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <hsqldb.version>2.3.3</hsqldb.version>
         <javaee-api.version>7.0</javaee-api.version>
+	    <javax.activation-api.version>1.2.0</javax.activation-api.version>
+	    <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
         <jaxen.version>1.1.6</jaxen.version>
@@ -83,6 +83,17 @@
    			    <version>${javaee-api.version}</version>
    			    <scope>test</scope>
    		    </dependency>
+			<dependency>
+			    <groupId>javax.persistence</groupId>
+			    <artifactId>javax.persistence-api</artifactId>
+			    <version>${javax.persistence-api.version}</version>
+		    </dependency>
+		    <dependency>
+			    <groupId>javax.xml.bind</groupId>
+			    <artifactId>jaxb-api</artifactId>
+			    <version>${jaxb-api.version}</version>
+			    <scope>runtime</scope>
+		    </dependency>
   	        <dependency>
                 <groupId>jaxen</groupId>
                 <artifactId>jaxen</artifactId>
@@ -115,47 +126,36 @@
 			    <artifactId>freemarker</artifactId>
 			    <version>${freemarker.version}</version>
 		    </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-core</artifactId>
-                <version>${hibernate-core.version}</version>
-            </dependency>
-        	    <dependency>
-        		    <groupId>org.hibernate</groupId>
-        		    <artifactId>hibernate-tools</artifactId>
-        		    <version>${project.version}</version>
-        	    </dependency>
-        		<dependency>
-        		    <groupId>org.hibernate</groupId>
-        		    <artifactId>hibernate-tools-tests-common</artifactId>
-        		    <version>${project.version}</version>
-            	</dependency>
-            	<dependency>
-        	        <groupId>org.hibernate</groupId>
-        		    <artifactId>hibernate-tools-tests-utils</artifactId>
-        		    <version>${project.version}</version>
-        	    </dependency>
- 		    <dependency>
-			    <groupId>org.hibernate.common</groupId>
-			    <artifactId>hibernate-commons-annotations</artifactId>
-			    <version>${hibernate-commons-annotations.version}</version>
-		    </dependency>
-			<dependency>
-			    <groupId>javax.persistence</groupId>
-			    <artifactId>javax.persistence-api</artifactId>
-			    <version>${javax.persistence-api.version}</version>
-		    </dependency>
-		    <dependency>
-			    <groupId>javax.xml.bind</groupId>
-			    <artifactId>jaxb-api</artifactId>
-			    <version>${jaxb-api.version}</version>
-			    <scope>runtime</scope>
-		    </dependency>
 		    <dependency>
 		        <groupId>org.glassfish.jaxb</groupId>
 		        <artifactId>jaxb-runtime</artifactId>
 			    <version>${jaxb-runtime.version}</version>
 			    <scope>runtime</scope>
+		    </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${hibernate-core.version}</version>
+            </dependency>
+        	<dependency>
+                <groupId>org.hibernate</groupId>
+        		<artifactId>hibernate-tools</artifactId>
+        		<version>${project.version}</version>
+        	</dependency>
+        	<dependency>
+        	    <groupId>org.hibernate</groupId>
+        	    <artifactId>hibernate-tools-tests-common</artifactId>	
+        	    <version>${project.version}</version>
+            </dependency>
+            <dependency>
+        	    <groupId>org.hibernate</groupId>
+        	    <artifactId>hibernate-tools-tests-utils</artifactId>
+        	    <version>${project.version}</version>
+        	    </dependency>
+ 		    <dependency>
+			    <groupId>org.hibernate.common</groupId>
+			    <artifactId>hibernate-commons-annotations</artifactId>
+			    <version>${hibernate-commons-annotations.version}</version>
 		    </dependency>
             <dependency>
                 <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>