### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add ExportCfgTask.setDestinationFolder(File) method

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -1,12 +1,19 @@
 package org.hibernate.tool.ant;
 
+import java.io.File;
+
 public class ExportCfgTask {
 	
 	boolean executed = false;
 	HibernateToolTask parent = null;
+	File destinationFolder = null;
 	
 	public ExportCfgTask(HibernateToolTask parent) {
 		this.parent = parent;
+	}
+	
+	public void setDestinationFolder(File destinationFolder) {
+		this.destinationFolder = destinationFolder;
 	}
 	
 	public void execute() {

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -1,8 +1,11 @@
 package org.hibernate.tool.ant;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,6 +23,15 @@ public class ExportCfgTaskTest {
 		assertFalse(ect.executed);
 		ect.execute();
 		assertTrue(ect.executed);
+	}
+	
+	@Test
+	public void testSetDestinationFolder() {
+		ExportCfgTask ect = new ExportCfgTask(null);
+		assertNull(ect.destinationFolder);
+		File file = new File("/");
+		ect.setDestinationFolder(file);
+		assertSame(file, ect.destinationFolder);
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>