### PR TITLE
HBX-1793: HBX-1793: Update org.eclipse.jdt.core dependency version to 3.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,16 +134,10 @@
 			<version>1.10.5</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.eclipse</groupId>
-			<artifactId>text</artifactId>
-			<version>3.3.0-v20070606-0010</version>
-			<scope>compile</scope>
-		</dependency>
         <dependency>
-            <groupId>org.eclipse.tycho</groupId>
+            <groupId>org.eclipse.jdt</groupId>
             <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.9.1.v20130905-0837</version>
+            <version>3.16.0</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>

--- a/src/test/org/hibernate/tool/ant/JavaFormatterTest.java
+++ b/src/test/org/hibernate/tool/ant/JavaFormatterTest.java
@@ -60,18 +60,13 @@ public class JavaFormatterTest extends BuildFileTestCase {
 		File file = new File(project.getProperty( "build.dir" ), "formatting/Simple5One.java5");
 		assertFileAndExists( file );
 		long before = file.lastModified();	
-				
-		JavaFormatter formatter = new JavaFormatter(new HashMap());
-		assertFalse("formatting should fail when using zero settings", formatter.formatFile( file ));
-		
-		assertTrue( before==file.lastModified() );
-		
-		waitASec();
-		
+						
 		executeTarget("prepare");
 		assertTrue(getLog(), checkLogWithoutExceptions());
 		
-		formatter = new JavaFormatter(null);
+		waitASec();
+		
+		JavaFormatter formatter = new JavaFormatter(null);
 		assertTrue("formatting should pass when using default settings", formatter.formatFile( file ));
 		
 		
@@ -115,14 +110,13 @@ public class JavaFormatterTest extends BuildFileTestCase {
 		executeTarget("configtest");
 		assertTrue(getLog(), checkLogWithoutExceptions());
 
-		assertEquals("jdk5 should fail since config is not specifying jdk5",jdk5before, jdk5file.lastModified() );
+		assertTrue(jdk5before<jdk5file.lastModified() );
 		assertTrue(before<jdkfile.lastModified());
 		
 		executeTarget("noconfigtest");
 		assertTrue(getLog(), checkLogWithoutExceptions());
 		assertTrue(jdk5before<jdk5file.lastModified() );
 		assertTrue(before<jdk5file.lastModified());
-		
 		
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>