### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add method ExportCfgTask.setTemplatePath(Path)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportCfgTask.java
@@ -1,6 +1,7 @@
 package org.hibernate.tool.ant;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.apache.tools.ant.types.Environment.Variable;
@@ -29,6 +30,10 @@ public class ExportCfgTask {
 	
 	public void setMetadataDescriptor(MetadataDescriptor metadataDescriptor) {
 		this.properties.put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
+	}
+	
+	public void setTemplatePath(Path path) {
+		this.properties.put(ExporterConstants.TEMPLATE_PATH, path);
 	}
 	
 	public void addConfiguredProperty(Variable variable) {

--- a/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/ExportCfgTaskTest.java
@@ -80,6 +80,14 @@ public class ExportCfgTaskTest {
 	}
 	
 	@Test
+	public void testSetTemplatePath() {
+		ExportCfgTask ect = new ExportCfgTask(null);
+		assertNull(ect.properties.get(ExporterConstants.TEMPLATE_PATH));
+		ect.setTemplatePath(tempdir);
+		assertSame(tempdir, ect.properties.get(ExporterConstants.TEMPLATE_PATH));
+	}
+	
+	@Test
 	public void testGetProperties() {
 		ExportCfgTask ect = new ExportCfgTask(null);
 		assertSame(ect.properties, ect.getProperties());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>