### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add method MetadataTask.setPersistenceUnit(String)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
@@ -19,10 +19,15 @@ public class MetadataTask {
 	
 	enum Type { JDBC, JPA, NATIVE }
 	
+	String persistenceUnit = null;
 	File propertyFile = null;
 	File configFile = null;
 	List<FileSet> fileSets = new ArrayList<FileSet>();	
 	Type type = Type.NATIVE;
+	
+	public void setPersistenceUnit(String pU) {
+		this.persistenceUnit = pU;
+	}
 	
 	public void setPropertyFile(File file) {
 		this.propertyFile = file;

--- a/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
@@ -24,6 +24,14 @@ public class MetadataTaskTest {
 	Path tempDir;
 	
 	@Test
+	public void testSetPersistenceUnit() {
+		MetadataTask mdt = new MetadataTask();
+		assertNull(mdt.persistenceUnit);
+		mdt.setPersistenceUnit("foobar");
+		assertEquals("foobar", mdt.persistenceUnit);
+	}
+	
+	@Test
 	public void testSetPropertyFile() {
 		MetadataTask mdt = new MetadataTask();
 		assertNull(mdt.propertyFile);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>