### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Implement initial ExportCfgTask.execute()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -1,5 +1,11 @@
 package org.hibernate.tool.ant;
 
 public class ExportCfgTask {
+	
+	boolean executed = false;
+	
+	public void execute() {
+		executed = true;
+	}
 
 }

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportDdlTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportDdlTaskTest.java
@@ -1,0 +1,18 @@
+package org.hibernate.tool.ant;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportDdlTaskTest {
+	
+	@Test
+	public void testExecute() {
+		ExportCfgTask ect = new ExportCfgTask();
+		assertFalse(ect.executed);
+		ect.execute();
+		assertTrue(ect.executed);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>