### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add method MetadataTask.setType(Type)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
@@ -17,9 +17,12 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 
 public class MetadataTask {
 	
+	enum Type { JDBC, JPA, NATIVE }
+	
 	File propertyFile = null;
 	File configFile = null;
 	List<FileSet> fileSets = new ArrayList<FileSet>();	
+	Type type = Type.NATIVE;
 	
 	public void setPropertyFile(File file) {
 		this.propertyFile = file;
@@ -27,6 +30,10 @@ public class MetadataTask {
 	
 	public void setConfigFile(File file) {
 		this.configFile = file;
+	}
+	
+	public void setType(Type type) {
+		this.type = type;
 	}
 	
 	public void addConfiguredFileSet(FileSet fileSet) {

--- a/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.selectors.FilenameSelector;
+import org.hibernate.tool.ant.MetadataTask.Type;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -38,6 +39,14 @@ public class MetadataTaskTest {
 		File f = new File(".");
 		mdt.setConfigFile(f);
 		assertSame(f, mdt.configFile);
+	}
+	
+	@Test
+	public void testSetType() {
+		MetadataTask mdt = new MetadataTask();
+		assertSame(Type.NATIVE, mdt.type);
+		mdt.setType(Type.JDBC);
+		assertSame(Type.JDBC, mdt.type);
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>