### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Add first version of NativeMetadataDdlTest

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -22,10 +22,12 @@ public class HibernateToolTask {
 	}
 	
 	public void execute() {
-		exportCfgTask.getProperties().put(
-				ExporterConstants.METADATA_DESCRIPTOR, 
-				metadataTask.createMetadataDescriptor());
-		exportCfgTask.execute();
+		if (exportCfgTask != null) {
+			exportCfgTask.getProperties().put(
+					ExporterConstants.METADATA_DESCRIPTOR, 
+					metadataTask.createMetadataDescriptor());
+			exportCfgTask.execute();
+		}
 	}
 	
 }

--- a/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataDdlTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataDdlTest.java
@@ -1,0 +1,51 @@
+package org.hibernate.tool.ant.test.it;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.tools.ant.Project;
+import org.hibernate.tool.ant.test.util.ProjectUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class NativeMetadataDdlTest {
+
+	@TempDir
+	Path tempDir;
+	
+	@Test
+	public void testNativeMetadataExportCfg() throws Exception {
+		File buildXmlFile = createBuildXmlFile();
+		Project project = ProjectUtil.createProject(buildXmlFile);
+		project.executeTarget("testNativeMetadataExportDdl");
+	}
+	
+	private File createHbmXmlFile() {
+		File result = new File(tempDir.toFile(), "ddl.hbm.xml");
+		return result;
+	}
+	
+	private File createBuildXmlFile() throws Exception {
+		String hbmXmlFile = createHbmXmlFile().getAbsolutePath();
+		String buildXmlString = 
+				"<project name='NativeMetadataDdlTest'>                       " +
+				"  <taskdef                                                   " +
+                "      name='hibernatetool'                                   " +
+				"      classname='org.hibernate.tool.ant.HibernateToolTask'/> " +
+		        "  <target name='testNativeMetadataExportDdl'>                " +
+				"    <hibernatetool>                                          " +
+				"      <metadata                                              " +
+				"          type='native'>                                     " +
+				"        <fileset file='" + hbmXmlFile + "'/>                 " +
+				"      </metadata>                                            " +
+				"      <exportDdl/>                                           " + 
+				"    </hibernatetool>                                         " +
+		        "  </target>                                                  " +
+		        "</project>                                                   " ;
+		File result = new File(tempDir.toFile(), "build.xml");
+		Files.write(result.toPath(), buildXmlString.getBytes());
+		return result;
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>