### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Remove HibernateToolTask.createConfiguration()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ConfigurationTask.java
@@ -1,5 +1,0 @@
-package org.hibernate.tool.ant;
-
-public class ConfigurationTask {
-
-}

--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -2,10 +2,6 @@ package org.hibernate.tool.ant;
 
 public class HibernateToolTask {
 	
-	public ConfigurationTask createConfiguration() {
-		return new ConfigurationTask();
-	}
-	
 	public MetadataTask createMetadata() {
 		return new MetadataTask();
 	}

--- a/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
@@ -7,12 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Target;
 import org.apache.tools.ant.Task;
-import org.apache.tools.ant.UnknownElement;
 import org.hibernate.tool.ant.test.util.ProjectUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -45,31 +43,6 @@ public class HibernateToolTaskTest {
 		assertEquals("hibernatetool", hibernateToolTask.getTaskName());
 	}
 
-	@Test
-	public void testCreateConfiguration() throws Exception {
-		String buildXmlString = 
-				"<project name='HibernateToolTaskTest'>                       " +
-				"  <taskdef                                                   " +
-                "      name='hibernatetool'                                   " +
-				"      classname='org.hibernate.tool.ant.HibernateToolTask' />" +
-		        "  <target name='testCreateConfiguration'>                    " +
-				"    <hibernatetool>                                          " +
-				"      <configuration/>                                       " +
-				"    </hibernatetool>                                         " +
-		        "  </target>                                                  " +
-		        "</project>                                                   " ;
-		File buildXml = new File(tempDir.toFile(), "build.xml");
-		Files.write(buildXml.toPath(), buildXmlString.getBytes());
-		Project project = ProjectUtil.createProject(buildXml);
-		project.executeTarget("testCreateConfiguration");
-		Target testHibernateToolTaskTarget = project.getTargets().get("testCreateConfiguration");
-		UnknownElement hibernateToolTask = (UnknownElement)testHibernateToolTaskTarget.getTasks()[0];
-		List<UnknownElement> children = hibernateToolTask.getChildren();
-		assertEquals(1, children.size());
-		UnknownElement configurationTask = children.get(0);
-		assertEquals("configuration", configurationTask.getTag());
-	}
-	
 	@Test
 	public void testCreateMetadata() {
 		HibernateToolTask htt = new HibernateToolTask();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>