### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add MetadataTask.setPropertyFile(File)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
@@ -1,5 +1,13 @@
 package org.hibernate.tool.ant;
 
+import java.io.File;
+
 public class MetadataTask {
+	
+	File propertyFile = null;
+	
+	public void setPropertyFile(File file) {
+		this.propertyFile = file;
+	}
 	
 }

--- a/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
@@ -1,0 +1,21 @@
+package org.hibernate.tool.ant;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class MetadataTaskTest {
+	
+	@Test
+	public void testSetPropertyFile() {
+		MetadataTask mdt = new MetadataTask();
+		assertNull(mdt.propertyFile);
+		File f = new File(".");
+		mdt.setPropertyFile(f);
+		assertSame(f, mdt.propertyFile);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>