### PR TITLE
HBX-1812: Update Eclipse-jdt-core dependency to version 3.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.16.0</version>
+            <version>3.17.0</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>