### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Implement HibernateToolTask.createMetadata()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -2,10 +2,12 @@ package org.hibernate.tool.ant;
 
 public class HibernateToolTask {
 	
-	boolean hasConfiguration = false;
-	
 	public ConfigurationTask createConfiguration() {
 		return new ConfigurationTask();
+	}
+	
+	public MetadataTask createMetadata() {
+		return new MetadataTask();
 	}
 	
 	public void execute() {

--- a/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.ant;
+
+public class MetadataTask {
+	
+}

--- a/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
@@ -1,6 +1,7 @@
 package org.hibernate.tool.ant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -67,6 +68,13 @@ public class HibernateToolTaskTest {
 		assertEquals(1, children.size());
 		UnknownElement configurationTask = children.get(0);
 		assertEquals("configuration", configurationTask.getTag());
+	}
+	
+	@Test
+	public void testCreateMetadata() {
+		HibernateToolTask htt = new HibernateToolTask();
+		MetadataTask mdt = htt.createMetadata();
+		assertNotNull(mdt);
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>