### PR TITLE
HBX-1852: Remove the 'preferBasicCompositeIds' argument from MetadataDescriptorFactory.createJdbcDescriptor() - Remove unused constructor JdbcMetadataDescriptor(ReverseEngineeringStrategy,Properties,boolean)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/metadata/JdbcMetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/metadata/JdbcMetadataDescriptor.java
@@ -32,20 +32,6 @@ public class JdbcMetadataDescriptor implements MetadataDescriptor {
 
 	public JdbcMetadataDescriptor(
 			ReverseEngineeringStrategy reverseEngineeringStrategy, 
-			Properties properties,
-			boolean preferBasicCompositeIds) {
-		this.properties.putAll(Environment.getProperties());
-		if (properties != null) {
-			this.properties.putAll(properties);
-		}
-		if (reverseEngineeringStrategy != null) {
-			this.reverseEngineeringStrategy = reverseEngineeringStrategy;
-		}
-		this.properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
-	}
-
-	public JdbcMetadataDescriptor(
-			ReverseEngineeringStrategy reverseEngineeringStrategy, 
 			Properties properties) {
 		this.properties.putAll(Environment.getProperties());
 		if (properties != null) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>