### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add method ExportCfgTask.getProperties()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -19,6 +19,10 @@ public class ExportCfgTask {
 		this.parent = parent;
 	}
 	
+	public Properties getProperties() {
+		return this.properties;
+	}
+	
 	public void setDestinationFolder(File destinationFolder) {
 		this.properties.put(ExporterConstants.DESTINATION_FOLDER, destinationFolder);
 	}

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -75,5 +75,11 @@ public class ExportCfgTaskTest {
 		ect.setMetadataDescriptor(mdd);
 		assertSame(mdd, ect.properties.get(ExporterConstants.METADATA_DESCRIPTOR));
 	}
+	
+	@Test
+	public void testGetProperties() {
+		ExportCfgTask ect = new ExportCfgTask(null);
+		assertSame(ect.properties, ect.getProperties());
+	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>