### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Implement ExportCfgTask.execute()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -4,11 +4,13 @@ import java.io.File;
 import java.util.Properties;
 
 import org.apache.tools.ant.types.Environment.Variable;
+import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class ExportCfgTask {
 	
-	boolean executed = false;
 	HibernateToolTask parent = null;
 	Properties properties = new Properties();
 	
@@ -25,7 +27,9 @@ public class ExportCfgTask {
 	}
 	
 	public void execute() {
-		executed = true;
+		Exporter exporter = ExporterFactory.createExporter(ExporterType.CFG);
+		exporter.getProperties().putAll(this.properties);
+		exporter.start();
 	}
 
 }

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -7,12 +7,20 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.util.Properties;
 
 import org.apache.tools.ant.types.Environment.Variable;
 import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ExportCfgTaskTest {
+	
+	@TempDir 
+	Path tempdir;
 	
 	@Test 
 	public void testExportCfgTask() {
@@ -24,9 +32,19 @@ public class ExportCfgTaskTest {
 	@Test
 	public void testExecute() {
 		ExportCfgTask ect = new ExportCfgTask(null);
-		assertFalse(ect.executed);
+		Properties properties = new Properties();
+		properties.put("hibernate.dialect", "H2");
+		MetadataDescriptor mdd = MetadataDescriptorFactory.createNativeDescriptor(
+				null, 
+				new File[] {}, 
+				properties);
+		ect.properties.put(ExporterConstants.METADATA_DESCRIPTOR, mdd);
+		File destinationFolder = tempdir.toFile();
+		ect.properties.put(ExporterConstants.OUTPUT_FOLDER, destinationFolder);
+		File cfgFile = new File(destinationFolder, "hibernate.cfg.xml");
+		assertFalse(cfgFile.exists());
 		ect.execute();
-		assertTrue(ect.executed);
+		assertTrue(cfgFile.exists());
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>