### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add ExportCfgTask.addConfiguredProperty(Variable)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -1,12 +1,16 @@
 package org.hibernate.tool.ant;
 
 import java.io.File;
+import java.util.Properties;
+
+import org.apache.tools.ant.types.Environment.Variable;
 
 public class ExportCfgTask {
 	
 	boolean executed = false;
 	HibernateToolTask parent = null;
 	File destinationFolder = null;
+	Properties properties = new Properties();
 	
 	public ExportCfgTask(HibernateToolTask parent) {
 		this.parent = parent;
@@ -18,6 +22,10 @@ public class ExportCfgTask {
 	
 	public File getDestinationFolder() {
 		return this.destinationFolder;
+	}
+	
+	public void addConfiguredProperty(Variable variable) {
+		properties.put(variable.getKey(), variable.getValue());
 	}
 	
 	public void execute() {

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -1,5 +1,6 @@
 package org.hibernate.tool.ant;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -7,11 +8,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
+import org.apache.tools.ant.types.Environment.Variable;
 import org.junit.jupiter.api.Test;
 
 public class ExportCfgTaskTest {
 	
-	@Test void testExportCfgTask() {
+	@Test 
+	public void testExportCfgTask() {
 		HibernateToolTask htt = new HibernateToolTask();
 		ExportCfgTask ect = new ExportCfgTask(htt);
 		assertSame(htt, ect.parent);
@@ -42,5 +45,17 @@ public class ExportCfgTaskTest {
 		ect.destinationFolder = file;
 		assertSame(file, ect.getDestinationFolder());
 	}
+	
+	@Test
+	public void testAddConfiguredProperty() {
+		ExportCfgTask ect = new ExportCfgTask(null);
+		assertNull(ect.properties.get("foo"));
+		Variable v = new Variable();
+		v.setKey("foo");
+		v.setValue("bar");
+		ect.addConfiguredProperty(v);
+		assertEquals("bar", ect.properties.get("foo"));
+	}
+	
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>