### PR TITLE
HBX-1832: Update eclipse-jdt-core dependency to version 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	    <ant.version>1.10.6</ant.version>
 	    <commons-collections.version>3.2.2</commons-collections.version>
 	    <commons-logging.version>1.2</commons-logging.version>
-	    <eclipse-jdt-core.version>3.17.0</eclipse-jdt-core.version>
+	    <eclipse-jdt-core.version>3.18.0</eclipse-jdt-core.version>
  	    <freemarker.version>2.3.28</freemarker.version>
         <h2.version>1.4.199</h2.version>
 	    <hibernate-commons-annotations.version>5.1.0.Final</hibernate-commons-annotations.version>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>