### PR TITLE
 HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Rename ExportDdlTaskTest to ExportCfgTaskTest

### DIFF
--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class ExportDdlTaskTest {
+public class ExportCfgTaskTest {
 	
 	@Test void testExportCfgTask() {
 		HibernateToolTask htt = new HibernateToolTask();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>