### PR TITLE
HBX-1852: Remove the 'preferBasicCompositeIds' argument from MetadataDescriptorFactory.createJdbcDescriptor() - Add method MetadataDescriptorFactory.createJdbcDescriptor(ReverseEngineeringStrategy,Properties)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptorFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptorFactory.java
@@ -20,6 +20,14 @@ public class MetadataDescriptorFactory {
 				preferBasicCompositeIds);
 	}
 	
+	public static MetadataDescriptor createJdbcDescriptor(
+			ReverseEngineeringStrategy reverseEngineeringStrategy, 
+			Properties properties) {
+		return new JdbcMetadataDescriptor(
+				reverseEngineeringStrategy, 
+				properties);
+	}
+	
 	public static MetadataDescriptor createJpaDescriptor(String persistenceUnit, Properties properties) {
 		return new JpaMetadataDescriptor(persistenceUnit, properties);
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>