### PR TITLE
HBX-1829: Update javassist dependency to version 3.25.0-GA - Remove the dependency for 3.6.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,12 +92,6 @@
 			<version>2.3.8</version>
 			<scope>compile</scope>
 		</dependency>
-        <dependency>
-		    <groupId>org.javassist</groupId>
-		    <artifactId>javassist</artifactId>
-		    <version>3.25.0-GA</version>
-		    <scope>compile</scope>
-		</dependency>
 		<dependency>
 			<groupId>javax.transaction</groupId>
 			<artifactId>jta</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>