### PR TITLE
Rename 'org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter' to 'org.hibernate.tool.internal.export.cfg.CfgExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
@@ -5,7 +5,7 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter;
+import org.hibernate.tool.internal.export.cfg.CfgExporter;
 
 public class Hbm2CfgXmlExporterTask extends ExporterTask {
 
@@ -16,7 +16,7 @@ public class Hbm2CfgXmlExporterTask extends ExporterTask {
 	}
 
 	public Exporter createExporter() {
-		return new HibernateConfigurationExporter();
+		return new CfgExporter();
 	}
 
 	public void setEjb3(boolean ejb3) {
@@ -28,7 +28,7 @@ public class Hbm2CfgXmlExporterTask extends ExporterTask {
 	}
 	
 	protected Exporter configureExporter(Exporter exporter) {
-		HibernateConfigurationExporter hce = (HibernateConfigurationExporter)super.configureExporter( exporter );
+		CfgExporter hce = (CfgExporter)super.configureExporter( exporter );
         hce.getProperties().setProperty("ejb3", ""+ejb3);
 		return hce;
 	}

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -2,7 +2,7 @@ package org.hibernate.tool.api.export;
 
 public enum ExporterType {
 	
-	CFG ("org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter"),
+	CFG ("org.hibernate.tool.internal.export.cfg.CfgExporter"),
 	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
 	
 	private String className;

--- a/orm/src/main/java/org/hibernate/tool/internal/export/cfg/CfgExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/cfg/CfgExporter.java
@@ -26,7 +26,7 @@ import org.hibernate.tool.internal.export.common.AbstractExporter;
  * @author max
  *
  */
-public class HibernateConfigurationExporter extends AbstractExporter {
+public class CfgExporter extends AbstractExporter {
 
 	private Writer output;
     private Properties customProperties = new Properties();

--- a/orm/src/test/java/org/hibernate/tool/api/export/ExporterTypeTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/export/ExporterTypeTest.java
@@ -12,7 +12,7 @@ public class ExporterTypeTest {
 				"org.hibernate.tool.internal.export.pojo.POJOExporter",
 				ExporterType.POJO.className());
 		Assert.assertEquals(
-				"org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter", 
+				"org.hibernate.tool.internal.export.cfg.CfgExporter", 
 				ExporterType.CFG.className());
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -25,7 +25,7 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
-import org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter;
+import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.internal.export.doc.DocExporter;
 import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
@@ -99,7 +99,7 @@ public class TestCase {
 	
 	@Test
 	public void testGenerateCfgXml() throws DocumentException {	
-		Exporter exporter = new HibernateConfigurationExporter();
+		Exporter exporter = new CfgExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.start();				
@@ -124,8 +124,8 @@ public class TestCase {
 	
 	@Test
 	public void testGenerateAnnotationCfgXml() throws DocumentException {
-		HibernateConfigurationExporter exporter = 
-				new HibernateConfigurationExporter();
+		CfgExporter exporter = 
+				new CfgExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "true");

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
@@ -12,7 +12,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.cfg.HibernateConfigurationExporter;
+import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -38,7 +38,7 @@ public class TestCase {
 	private File outputDir = null;
 	private File resourcesDir = null;
 	
-	private HibernateConfigurationExporter cfgexporter;
+	private CfgExporter cfgexporter;
 
 	@Before
 	public void setUp() throws Exception {
@@ -48,7 +48,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		cfgexporter = new HibernateConfigurationExporter();
+		cfgexporter = new CfgExporter();
 		cfgexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		cfgexporter.getProperties().put(ExporterConstants.OUTPUT_FOLDER, outputDir);
 		cfgexporter.start();
@@ -56,7 +56,7 @@ public class TestCase {
 	
 	@Test
 	public void testMagicPropertyHandling() {
-	   HibernateConfigurationExporter exporter = new HibernateConfigurationExporter();
+	   CfgExporter exporter = new CfgExporter();
 	   Properties properties = exporter.getProperties();
 	   properties.setProperty( "hibernate.basic", "aValue" );
 	   properties.setProperty( Environment.SESSION_FACTORY_NAME, "shouldNotShowUp");
@@ -78,7 +78,7 @@ public class TestCase {
 			   FileUtil.findFirstString( Environment.HBM2DDL_AUTO, file ));
 	   Assert.assertNull(
 			   FileUtil.findFirstString("hibernate.temp.use_jdbc_metadata_defaults", file ));
-	   exporter = new HibernateConfigurationExporter();
+	   exporter = new CfgExporter();
 	   properties = exporter.getProperties();
 	   properties.setProperty( Environment.HBM2DDL_AUTO, "validator");   
 	   properties.setProperty("hibernate.dialect", HibernateUtil.Dialect.class.getName());
@@ -89,7 +89,7 @@ public class TestCase {
 	   exporter.start();
 	   Assert.assertNotNull(
 			   FileUtil.findFirstString( Environment.HBM2DDL_AUTO, file ));
-	   exporter = new HibernateConfigurationExporter();
+	   exporter = new CfgExporter();
 	   properties = exporter.getProperties();
 	   properties.setProperty( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "org.hibernate.console.FakeTransactionManagerLookup"); // Hack for seam-gen console configurations
 	   properties.setProperty("hibernate.dialect", HibernateUtil.Dialect.class.getName());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>