### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Rename MetadataTaskTest#testCreateMetadataDescriptor() into MetadataTaskTest#testCreateNativeMetadataDescriptor()

### DIFF
--- a/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/MetadataTaskTest.java
@@ -68,7 +68,7 @@ public class MetadataTaskTest {
 	}
 	
 	@Test
-	public void testCreateMetadataDescriptor() throws Exception {
+	public void testCreateNativeMetadataDescriptor() throws Exception {
 		String propertiesString = "hibernate.dialect=H2";
 		File propertiesFile = new File(tempDir.toFile(), "hibernate.properties");
 		Files.write(propertiesFile.toPath(), propertiesString.getBytes());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>