### PR TITLE
HBX-1793: Update org.eclipse.jdt.core dependency version to 3.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,28 +76,27 @@
 	<!-- TODO: is it possible to automate this with maven? -->
 
 	<dependencies>
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-core</artifactId>
-			<version>${hibernateversion}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate.common</groupId>
-			<artifactId>hibernate-commons-annotations</artifactId>
-			<version>${hibernateCommonsAnnotationsVersion}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate.javax.persistence</groupId>
-			<artifactId>hibernate-jpa-2.1-api</artifactId>
-			<version>${hibernateJpaversion}</version>
-			<scope>compile</scope>
-		</dependency>
+	    <dependency>
+		    <groupId>commons-collections</groupId>
+		    <artifactId>commons-collections</artifactId>
+		    <version>3.2.2</version>
+	    </dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 			<version>1.2</version>
+		</dependency>
+		<dependency>
+   			<groupId>javax</groupId>
+   			<artifactId>javaee-api</artifactId>
+   			<version>7.0</version>
+   			<scope>test</scope>
+   		</dependency>
+		<dependency>
+			<groupId>jaxen</groupId>
+			<artifactId>jaxen</artifactId>
+			<version>1.1.6</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -116,69 +115,63 @@
 			<version>1.10.5</version>
 			<scope>test</scope>
 		</dependency>
- 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.25</version>
-			<scope>test</scope>
-		</dependency> 
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.core</artifactId>
+            <version>3.16.0</version>
+            <scope>compile</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
 			<version>2.3.28</version>
 		</dependency>
-        <dependency>
-            <groupId>org.eclipse.jdt</groupId>
-            <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.15.0</version>
-            <scope>compile</scope>
-        </dependency>
-		<dependency>
-			<groupId>jaxen</groupId>
-			<artifactId>jaxen</artifactId>
-			<version>1.1.6</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-   			<groupId>javax</groupId>
-   			<artifactId>javaee-api</artifactId>
-   			<version>7.0</version>
-   			<scope>test</scope>
-   		</dependency>
-		<dependency>
-   			<groupId>javax</groupId>
-   			<artifactId>javaee-api</artifactId>
-   			<version>7.0</version>
-   			<scope>test</scope>
-   		</dependency>
    		<dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.2</version>
         </dependency>
-
-	    <dependency>
-		    <groupId>${jdbc.driver.groupId}</groupId>
-		    <artifactId>${jdbc.driver.artifactId}</artifactId>
-		    <version>${jdbc.driver.jdbc.driver.version}</version>
-		    <scope>test</scope>
-	    </dependency>
-	    <dependency>
-		    <groupId>commons-collections</groupId>
-		    <artifactId>commons-collections</artifactId>
-		    <version>3.2.2</version>
-	    </dependency>
-	    <dependency>
-		    <groupId>org.slf4j</groupId>
-		    <artifactId>slf4j-api</artifactId>
-		    <version>1.7.23</version>
-	    </dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>${hibernateversion}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.common</groupId>
+			<artifactId>hibernate-commons-annotations</artifactId>
+			<version>${hibernateCommonsAnnotationsVersion}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.javax.persistence</groupId>
+			<artifactId>hibernate-jpa-2.1-api</artifactId>
+			<version>${hibernateJpaversion}</version>
+			<scope>compile</scope>
+		</dependency>
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>3.24.1-GA</version>
             <scope>test</scope>
         </dependency>	
+	    <dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-api</artifactId>
+		    <version>1.7.23</version>
+	    </dependency>
+ 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>1.7.25</version>
+			<scope>test</scope>
+		</dependency> 
+	    <dependency>
+		    <groupId>${jdbc.driver.groupId}</groupId>
+		    <artifactId>${jdbc.driver.artifactId}</artifactId>
+		    <version>${jdbc.driver.jdbc.driver.version}</version>
+		    <scope>test</scope>
+	    </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>