### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add ExportCfgTask.getDestinationFolder() method

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -16,6 +16,10 @@ public class ExportCfgTask {
 		this.destinationFolder = destinationFolder;
 	}
 	
+	public File getDestinationFolder() {
+		return this.destinationFolder;
+	}
+	
 	public void execute() {
 		executed = true;
 	}

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -33,5 +33,14 @@ public class ExportCfgTaskTest {
 		ect.setDestinationFolder(file);
 		assertSame(file, ect.destinationFolder);
 	}
+	
+	@Test
+	public void testGetDestinationFolder() {
+		ExportCfgTask ect = new ExportCfgTask(null);
+		assertNull(ect.getDestinationFolder());
+		File file = new File("/");
+		ect.destinationFolder = file;
+		assertSame(file, ect.getDestinationFolder());
+	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>