### PR TITLE
 HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add create JPA metadata descriptor

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/MetadataTask.java
@@ -46,10 +46,18 @@ public class MetadataTask {
 	}
 	
 	public MetadataDescriptor createMetadataDescriptor() {
-		return MetadataDescriptorFactory.createNativeDescriptor(
-				this.configFile, 
-				getFiles(), 
-				getProperties());
+		switch(type) {
+			case NATIVE:
+				return MetadataDescriptorFactory.createNativeDescriptor(
+					this.configFile, 
+					getFiles(), 
+					getProperties());
+			case JPA:
+				return MetadataDescriptorFactory.createJpaDescriptor(
+					persistenceUnit, 
+					getProperties());
+			default: return null;
+		}
 	}
 	
 	private File[] getFiles() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>