### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Implement HibernateToolTask.execute()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -1,5 +1,7 @@
 package org.hibernate.tool.ant;
 
+import org.hibernate.tool.api.export.ExporterConstants;
+
 public class HibernateToolTask {
 	
 	MetadataTask metadataTask;
@@ -20,7 +22,10 @@ public class HibernateToolTask {
 	}
 	
 	public void execute() {
-		// do nothing for now
+		exportCfgTask.getProperties().put(
+				ExporterConstants.METADATA_DESCRIPTOR, 
+				metadataTask.createMetadataDescriptor());
+		exportCfgTask.execute();
 	}
 	
 }

--- a/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/HibernateToolTaskTest.java
@@ -4,6 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.junit.jupiter.api.Test;
 
 public class HibernateToolTaskTest {	
@@ -29,6 +34,39 @@ public class HibernateToolTaskTest {
 		assertNull(htt.exportCfgTask);
 		ExportCfgTask ect = htt.createExportCfg();
 		assertSame(ect, htt.exportCfgTask);
+	}
+	
+	Object testObject = null;
+	@Test
+	public void testExecute() {
+		HibernateToolTask htt = new HibernateToolTask();
+		final MetadataDescriptor mdd = new MetadataDescriptor() {			
+			@Override
+			public Properties getProperties() {
+				return null;
+			}		
+			@Override
+			public Metadata createMetadata() {
+				return null;
+			}
+		};
+		MetadataTask mdt = new MetadataTask() {
+			@Override
+			public MetadataDescriptor createMetadataDescriptor() {
+				return mdd;
+			}
+		};
+		htt.metadataTask = mdt;
+		ExportCfgTask ect = new ExportCfgTask(htt) {
+			@Override 
+			public void execute() {
+				testObject = getProperties().get(ExporterConstants.METADATA_DESCRIPTOR);
+			}
+		};
+		htt.exportCfgTask = ect;
+		assertNull(testObject);
+		htt.execute();
+		assertSame(testObject, mdd);
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>