### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add MetadataTask.addConfiguredFileSet(FileSet)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
@@ -1,11 +1,16 @@
 package org.hibernate.tool.ant;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.tools.ant.types.FileSet;
 
 public class MetadataTask {
 	
 	File propertyFile = null;
 	File configFile = null;
+	List<FileSet> fileSets = new ArrayList<FileSet>();	
 	
 	public void setPropertyFile(File file) {
 		this.propertyFile = file;
@@ -13,6 +18,10 @@ public class MetadataTask {
 	
 	public void setConfigFile(File file) {
 		this.configFile = file;
+	}
+	
+	public void addConfiguredFileSet(FileSet fileSet) {
+		fileSets.add(fileSet);
 	}
 	
 }

--- a/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
@@ -1,10 +1,13 @@
 package org.hibernate.tool.ant;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
+import org.apache.tools.ant.types.FileSet;
 import org.junit.jupiter.api.Test;
 
 public class MetadataTaskTest {
@@ -25,6 +28,16 @@ public class MetadataTaskTest {
 		File f = new File(".");
 		mdt.setConfigFile(f);
 		assertSame(f, mdt.configFile);
+	}
+	
+	@Test
+	public void testAddConfiguredFileSet() {
+		MetadataTask mdt = new MetadataTask();
+		assertTrue(mdt.fileSets.isEmpty());
+		FileSet fs = new FileSet();
+		mdt.addConfiguredFileSet(fs);
+		assertEquals(1, mdt.fileSets.size());
+		assertSame(fs, mdt.fileSets.get(0));
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>