### PR TITLE
HBX-1408 - Bad default type mapping for SQL Type NUMERIC or DECIMAL with precision >= 19 and scale = 0

### DIFF
--- a/src/java/org/hibernate/cfg/reveng/JDBCToHibernateTypeHelper.java
+++ b/src/java/org/hibernate/cfg/reveng/JDBCToHibernateTypeHelper.java
@@ -79,7 +79,7 @@ public final class JDBCToHibernateTypeHelper {
 			   return returnNullable?Long.class.getName():"long";
 		   }
 		   else {
-			   return "big_decimal";
+			   return "big_integer";
 		   }
 	   }
 	   


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>