### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Replace constructor ExportCfgTask() with ExportCfgTask(HibernateToolTask)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -3,6 +3,11 @@ package org.hibernate.tool.ant;
 public class ExportCfgTask {
 	
 	boolean executed = false;
+	HibernateToolTask parent = null;
+	
+	public ExportCfgTask(HibernateToolTask parent) {
+		this.parent = parent;
+	}
 	
 	public void execute() {
 		executed = true;

--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -7,7 +7,7 @@ public class HibernateToolTask {
 	}
 	
 	public ExportCfgTask createExportCfg() {
-		return new ExportCfgTask();
+		return new ExportCfgTask(this);
 	}
 	
 	public ExportDdlTask createExportDdl() {

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportDdlTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportDdlTaskTest.java
@@ -1,15 +1,22 @@
 package org.hibernate.tool.ant;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 public class ExportDdlTaskTest {
 	
+	@Test void testExportCfgTask() {
+		HibernateToolTask htt = new HibernateToolTask();
+		ExportCfgTask ect = new ExportCfgTask(htt);
+		assertSame(htt, ect.parent);
+	}
+	
 	@Test
 	public void testExecute() {
-		ExportCfgTask ect = new ExportCfgTask();
+		ExportCfgTask ect = new ExportCfgTask(null);
 		assertFalse(ect.executed);
 		ect.execute();
 		assertTrue(ect.executed);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>