### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add instance veriable 'HibernateToolTask.exportCfgTask'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.ant;
 public class HibernateToolTask {
 	
 	MetadataTask metadataTask;
+	ExportCfgTask exportCfgTask;
 	
 	public MetadataTask createMetadata() {
 		this.metadataTask = new MetadataTask();
@@ -10,7 +11,8 @@ public class HibernateToolTask {
 	}
 	
 	public ExportCfgTask createExportCfg() {
-		return new ExportCfgTask(this);
+		this.exportCfgTask = new ExportCfgTask(this);
+		return this.exportCfgTask;
 	}
 	
 	public ExportDdlTask createExportDdl() {

--- a/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
@@ -26,8 +26,9 @@ public class HibernateToolTaskTest {
 	@Test
 	public void testCreateExportCfg() {
 		HibernateToolTask htt = new HibernateToolTask();
+		assertNull(htt.exportCfgTask);
 		ExportCfgTask ect = htt.createExportCfg();
-		assertNotNull(ect);
+		assertSame(ect, htt.exportCfgTask);
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>