### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Replace method MetadataTask.setType(Type) by MetadataTask.setType(String)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
@@ -32,8 +32,8 @@ public class MetadataTask {
 		this.configFile = file;
 	}
 	
-	public void setType(Type type) {
-		this.type = type;
+	public void setType(String type) {
+		this.type = Type.valueOf(type.toUpperCase());
 	}
 	
 	public void addConfiguredFileSet(FileSet fileSet) {

--- a/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
@@ -45,7 +45,7 @@ public class MetadataTaskTest {
 	public void testSetType() {
 		MetadataTask mdt = new MetadataTask();
 		assertSame(Type.NATIVE, mdt.type);
-		mdt.setType(Type.JDBC);
+		mdt.setType("jdbc");
 		assertSame(Type.JDBC, mdt.type);
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>