### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Implement HibernateToolTask.createExportCfg()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.ant;
+
+public class ExportCfgTask {
+
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -6,6 +6,10 @@ public class HibernateToolTask {
 		return new MetadataTask();
 	}
 	
+	public ExportCfgTask createExportCfg() {
+		return new ExportCfgTask();
+	}
+	
 	public ExportDdlTask createExportDdl() {
 		return new ExportDdlTask();
 	}

--- a/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
@@ -57,4 +57,11 @@ public class HibernateToolTaskTest {
 		assertNotNull(edt);
 	}
 
+	@Test
+	public void testCreateExportCfg() {
+		HibernateToolTask htt = new HibernateToolTask();
+		ExportCfgTask ect = htt.createExportCfg();
+		assertNotNull(ect);
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>