### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add instance veriable 'HibernateToolTask.metadataTask'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -2,8 +2,11 @@ package org.hibernate.tool.ant;
 
 public class HibernateToolTask {
 	
+	MetadataTask metadataTask;
+	
 	public MetadataTask createMetadata() {
-		return new MetadataTask();
+		this.metadataTask = new MetadataTask();
+		return this.metadataTask;
 	}
 	
 	public ExportCfgTask createExportCfg() {

--- a/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
@@ -1,6 +1,8 @@
 package org.hibernate.tool.ant;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,8 +11,9 @@ public class HibernateToolTaskTest {
 	@Test
 	public void testCreateMetadata() {
 		HibernateToolTask htt = new HibernateToolTask();
+		assertNull(htt.metadataTask);
 		MetadataTask mdt = htt.createMetadata();
-		assertNotNull(mdt);
+		assertSame(mdt, htt.metadataTask);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>