### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Don't ignore the metadata properties in  method ExportCfgTask.execute()

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -37,6 +37,9 @@ public class ExportCfgTask {
 	
 	public void execute() {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.CFG);
+		MetadataDescriptor metadataDescriptor = 
+				(MetadataDescriptor)this.properties.get(ExporterConstants.METADATA_DESCRIPTOR);
+		exporter.getProperties().putAll(metadataDescriptor.getProperties());
 		exporter.getProperties().putAll(this.properties);
 		exporter.start();
 	}

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
@@ -30,7 +31,7 @@ public class ExportCfgTaskTest {
 	}
 	
 	@Test
-	public void testExecute() {
+	public void testExecute() throws Exception {
 		ExportCfgTask ect = new ExportCfgTask(null);
 		Properties properties = new Properties();
 		properties.put("hibernate.dialect", "H2");
@@ -45,6 +46,8 @@ public class ExportCfgTaskTest {
 		assertFalse(cfgFile.exists());
 		ect.execute();
 		assertTrue(cfgFile.exists());
+		String cfgXmlString = new String(Files.readAllBytes(cfgFile.toPath()));
+		assertTrue(cfgXmlString.contains("hibernate.dialect"));
 	}
 	
 	@Test

--- a/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataCfgTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataCfgTest.java
@@ -28,6 +28,8 @@ public class NativeMetadataCfgTest {
 		assertFalse(generatedFile.exists());
 		project.executeTarget("testNativeMetadataExportCfg");
 		assertTrue(generatedFile.exists());
+		String cfgXmlString = new String(Files.readAllBytes(generatedFile.toPath()));
+		assertTrue(cfgXmlString.contains("hibernate.dialect"));
 	}
 	
 	private String getDestinationFolder() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>