### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Remove method ExportCfgTask.getDestinationFolder()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -20,10 +20,6 @@ public class ExportCfgTask {
 		this.properties.put(ExporterConstants.OUTPUT_FOLDER, destinationFolder);
 	}
 	
-	public File getDestinationFolder() {
-		return (File)this.properties.get(ExporterConstants.OUTPUT_FOLDER);
-	}
-	
 	public void addConfiguredProperty(Variable variable) {
 		properties.put(variable.getKey(), variable.getValue());
 	}

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -39,15 +39,6 @@ public class ExportCfgTaskTest {
 	}
 	
 	@Test
-	public void testGetDestinationFolder() {
-		ExportCfgTask ect = new ExportCfgTask(null);
-		assertNull(ect.getDestinationFolder());
-		File file = new File("/");
-		ect.properties.put(ExporterConstants.OUTPUT_FOLDER, file);
-		assertSame(file, ect.getDestinationFolder());
-	}
-	
-	@Test
 	public void testAddConfiguredProperty() {
 		ExportCfgTask ect = new ExportCfgTask(null);
 		assertNull(ect.properties.get("foo"));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>