### PR TITLE
HBX-1331: Rewrite org.hibernate.tool.hbm2x.XMLPrettyPrinter to eliminate use of JTidy

### DIFF
--- a/src/test/org/hibernate/tool/test/jdbc2cfg/CompositeIdTest.java
+++ b/src/test/org/hibernate/tool/test/jdbc2cfg/CompositeIdTest.java
@@ -234,7 +234,6 @@ public class CompositeIdTest extends JDBCMetaDataBinderTestCase {
 		for (int i = 0; i < files.length; i++) {
 			XMLPrettyPrinter.prettyPrintFile(files[i]);
 		}
-        
         TestHelper.compile(outputdir, outputdir);
         
         Configuration derived = new Configuration();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>