### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Store exporter destinationfolder in the properties map, remove ExportCfgTask.destinationFolder

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -4,12 +4,12 @@ import java.io.File;
 import java.util.Properties;
 
 import org.apache.tools.ant.types.Environment.Variable;
+import org.hibernate.tool.api.export.ExporterConstants;
 
 public class ExportCfgTask {
 	
 	boolean executed = false;
 	HibernateToolTask parent = null;
-	File destinationFolder = null;
 	Properties properties = new Properties();
 	
 	public ExportCfgTask(HibernateToolTask parent) {
@@ -17,11 +17,11 @@ public class ExportCfgTask {
 	}
 	
 	public void setDestinationFolder(File destinationFolder) {
-		this.destinationFolder = destinationFolder;
+		this.properties.put(ExporterConstants.OUTPUT_FOLDER, destinationFolder);
 	}
 	
 	public File getDestinationFolder() {
-		return this.destinationFolder;
+		return (File)this.properties.get(ExporterConstants.OUTPUT_FOLDER);
 	}
 	
 	public void addConfiguredProperty(Variable variable) {

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 
 import org.apache.tools.ant.types.Environment.Variable;
+import org.hibernate.tool.api.export.ExporterConstants;
 import org.junit.jupiter.api.Test;
 
 public class ExportCfgTaskTest {
@@ -31,10 +32,10 @@ public class ExportCfgTaskTest {
 	@Test
 	public void testSetDestinationFolder() {
 		ExportCfgTask ect = new ExportCfgTask(null);
-		assertNull(ect.destinationFolder);
+		assertNull(ect.properties.get(ExporterConstants.OUTPUT_FOLDER));
 		File file = new File("/");
 		ect.setDestinationFolder(file);
-		assertSame(file, ect.destinationFolder);
+		assertSame(file, ect.properties.get(ExporterConstants.OUTPUT_FOLDER));
 	}
 	
 	@Test
@@ -42,7 +43,7 @@ public class ExportCfgTaskTest {
 		ExportCfgTask ect = new ExportCfgTask(null);
 		assertNull(ect.getDestinationFolder());
 		File file = new File("/");
-		ect.destinationFolder = file;
+		ect.properties.put(ExporterConstants.OUTPUT_FOLDER, file);
 		assertSame(file, ect.getDestinationFolder());
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/ant/ExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/ExporterTask.java
@@ -25,7 +25,6 @@ public abstract class ExporterTask {
 	// refactor out so not dependent on Ant ?
 	protected HibernateToolTask parent;
 	Properties properties;
-	File destdir;
 	private Path templatePath;
 	
 	public ExporterTask(HibernateToolTask parent) {
@@ -44,6 +43,7 @@ public abstract class ExporterTask {
 	protected abstract Exporter createExporter();
 
 	public File getDestdir() {
+		File destdir = (File)this.properties.get(ExporterConstants.OUTPUT_FOLDER);
 		if(destdir==null) {
 			return parent.getDestDir();
 		} 
@@ -52,7 +52,7 @@ public abstract class ExporterTask {
 		}
 	}
 	public void setDestdir(File destdir) {
-		this.destdir = destdir;
+		this.properties.put(ExporterConstants.OUTPUT_FOLDER, destdir);
 	}
 	
 	public void setTemplatePath(Path path) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>