### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add MetadataTask.createMetadataDescriptor()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
@@ -1,10 +1,19 @@
 package org.hibernate.tool.ant;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
 
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 
 public class MetadataTask {
 	
@@ -22,6 +31,56 @@ public class MetadataTask {
 	
 	public void addConfiguredFileSet(FileSet fileSet) {
 		fileSets.add(fileSet);
+	}
+	
+	public MetadataDescriptor createMetadataDescriptor() {
+		return MetadataDescriptorFactory.createNativeDescriptor(
+				this.configFile, 
+				getFiles(), 
+				getProperties());
+	}
+	
+	private File[] getFiles() {
+		List<File> result = new ArrayList<File>();
+		Iterator<FileSet> iterator = this.fileSets.iterator();
+		while (iterator.hasNext()) {
+			FileSet fileSet = iterator.next();
+			DirectoryScanner scanner = fileSet.getDirectoryScanner();
+			for (String fileName : scanner.getIncludedFiles()) {
+				File file = new File(fileName);
+				if (!file.isFile()) {
+					file = new File(scanner.getBasedir(), fileName);
+				}
+				result.add(file);
+			}
+		}
+		return (File[]) result.toArray(new File[result.size()]);
+	}
+	
+	private Properties getProperties() {
+		Properties result = new Properties();
+		if (this.propertyFile != null) { 
+			FileInputStream is = null;
+			try {
+				is = new FileInputStream(propertyFile);
+				result.load(is);
+			} 
+			catch (FileNotFoundException e) {
+				throw new BuildException(propertyFile + " not found.", e);					
+			} 
+			catch (IOException e) {
+				throw new BuildException("Problem while loading " + propertyFile, e);				
+			}
+			finally {
+				if (is != null) {
+					try {
+						is.close();
+					} 
+					catch (IOException e) { /** ignore **/ }
+				}
+			}
+		} 
+	    return result;
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>