### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Rename HibernateToolTest into HibernateToolTaskTest

### DIFF
--- a/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
@@ -11,23 +11,22 @@ import org.hibernate.tool.ant.test.util.ProjectUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class HibernateToolTest {
-	
-	private static final String BUILD_XML = 
-			"<project name='HibernateToolTest'>                           " +
-	        "  <taskdef                                                   " +
-			"      name='hibernatetool'                                   " +
-	        "      classname='org.hibernate.tool.ant.HibernateToolTask' />" +
-			"  <hibernatetool/>                                           " +
-	        "</project>                                                   " ;
+public class HibernateToolTaskTest {	
 	
 	@TempDir
 	Path tempDir;
 	
 	@Test
-	public void testHibernateTool() throws Exception {
+	public void testHibernateToolTask() throws Exception {
+		String buildXmlString = 
+				"<project name='HibernateToolTest'>                           " +
+		        "  <taskdef                                                   " +
+				"      name='hibernatetool'                                   " +
+		        "      classname='org.hibernate.tool.ant.HibernateToolTask' />" +
+				"  <hibernatetool/>                                           " +
+		        "</project>                                                   " ;
 		File buildXml = new File(tempDir.toFile(), "build.xml");
-		Files.write(buildXml.toPath(), BUILD_XML.getBytes());
+		Files.write(buildXml.toPath(), buildXmlString.getBytes());
 		Project project = ProjectUtil.createProject(buildXml);
 		assertNotNull(project);
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>