### PR TITLE
HBX-1852: Remove the 'preferBasicCompositeIds' argument from MetadataDescriptorFactory.createJdbcDescriptor() - Remove unused method MetadataDescriptorFactory.createJdbcDescriptor(ReverseEngineeringStrategy,Properties,boolean)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptorFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptorFactory.java
@@ -12,16 +12,6 @@ public class MetadataDescriptorFactory {
 	
 	public static MetadataDescriptor createJdbcDescriptor(
 			ReverseEngineeringStrategy reverseEngineeringStrategy, 
-			Properties properties,
-			boolean preferBasicCompositeIds) {
-		return new JdbcMetadataDescriptor(
-				reverseEngineeringStrategy, 
-				properties,
-				preferBasicCompositeIds);
-	}
-	
-	public static MetadataDescriptor createJdbcDescriptor(
-			ReverseEngineeringStrategy reverseEngineeringStrategy, 
 			Properties properties) {
 		return new JdbcMetadataDescriptor(
 				reverseEngineeringStrategy, 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>