### PR TITLE
HBX-1852: Remove the 'preferBasicCompositeIds' argument from MetadataDescriptorFactory.createJdbcDescriptor() - Use MetadataDescriptorFactory.createJdbcDescriptor(ReverseEngineeringStrategy,Properties) instead of Use MetadataDescriptorFactory.createJdbcDescriptor(ReverseEngineeringStrategy,Properties,boolean)

### DIFF
--- a/maven/src/main/java/org/hibernate/mvn/AbstractHbm2xMojo.java
+++ b/maven/src/main/java/org/hibernate/mvn/AbstractHbm2xMojo.java
@@ -94,11 +94,11 @@ public abstract class AbstractHbm2xMojo extends AbstractMojo {
     }
 
     private MetadataDescriptor createJdbcDescriptor(ReverseEngineeringStrategy strategy, Properties properties) {
+    	properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
         return MetadataDescriptorFactory
                 .createJdbcDescriptor(
                         strategy,
-                        properties,
-                        preferBasicCompositeIds);
+                        properties);
     }
 
     protected abstract void executeExporter(MetadataDescriptor metadataDescriptor);

--- a/orm/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -41,11 +41,11 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 	protected MetadataDescriptor createMetadataDescriptor() {
 		Properties properties = loadPropertiesFile();
 		ReverseEngineeringStrategy res = createReverseEngineeringStrategy();
+		properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
 		return MetadataDescriptorFactory
 				.createJdbcDescriptor(
 						res, 
-						properties, 
-						preferBasicCompositeIds);
+						properties);
 	}
 	
 	private ReverseEngineeringStrategy createReverseEngineeringStrategy() {

--- a/test/common/src/main/java/org/hibernate/tool/cfg/JDBCMetaDataConfiguration/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/cfg/JDBCMetaDataConfiguration/TestCase.java
@@ -28,7 +28,7 @@ public class TestCase {
 	@Test
 	public void testReadFromJDBC() throws Exception {
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 		Assert.assertNotNull("WithRealTimestamp", metadata.getEntityBinding("WithRealTimestamp"));
 		Assert.assertNotNull("NoVersion", metadata.getEntityBinding("NoVersion"));
@@ -41,7 +41,7 @@ public class TestCase {
 		Assert.assertNotNull(
 				HibernateUtil.getTable(
 						MetadataDescriptorFactory
-							.createJdbcDescriptor(null, null, true)
+							.createJdbcDescriptor(null, null)
 							.createMetadata(), 
 						JdbcUtil.toIdentifier(this, "WITH_REAL_TIMESTAMP")));
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -62,7 +62,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, "cat.cat"));
 		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		List<Table> tables = getTables(MetadataDescriptorFactory
-				.createJdbcDescriptor(res, null, true)
+				.createJdbcDescriptor(res, null)
 				.createMetadata());
 		Assert.assertEquals(2,tables.size());
 		Table catchild = (Table) tables.get(0);

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -50,7 +50,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
 		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		List<Table> tables = getTables(MetadataDescriptorFactory
-				.createJdbcDescriptor(res, null, true)
+				.createJdbcDescriptor(res, null)
 				.createMetadata());
 		Assert.assertEquals(2,tables.size());	
 		Table catchild = (Table) tables.get(0);
@@ -74,7 +74,7 @@ public class TestCase {
 		ReverseEngineeringStrategy res = 
 				or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(res, null, true)
+				.createJdbcDescriptor(res, null)
 				.createMetadata();
 		Set<TableIdentifier> tables = new HashSet<TableIdentifier>();
 		Iterator<Table> iter = metadata.collectTableMappings().iterator();
@@ -93,7 +93,7 @@ public class TestCase {
 		properties.setProperty(Environment.DEFAULT_SCHEMA, "OVRTEST");
 		properties.setProperty(Environment.DEFAULT_SCHEMA, "OVRTEST");
 		List<Table> tables = getTables(MetadataDescriptorFactory
-				.createJdbcDescriptor(null, properties, true)
+				.createJdbcDescriptor(null, properties)
 				.createMetadata());
 		Assert.assertEquals(2,tables.size());
 		Table catchild = (Table) tables.get(0);

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -57,7 +57,7 @@ public class TestCase {
 		DefaultReverseEngineeringStrategy configurableNamingStrategy = new DefaultReverseEngineeringStrategy();
 		configurableNamingStrategy.setSettings(new ReverseEngineeringSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		metadataDescriptor = MetadataDescriptorFactory
-				.createJdbcDescriptor(configurableNamingStrategy, null, true);
+				.createJdbcDescriptor(configurableNamingStrategy, null);
 	}
 	
 	@After

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
@@ -95,7 +95,7 @@ public class TestCase {
 		ReverseEngineeringStrategy res = overrideRepository
 				.getReverseEngineeringStrategy(configurableNamingStrategy);
 		return MetadataDescriptorFactory
-				.createJdbcDescriptor(res, null, true);
+				.createJdbcDescriptor(res, null);
 	}
 	
 }

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3/TestCase.java
@@ -45,7 +45,7 @@ public class TestCase {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.POJO);
 		exporter.getProperties().put(
 				ExporterConstants.METADATA_DESCRIPTOR, 
-				MetadataDescriptorFactory.createJdbcDescriptor(null, null, true));
+				MetadataDescriptorFactory.createJdbcDescriptor(null, null));
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.getProperties().put(ExporterConstants.TEMPLATE_PATH, new String[0]);
 		exporter.getProperties().setProperty("ejb3", "true");

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/AutoQuote/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/AutoQuote/TestCase.java
@@ -28,7 +28,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Basic/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Basic/TestCase.java
@@ -31,7 +31,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/BasicMultiSchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/BasicMultiSchema/TestCase.java
@@ -31,7 +31,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -57,7 +57,7 @@ public class TestCase {
 		JdbcUtil.createDatabase(this);
 		reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
 		metadataDescriptor = MetadataDescriptorFactory
-				.createJdbcDescriptor(reverseEngineeringStrategy, null, true);
+				.createJdbcDescriptor(reverseEngineeringStrategy, null);
 	}
 
 	@After

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
@@ -39,7 +39,7 @@ public class TestCase {
 		JdbcUtil.createDatabase(this);
 		reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(reverseEngineeringStrategy, null, true)
+				.createJdbcDescriptor(reverseEngineeringStrategy, null)
 				.createMetadata();
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -28,7 +28,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Index/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Index/TestCase.java
@@ -31,7 +31,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -52,8 +53,10 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
+		Properties properties = new Properties();
+		properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, false);
 		metadataDescriptor = MetadataDescriptorFactory
-				.createJdbcDescriptor(reverseEngineeringStrategy, null, false);
+				.createJdbcDescriptor(reverseEngineeringStrategy, properties);
 	}
 
 	@After

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -49,7 +49,7 @@ public class TestCase {
         DefaultReverseEngineeringStrategy c = new DefaultReverseEngineeringStrategy();
         c.setSettings(new ReverseEngineeringSettings(c).setDetectManyToMany(false)); 
         Metadata metadata =  MetadataDescriptorFactory
-        		.createJdbcDescriptor(c, null, true)
+        		.createJdbcDescriptor(c, null)
         		.createMetadata();
 
         PersistentClass project = metadata.getEntityBinding("Project");
@@ -79,7 +79,7 @@ public class TestCase {
 	@Test
 	public void testAutoCreation() {
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 		
         Assert.assertNull("No middle class should be generated.", metadata.getEntityBinding( "WorksOn" ));
@@ -104,7 +104,7 @@ public class TestCase {
 	@Test
 	public void testFalsePositive() {
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();	    
         Assert.assertNotNull("Middle class should be generated.", metadata.getEntityBinding( "NonMiddle" ));	
 	}
@@ -112,7 +112,7 @@ public class TestCase {
 	@Test
 	public void testBuildMappings() {		
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 		Assert.assertNotNull(metadata);	
 	}
@@ -121,7 +121,7 @@ public class TestCase {
 	public void testGenerateAndReadable() {
 		
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true);
+				.createJdbcDescriptor(null, null);
 		File outputDir = temporaryFolder.getRoot();
 		
 		Assert.assertNotNull(metadataDescriptor.createMetadata());

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/MetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/MetaData/TestCase.java
@@ -29,7 +29,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/NoPrimaryKey/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/NoPrimaryKey/TestCase.java
@@ -33,7 +33,7 @@ public class TestCase {
 	public void testMe() {
 		Assert.assertNotNull(
 			MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata());
 	}
 	

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
@@ -56,7 +56,7 @@ public class TestCase {
 	@Before
 	public void setUp() throws Exception {
 		JdbcUtil.createDatabase(this);
-		metadataDescriptor = MetadataDescriptorFactory.createJdbcDescriptor(null, null, true);
+		metadataDescriptor = MetadataDescriptorFactory.createJdbcDescriptor(null, null);
 		metadata = metadataDescriptor.createMetadata();
 	}
 	

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -56,7 +56,7 @@ public class TestCase {
 		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(
 				new DefaultReverseEngineeringStrategy() );
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(res, null, true)
+				.createJdbcDescriptor(res, null)
 				.createMetadata();
 	}
 
@@ -146,7 +146,7 @@ public class TestCase {
 		ox.addSchemaSelection(new SchemaSelection(null, null, "DUMMY.*"));
 		ReverseEngineeringStrategy strategy = ox.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		Metadata md = MetadataDescriptorFactory
-				.createJdbcDescriptor(strategy, null, true)
+				.createJdbcDescriptor(strategy, null)
 				.createMetadata();
 		
 		Iterator<Table> tableMappings = md.collectTableMappings().iterator();

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Performance/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Performance/TestCase.java
@@ -38,7 +38,7 @@ public class TestCase {
 	@Test
 	public void testBasic() throws SQLException {	
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 		JUnitUtil.assertIteratorContainsExactly(
 				"There should be " + TABLECOUNT + " tables!", 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -45,7 +45,7 @@ public class TestCase {
         DefaultReverseEngineeringStrategy c = new DefaultReverseEngineeringStrategy();
         c.setSettings(new ReverseEngineeringSettings(c).setDefaultPackageName(PACKAGE_NAME));
         metadata = MetadataDescriptorFactory
-        		.createJdbcDescriptor(c, null, true)
+        		.createJdbcDescriptor(c, null)
         		.createMetadata();
 	}
 	

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
@@ -43,7 +43,7 @@ public class TestCase {
 	@Test
 	public void testDefaultBiDirectional() {
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 		PersistentClass project = metadata.getEntityBinding("Project");
 		Assert.assertNotNull(project.getProperty("worksOns"));
@@ -70,7 +70,7 @@ public class TestCase {
 		or.addResource(FOREIGN_KEY_TEST_XML);
 		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(repository, null, true)
+				.createJdbcDescriptor(repository, null)
 				.createMetadata();			
 		PersistentClass project = metadata.getEntityBinding("Project");		
 		Assert.assertNotNull(project.getProperty("worksOns"));
@@ -102,7 +102,7 @@ public class TestCase {
 		or.addResource(FOREIGN_KEY_TEST_XML);
 		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(repository, null, true)
+				.createJdbcDescriptor(repository, null)
 				.createMetadata();
 		PersistentClass person = metadata.getEntityBinding("Person");
 		PersistentClass addressPerson = metadata.getEntityBinding("AddressPerson");
@@ -127,7 +127,7 @@ public class TestCase {
 			or.addResource(BAD_FOREIGNKEY_XML);
 			ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 			MetadataDescriptorFactory
-					.createJdbcDescriptor(repository, null, true)
+					.createJdbcDescriptor(repository, null)
 					.createMetadata();
 			Assert.fail("Should fail because foreign key is already defined in the database"); // maybe we should ignore the definition and only listen to what is overwritten ? For now we error. 
 		} catch(MappingException me) {
@@ -138,7 +138,7 @@ public class TestCase {
 	@Test
 	public void testManyToOneAttributeDefaults() {	
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 		PersistentClass classMapping = metadata.getEntityBinding("Employee");
 		Property property = classMapping.getProperty("employee");	
@@ -154,7 +154,7 @@ public class TestCase {
 		or.addResource(FOREIGN_KEY_TEST_XML);
 		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(repository, null, true)
+				.createJdbcDescriptor(repository, null)
 				.createMetadata();
 		PersistentClass classMapping = metadata.getEntityBinding("Employee");
 		Property property = classMapping.getProperty("manager");	

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/SearchEscapeString/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/SearchEscapeString/TestCase.java
@@ -29,7 +29,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 	

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
@@ -54,7 +54,7 @@ public class TestCase {
 			}
 		};           
 	    metadataDescriptor = MetadataDescriptorFactory
-	    		.createJdbcDescriptor(c, null, true);
+	    		.createJdbcDescriptor(c, null);
 	}
 
 	@After

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
@@ -43,7 +43,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadataDescriptor = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true);
+				.createJdbcDescriptor(null, null);
 		metadata = metadataDescriptor
 				.createMetadata();
 	}

--- a/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
+++ b/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
@@ -42,7 +42,7 @@ public class TestCase {
         DefaultReverseEngineeringStrategy c = new DefaultReverseEngineeringStrategy();
         c.setSettings(new ReverseEngineeringSettings(c).setDetectManyToMany(true)); 
 		metadataDescriptor = MetadataDescriptorFactory
-				.createJdbcDescriptor(c, null, true);
+				.createJdbcDescriptor(c, null);
 	}
 	
 	@After

--- a/test/mssql/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/mssql/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -29,7 +29,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		MetadataDescriptorFactory
-			.createJdbcDescriptor(null, null, true)
+			.createJdbcDescriptor(null, null)
 			.createMetadata();
 	}
 

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -65,7 +65,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, "cat.cat"));
 		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(res, null, true)
+				.createJdbcDescriptor(res, null)
 				.createMetadata();
 		List<Table> tables = getTables(metadata);
 		Assert.assertEquals(2,tables.size());

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -53,7 +53,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
 		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(res, null, true)
+				.createJdbcDescriptor(res, null)
 				.createMetadata();
 		List<Table> tables = getTables(metadata);
 		Assert.assertEquals(2,tables.size());	
@@ -78,7 +78,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, null, "CHILD"));
 		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(res, null, true)
+				.createJdbcDescriptor(res, null)
 				.createMetadata();
 		Set<TableIdentifier> tables = new HashSet<TableIdentifier>();
 		Iterator<Table> iter = metadata.collectTableMappings().iterator();
@@ -98,7 +98,7 @@ public class TestCase {
 		properties.setProperty(Environment.DEFAULT_SCHEMA, "OVRTEST");
 		properties.setProperty(Environment.DEFAULT_SCHEMA, "OVRTEST");
 		Metadata metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, properties, true)
+				.createJdbcDescriptor(null, properties)
 				.createMetadata();
 		List<Table> tables = getTables(metadata);
 		Assert.assertEquals(2,tables.size());

--- a/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeIdOrder/TestCase.java
+++ b/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeIdOrder/TestCase.java
@@ -36,7 +36,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 	

--- a/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -29,7 +29,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 

--- a/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Views/TestCase.java
+++ b/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Views/TestCase.java
@@ -31,7 +31,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
-				.createJdbcDescriptor(null, null, true)
+				.createJdbcDescriptor(null, null)
 				.createMetadata();
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>