### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Move the old ant tasks to hibernate-tools-ant in the package 'org.hibernate.tool.ant.old'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/old/ConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/ConfigurationTask.java
@@ -1,0 +1,133 @@
+/*
+ * Created on 13-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.types.FileSet;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+
+/**
+ * @author max
+ *
+ */
+public class ConfigurationTask extends Task {
+
+	private List<FileSet> fileSets = new ArrayList<FileSet>();
+	private MetadataDescriptor metadataDescriptor;
+	private File configurationFile;
+	private File propertyFile;
+	protected String entityResolver;
+	
+	public ConfigurationTask() {
+		setDescription("Standard Configuration");
+	}
+	
+	public void addConfiguredFileSet(FileSet fileSet) {
+		fileSets.add(fileSet);	 	
+	}
+
+	/**
+	 * @return
+	 */
+	public final MetadataDescriptor getMetadataDescriptor() {
+		if (metadataDescriptor == null) {
+			metadataDescriptor = createMetadataDescriptor();
+		}
+		return metadataDescriptor;
+	}
+	
+	protected MetadataDescriptor createMetadataDescriptor() {
+		return MetadataDescriptorFactory
+				.createNativeDescriptor(
+						configurationFile, 
+						getFiles(), 
+						loadPropertiesFile());
+	}
+	
+	protected Properties loadPropertiesFile() {
+		if (propertyFile!=null) { 
+			Properties properties = new Properties(); // TODO: should we "inherit" from the ant projects properties ?
+			FileInputStream is = null;
+			try {
+				is = new FileInputStream(propertyFile);
+				properties.load(is);
+				return properties;
+			} 
+			catch (FileNotFoundException e) {
+				throw new BuildException(propertyFile + " not found.",e);					
+			} 
+			catch (IOException e) {
+				throw new BuildException("Problem while loading " + propertyFile,e);				
+			}
+			finally {
+				if (is != null) {
+					try {
+						is.close();
+					} catch (IOException e) {
+					}
+				}
+			}
+		} else {
+			return null;
+		}
+	}
+	
+	
+	protected File[] getFiles() {
+
+		List<File> files = new LinkedList<File>();
+		for ( Iterator<FileSet> i = fileSets.iterator(); i.hasNext(); ) {
+
+			FileSet fs = i.next();
+			DirectoryScanner ds = fs.getDirectoryScanner( getProject() );
+
+			String[] dsFiles = ds.getIncludedFiles();
+			for (int j = 0; j < dsFiles.length; j++) {
+				File f = new File(dsFiles[j]);
+				if ( !f.isFile() ) {
+					f = new File( ds.getBasedir(), dsFiles[j] );
+				}
+
+				files.add( f );
+			}
+		}
+
+		return (File[]) files.toArray(new File[files.size()]);
+	}
+
+	
+	public File getConfigurationFile() {
+		return configurationFile;
+	}
+	public void setConfigurationFile(File configurationFile) {
+		this.configurationFile = configurationFile;
+	}
+	public File getPropertyFile() {
+		return propertyFile;
+	}
+	public void setPropertyFile(File propertyFile) {
+		this.propertyFile = propertyFile;
+	}
+	
+	public void setEntityResolver(String entityResolverName) {
+		this.entityResolver = entityResolverName;
+	}
+	
+	public void setNamingStrategy(String namingStrategy) {
+	}
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/ExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/ExporterTask.java
@@ -1,0 +1,101 @@
+/*
+ * Created on 13-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.types.Environment;
+import org.apache.tools.ant.types.Path;
+import org.apache.tools.ant.types.PropertySet;
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.api.export.ExporterConstants;
+
+/**
+ * @author max
+ * 
+ * Is not actually a ant task, but simply just a task part of a HibernateToolTask
+ *
+ */
+public abstract class ExporterTask {
+
+	// refactor out so not dependent on Ant ?
+	protected HibernateToolTask parent;
+	Properties properties;
+	private Path templatePath;
+	
+	public ExporterTask(HibernateToolTask parent) {
+		this.parent = parent;
+		this.properties = new Properties();
+	}
+
+	
+	/*final*/ public void execute() {
+	
+		Exporter exporter = configureExporter(createExporter() );
+		exporter.start();
+		
+	}
+	
+	protected abstract Exporter createExporter();
+
+	public File getDestdir() {
+		File destdir = (File)this.properties.get(ExporterConstants.DESTINATION_FOLDER);
+		if(destdir==null) {
+			return parent.getDestDir();
+		} 
+		else {
+			return destdir;
+		}
+	}
+	public void setDestdir(File destdir) {
+		this.properties.put(ExporterConstants.DESTINATION_FOLDER, destdir);
+	}
+	
+	public void setTemplatePath(Path path) {
+		templatePath = path;
+	}
+	
+	public void setTemplatePrefix(String s) {
+	}
+	
+	public void validateParameters() {
+		if(getDestdir()==null) {
+			throw new BuildException("destdir must be set, either locally or on <hibernatetool>");
+		}		
+	}
+	
+	public void addConfiguredPropertySet(PropertySet ps) {
+		properties.putAll(ps.getProperties());
+	}
+	
+	public void addConfiguredProperty(Environment.Variable property) {
+		properties.put(property.getKey(), property.getValue());
+	}
+	
+	protected Path getTemplatePath() {
+		if(templatePath==null) {
+			return parent.getTemplatePath();
+		} 
+		else {
+			return templatePath;
+		}		
+	}
+	
+	
+	abstract String getName();
+	
+	protected Exporter configureExporter(Exporter exporter) {
+		Properties prop = new Properties();
+		prop.putAll(parent.getProperties());
+		prop.putAll(properties);
+		exporter.getProperties().putAll(prop);
+		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getMetadataDescriptor());
+		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, getDestdir());
+		exporter.getProperties().put(ExporterConstants.TEMPLATE_PATH, getTemplatePath().list());
+		return exporter;
+	}
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/GenericExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/GenericExporterTask.java
@@ -1,0 +1,86 @@
+/*
+ * Created on 14-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import org.apache.tools.ant.BuildException;
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.internal.export.common.GenericExporter;
+import org.hibernate.tool.internal.util.ReflectHelper;
+
+/**
+ * @author max
+ *
+ */
+public class GenericExporterTask extends ExporterTask {
+
+	public GenericExporterTask(HibernateToolTask parent) {
+		super(parent);
+	}
+
+	String templateName;
+	String exporterClass;
+	String filePattern;
+	String forEach;
+	
+	/**
+	 * The FilePattern defines the pattern used to generate files.
+	 * @param filePattern
+	 */
+	public void setFilePattern(String filePattern) {
+		this.filePattern = filePattern;
+	}
+	
+	public void setForEach(String forEach) {
+		this.forEach = forEach;
+	}
+	
+	public void setTemplate(String templateName) {
+		this.templateName = templateName;
+	}
+	
+	public void setExporterClass(String exporterClass) {
+		this.exporterClass = exporterClass;
+	}
+	
+	protected Exporter createExporter() {
+		if (exporterClass == null) {
+			return new GenericExporter();
+		} else {
+			try {
+				return (Exporter) ReflectHelper.classForName(exporterClass).newInstance();
+			} catch (ClassNotFoundException e) {
+				throw new BuildException("Could not find custom exporter class: " + exporterClass, e);
+			} catch (InstantiationException e) {
+				throw new BuildException("Could not create custom exporter class: " + exporterClass, e);
+			} catch (IllegalAccessException e) {
+				throw new BuildException("Could not access custom exporter class: " + exporterClass, e);
+			}
+		}		
+	}
+	
+	protected Exporter configureExporter(Exporter exp) {
+		super.configureExporter(exp);
+		
+		if(exp instanceof GenericExporter) {
+			GenericExporter exporter = (GenericExporter) exp;
+			if(filePattern!=null) exporter.setFilePattern(filePattern);
+			if(templateName!=null) exporter.setTemplateName(templateName);
+			if(forEach!=null) exporter.setForEach(forEach);
+		}
+		
+		return exp;
+	}
+
+	public String getName() {
+		StringBuffer buf = new StringBuffer("generic exporter");
+		if(exporterClass!=null) {
+			buf.append( "class: " + exporterClass);
+		}
+		if(templateName!=null) {
+			buf.append( "template: " + templateName);
+		}
+		return buf.toString();
+	}
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2CfgXmlExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2CfgXmlExporterTask.java
@@ -1,0 +1,35 @@
+/*
+ * Created on 25-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.internal.export.cfg.CfgExporter;
+
+public class Hbm2CfgXmlExporterTask extends ExporterTask {
+
+	private boolean ejb3;
+
+	public Hbm2CfgXmlExporterTask(HibernateToolTask parent) {
+		super(parent);
+	}
+
+	public Exporter createExporter() {
+		return new CfgExporter();
+	}
+
+	public void setEjb3(boolean ejb3) {
+		this.ejb3 = ejb3;
+	}
+	
+	public String getName() {
+		return "hbm2cfgxml (Generates hibernate.cfg.xml)";
+	}
+	
+	protected Exporter configureExporter(Exporter exporter) {
+		CfgExporter hce = (CfgExporter)super.configureExporter( exporter );
+        hce.getProperties().setProperty("ejb3", ""+ejb3);
+		return hce;
+	}
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2DAOExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2DAOExporterTask.java
@@ -1,0 +1,34 @@
+package org.hibernate.tool.ant.old;
+
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.dao.DAOExporter;
+
+/**
+ * @author Dennis Byrne
+ */
+public class Hbm2DAOExporterTask extends Hbm2JavaExporterTask {
+
+	public Hbm2DAOExporterTask(HibernateToolTask parent) {
+		super(parent);
+	}
+	
+	protected Exporter configureExporter(Exporter exp) {
+		DAOExporter exporter = (DAOExporter)exp;
+		super.configureExporter(exp);
+		return exporter;
+	}
+	
+	protected Exporter createExporter() {
+		Exporter result = new DAOExporter();
+		result.getProperties().putAll(parent.getProperties());
+		result.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getMetadataDescriptor());
+		result.getProperties().put(ExporterConstants.DESTINATION_FOLDER, getDestdir());
+		return result;
+	}
+
+	public String getName() {
+		return "hbm2dao (Generates a set of DAOs)";
+	}
+
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2DDLExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2DDLExporterTask.java
@@ -1,0 +1,111 @@
+/*
+ * Created on 13-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.ddl.Hbm2DDLExporter;
+
+/**
+ * @author max
+ *
+ */
+public class Hbm2DDLExporterTask extends ExporterTask {
+
+	boolean exportToDatabase = true; 
+	boolean scriptToConsole = true;
+	boolean schemaUpdate = false;
+	String delimiter = ";"; 
+	boolean drop = false;
+	boolean create = true;
+	boolean format = false;
+	
+	String outputFileName = null;
+	private boolean haltOnError = false;
+	
+	public Hbm2DDLExporterTask(HibernateToolTask parent) {
+		super(parent);
+	}
+	
+	public String getName() {
+		return "hbm2ddl (Generates database schema)";
+	}
+
+	protected Exporter configureExporter(Exporter exp) {
+		Hbm2DDLExporter exporter = (Hbm2DDLExporter) exp;
+		super.configureExporter( exp );
+		exporter.setExport(exportToDatabase);
+		exporter.setConsole(scriptToConsole);
+		exporter.setUpdate(schemaUpdate);
+		exporter.setDelimiter(delimiter);
+		exporter.setDrop(drop);
+		exporter.setCreate(create);
+		exporter.setFormat(format);
+		exporter.setOutputFileName(outputFileName);
+		exporter.setHaltonerror(haltOnError);		
+		return exporter;
+	}
+
+	protected Exporter createExporter() {
+		Hbm2DDLExporter exporter = new Hbm2DDLExporter();
+		exporter.getProperties().putAll(parent.getProperties());
+		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getProperties());
+		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, parent.getDestDir());
+		return exporter;
+	}
+
+	
+	public void setExport(boolean export) {
+		exportToDatabase = export;
+	}
+	
+	/**
+	 * Run SchemaUpdate instead of SchemaExport
+	 */
+	public void setUpdate(boolean update) {
+		this.schemaUpdate = update;
+	}
+	
+	/**
+	 * Output sql to console ? (default true)
+	 */
+	public void setConsole(boolean console) {
+		this.scriptToConsole = console;
+	}
+	
+	/**
+	 * Format the generated sql
+	 */
+	public void setFormat(boolean format) {
+		this.format = format;
+	}
+	
+	/**
+	 * File out put name (default: empty) 
+	 */
+	public void setOutputFileName(String fileName) {
+		outputFileName = fileName;
+	}
+
+	public void setDrop(boolean drop) {
+		this.drop = drop;
+	}
+	
+	public void setCreate(boolean create) {
+		this.create = create;
+	}
+	
+	public void setDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+	}
+	
+	public String getDelimiter() {
+		return delimiter;
+	}
+	
+	public void setHaltonerror(boolean haltOnError) {
+		this.haltOnError  = haltOnError;
+	}
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2DocExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2DocExporterTask.java
@@ -1,0 +1,23 @@
+/*
+ * Created on 25-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.internal.export.doc.DocExporter;
+
+public class Hbm2DocExporterTask extends ExporterTask {
+
+	public Hbm2DocExporterTask(HibernateToolTask parent) {
+		super(parent);
+	}
+
+	public String getName() {
+		return "hbm2doc (Generates html schema documentation)";
+	}
+
+	protected Exporter createExporter() {
+		return new DocExporter();
+	}
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2HbmXmlExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2HbmXmlExporterTask.java
@@ -1,0 +1,23 @@
+/*
+ * Created on 25-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+
+public class Hbm2HbmXmlExporterTask extends ExporterTask {
+
+	public Hbm2HbmXmlExporterTask(HibernateToolTask parent) {
+		super(parent);
+	}
+
+	protected Exporter createExporter() {
+		return new HibernateMappingExporter();
+	}	
+	
+	public String getName() {
+		return "hbm2hbmxml (Generates a set of hbm.xml files)";
+	}
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2JavaExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/Hbm2JavaExporterTask.java
@@ -1,0 +1,47 @@
+/*
+ * Created on 14-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
+
+/**
+ * @author max
+ * 
+ */
+public class Hbm2JavaExporterTask extends ExporterTask {
+
+	boolean ejb3 = false;
+
+	boolean jdk5 = false;
+
+	public Hbm2JavaExporterTask(HibernateToolTask parent) {
+		super( parent );
+	}
+
+	public void setEjb3(boolean b) {
+		ejb3 = b;
+	}
+
+	public void setJdk5(boolean b) {
+		jdk5 = b;
+	}
+
+	protected Exporter configureExporter(Exporter exp) {
+		super.configureExporter( exp );
+        exp.getProperties().setProperty("ejb3", ""+ejb3);
+        exp.getProperties().setProperty("jdk5", ""+jdk5);
+		return exp;
+	}
+
+	protected Exporter createExporter() {
+		return ExporterFactory.createExporter(ExporterType.POJO);
+	}
+
+	public String getName() {
+		return "hbm2java (Generates a set of .java files)";
+	}
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/HbmLintExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/HbmLintExporterTask.java
@@ -1,0 +1,21 @@
+package org.hibernate.tool.ant.old;
+
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.internal.export.lint.HbmLintExporter;
+
+public class HbmLintExporterTask extends ExporterTask {
+
+	public HbmLintExporterTask(HibernateToolTask parent) {
+		super( parent );
+	}
+
+	protected Exporter createExporter() {
+		return new HbmLintExporter();
+	}
+		
+
+	String getName() {
+		return "hbmlint (scans mapping for errors)";
+	}
+
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/HibernateToolTask.java
@@ -1,0 +1,312 @@
+/*
+ * Created on 13-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.tools.ant.AntClassLoader;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.types.Environment;
+import org.apache.tools.ant.types.Path;
+import org.apache.tools.ant.types.PropertySet;
+import org.hibernate.boot.MappingNotFoundException;
+import org.hibernate.boot.jaxb.Origin;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.hibernate.tool.internal.util.StringUtil;
+
+/**
+ * @author max
+ *
+ */
+public class HibernateToolTask extends Task {
+
+	public HibernateToolTask() {
+		super();
+	}
+	ConfigurationTask configurationTask;
+	private File destDir;
+	private List<ExporterTask> generators = new ArrayList<ExporterTask>();
+	private Path classPath;
+	private Path templatePath;
+	private Properties properties = new Properties(); 	
+	
+	private void checkConfiguration() {
+		if(configurationTask!=null) {
+			throw new BuildException("Only a single configuration is allowed.");
+		}
+	}
+
+	public ConfigurationTask createConfiguration() {
+		checkConfiguration();
+		configurationTask = new ConfigurationTask();
+		return configurationTask;			
+	}
+	
+
+	public JDBCConfigurationTask createJDBCConfiguration() {
+		checkConfiguration();
+		configurationTask = new JDBCConfigurationTask();
+		return (JDBCConfigurationTask) configurationTask;			
+	}
+	
+	public JPAConfigurationTask createJpaConfiguration() {
+		checkConfiguration();
+		configurationTask = new JPAConfigurationTask();
+		return (JPAConfigurationTask) configurationTask;			
+	}	
+	
+	public ExporterTask createHbm2DDL() {
+		ExporterTask generator = new Hbm2DDLExporterTask(this);
+		addGenerator( generator );
+		return generator;
+	}
+	
+	public ExporterTask createHbmTemplate() {
+		ExporterTask generator = new GenericExporterTask(this);
+		addGenerator( generator );
+		return generator;
+	}
+	
+	public ExporterTask createHbm2CfgXml() {
+		ExporterTask generator = new Hbm2CfgXmlExporterTask(this);
+		addGenerator( generator );
+		
+		return generator;
+	}
+
+	protected boolean addGenerator(ExporterTask generator) {
+		return generators.add(generator);
+	}
+	
+	public ExporterTask createHbm2Java() {
+		ExporterTask generator = new Hbm2JavaExporterTask(this);
+		addGenerator( generator );
+		return generator;
+	}
+	
+    public ExporterTask createHbm2HbmXml() {
+        ExporterTask generator= new Hbm2HbmXmlExporterTask(this);
+        addGenerator( generator );
+        return generator;
+    }
+    
+	public ExporterTask createHbm2Doc() {
+        ExporterTask generator= new Hbm2DocExporterTask(this);
+        addGenerator( generator );
+        return generator;
+    }
+	
+	/*public ExporterTask createHbm2Jsf(){
+        ExporterTask generator= new Hbm2JsfGeneratorTask(this);
+        generators.add(generator);
+        return generator;
+	}*/
+	
+	public ExporterTask createHbm2DAO(){
+        ExporterTask generator= new Hbm2DAOExporterTask(this);
+        addGenerator( generator );
+        return generator;
+	}
+	
+	
+	public QueryExporterTask createQuery() {
+		QueryExporterTask generator = new QueryExporterTask(this);
+		generators.add(generator);
+		return generator;
+	}
+	
+	public HbmLintExporterTask createHbmLint() {
+		HbmLintExporterTask generator = new HbmLintExporterTask(this);
+		generators.add(generator);
+		return generator;
+	}
+	
+	
+	/**
+     * Set the classpath to be used when running the Java class
+     *
+     * @param s an Ant Path object containing the classpath.
+     */
+    public void setClasspath(Path s) {
+		classPath = s;
+    }
+    
+    
+    /**
+     * Adds a path to the classpath.
+     *
+     * @return created classpath
+     */
+    public Path createClasspath() {
+		classPath = new Path(getProject() );
+		return classPath;
+    }
+
+	
+	public void execute() {
+		if(configurationTask==null) {
+			throw new BuildException("No configuration specified. <" + getTaskName() + "> must have one of the following: <configuration>, <jpaconfiguration>, <annotationconfiguration> or <jdbcconfiguration>");
+		}
+		log("Executing Hibernate Tool with a " + configurationTask.getDescription() );
+		validateParameters();
+		Iterator<ExporterTask> iterator = generators.iterator();
+		
+		AntClassLoader loader = getProject().createClassLoader(classPath);
+		
+		ExporterTask generatorTask = null;
+		int count = 1;
+		try {
+			ClassLoader classLoader = this.getClass().getClassLoader();
+			loader.setParent(classLoader ); // if this is not set, classes from the taskdef cannot be found - which is crucial for e.g. annotations.
+			loader.setThreadContextLoader();
+			
+			while (iterator.hasNext() ) {				
+				generatorTask = iterator.next();
+				log(count++ + ". task: " + generatorTask.getName() );
+				generatorTask.execute();			
+			}
+		} catch (RuntimeException re) {
+			reportException(re, count, generatorTask);
+		} 
+		finally {
+			if (loader != null) {
+				loader.resetThreadContextLoader();
+				loader.cleanup();
+			}            
+		}
+	}
+
+	private void reportException(Throwable re, int count, ExporterTask generatorTask) {
+		log("An exception occurred while running exporter #" + count + ":" + generatorTask.getName(), Project.MSG_ERR);
+		log("To get the full stack trace run ant with -verbose", Project.MSG_ERR);
+		
+		log(re.toString(), Project.MSG_ERR);
+		String ex = new String();
+		Throwable cause = re.getCause();
+		while(cause!=null) {
+			ex += cause.toString() + "\n";
+			if(cause==cause.getCause()) {
+				break; // we reached the top.
+			} else {
+				cause=cause.getCause();
+			}
+		}
+		if(StringUtil.isNotEmpty(ex)) {
+			log(ex, Project.MSG_ERR);
+		}
+
+		String newbieMessage = getProbableSolutionOrCause(re);
+		if(newbieMessage!=null) {
+			log(newbieMessage);
+		} 		
+		
+		if(re instanceof BuildException) {
+			throw (BuildException)re;
+		} else {
+			throw new BuildException(re, getLocation());
+		}
+	}
+
+	private String getProbableSolutionOrCause(Throwable re) {
+		if(re==null) return null;
+		
+		if(re instanceof MappingNotFoundException) {
+			MappingNotFoundException mnf = (MappingNotFoundException)re;
+			Origin origin = mnf.getOrigin();
+			return "A " + origin.getType() + " located at " + origin.getName() + " was not found.\n" +
+				"Check the following:\n" +
+				"\n" +
+				"1) Is the spelling/casing correct ?\n" +
+				"2)	Is " + mnf.getOrigin().getName() + " available via the classpath ?\n" +
+				"3) Does it actually exist ?\n";						
+		}
+
+		if(re instanceof ClassNotFoundException || re instanceof NoClassDefFoundError) {
+			
+			return "A class were not found in the classpath of the Ant task.\n" +
+					"Ensure that the classpath contains the classes needed for Hibernate and your code are in the classpath.\n"; 			
+			
+		}
+		
+		if(re instanceof UnsupportedClassVersionError) {
+			return "You are most likely running the ant task with a JRE that is older than the JRE required to use the classes.\n" +
+					"e.g. running with JRE 1.3 or 1.4 when using JDK 1.5 annotations is not possible.\n" +
+					"Ensure that you are using a correct JRE.";
+		}
+		
+		
+		
+		if(re.getCause()!=re) {
+			return getProbableSolutionOrCause( re.getCause() );					
+		}
+		
+		return null;
+	}
+
+	private void validateParameters() {
+		if(generators.isEmpty()) {
+			throw new BuildException("No exporters specified in <hibernatetool>. There has to be at least one specified. An exporter is e.g. <hbm2java> or <hbmtemplate>. See documentation for details.", getLocation());
+		} else {
+			Iterator<ExporterTask> iterator = generators.iterator();
+			
+			while (iterator.hasNext() ) {
+				ExporterTask generatorTask = iterator.next();
+				generatorTask.validateParameters();			
+			}
+		}
+	}
+
+	/**
+	 * @return
+	 */
+	public File getDestDir() {
+		return destDir;
+	}
+	
+	public void setDestDir(File file) {
+		destDir = file;
+	}
+
+	/**
+	 * @return
+	 */
+	public MetadataDescriptor getMetadataDescriptor() {
+		return configurationTask.getMetadataDescriptor();
+	}
+	
+	public void setTemplatePath(Path path) {
+		templatePath = path;
+	}
+	
+	public Path getTemplatePath() {
+		if(templatePath==null) {
+			templatePath = new Path(getProject()); // empty path
+		}
+		return templatePath;
+	}
+
+	public Properties getProperties() {
+		Properties p = new Properties();
+		p.putAll(getMetadataDescriptor().getProperties());
+		p.putAll(properties);
+		return p;
+	}
+	
+	public void addConfiguredPropertySet(PropertySet ps) {
+		properties.putAll(ps.getProperties());
+	}
+	
+	public void addConfiguredProperty(Environment.Variable property) {
+		properties.put(property.getKey(), property.getValue());
+	}
+	
+	
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/JDBCConfigurationTask.java
@@ -1,0 +1,132 @@
+/*
+ * Created on 15-Feb-2005
+ *
+ */
+package org.hibernate.tool.ant.old;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.util.Properties;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.types.Path;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
+import org.hibernate.tool.internal.util.ReflectHelper;
+
+
+/**
+ * @author max
+ * @author <a href='mailto:the_mindstorm@evolva.ro'>Alexandru Popescu</a>
+ */
+public class JDBCConfigurationTask extends ConfigurationTask {
+	//not expfosed here.
+    private boolean preferBasicCompositeIds = true;
+    
+    private String reverseEngineeringStrategyClass;
+    private String packageName;
+	private Path revengFiles;
+
+	private boolean detectOneToOne = true;
+	private boolean detectManyToMany = true;
+	private boolean detectOptimisticLock = true;
+    
+	public JDBCConfigurationTask() {
+		setDescription("JDBC Configuration (for reverse engineering)");
+	}
+	protected MetadataDescriptor createMetadataDescriptor() {
+		Properties properties = loadPropertiesFile();
+		ReverseEngineeringStrategy res = createReverseEngineeringStrategy();
+		properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
+		return MetadataDescriptorFactory
+				.createJdbcDescriptor(
+						res, 
+						properties);
+	}
+	
+	private ReverseEngineeringStrategy createReverseEngineeringStrategy() {
+		File[] revengFileList = null;
+		if (revengFiles != null ) {
+			String[] fileNames = revengFiles.list();
+			revengFileList = new File[fileNames.length];
+			for (int i = 0; i < fileNames.length; i++) {
+				revengFileList[i] = new File(fileNames[i]);
+			}
+		}
+
+		ReverseEngineeringStrategy strategy = 
+				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
+						null, revengFileList);
+		
+		if(reverseEngineeringStrategyClass!=null) {
+			strategy = loadreverseEngineeringStrategy(reverseEngineeringStrategyClass, strategy);			
+		}
+		
+		ReverseEngineeringSettings qqsettings = 
+			new ReverseEngineeringSettings(strategy).setDefaultPackageName(packageName)
+			.setDetectManyToMany( detectManyToMany )
+			.setDetectOneToOne( detectOneToOne )
+			.setDetectOptimisticLock( detectOptimisticLock );
+	
+		strategy.setSettings(qqsettings);
+		
+		return strategy;
+	}
+
+    
+    public void setPackageName(String pkgName) {
+        packageName = pkgName;
+    }
+    
+    public void setReverseStrategy(String fqn) {
+        reverseEngineeringStrategyClass = fqn;
+    }
+    
+	public void setRevEngFile(Path p) {
+		revengFiles = p;		
+	}
+	
+	public void setPreferBasicCompositeIds(boolean b) {
+		preferBasicCompositeIds = b;
+	}
+	
+	public void setDetectOneToOne(boolean b) {
+		detectOneToOne = b;
+	}
+	
+	public void setDetectManyToMany(boolean b) {
+		detectManyToMany = b;
+	}
+	
+	public void setDetectOptimisticLock(boolean b) {
+		detectOptimisticLock = b;
+	}
+	
+    private ReverseEngineeringStrategy loadreverseEngineeringStrategy(final String className, ReverseEngineeringStrategy delegate) 
+    throws BuildException {
+        try {
+            Class<?> clazz = ReflectHelper.classForName(className);			
+			Constructor<?> constructor = clazz.getConstructor(new Class[] { ReverseEngineeringStrategy.class });
+            return (ReverseEngineeringStrategy) constructor.newInstance(new Object[] { delegate }); 
+        } 
+        catch (NoSuchMethodException e) {
+			try {
+				getProject().log("Could not find public " + className + "(ReverseEngineeringStrategy delegate) constructor on ReverseEngineeringStrategy. Trying no-arg version.",Project.MSG_VERBOSE);			
+				Class<?> clazz = ReflectHelper.classForName(className);						
+				ReverseEngineeringStrategy rev = (ReverseEngineeringStrategy) clazz.newInstance();
+				getProject().log("Using non-delegating strategy, thus packagename and revengfile will be ignored.", Project.MSG_INFO);
+				return rev;
+			} 
+			catch (Exception eq) {
+				throw new BuildException("Could not create or find " + className + " with default no-arg constructor", eq);
+			}
+		} 
+        catch (Exception e) {
+			throw new BuildException("Could not create or find " + className + " with one argument delegate constructor", e);
+		} 
+    }
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/JPAConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/JPAConfigurationTask.java
@@ -1,0 +1,57 @@
+package org.hibernate.tool.ant.old;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.apache.tools.ant.BuildException;
+import org.hibernate.HibernateException;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+
+public class JPAConfigurationTask extends ConfigurationTask {
+	
+	private String persistenceUnit = null;
+
+	public JPAConfigurationTask() {
+		setDescription("JPA Configuration");
+	}
+	
+	protected MetadataDescriptor createMetadataDescriptor() {
+		try {
+			Properties overrides = new Properties();
+			Properties p = loadPropertiesFile();	
+			if(p!=null) {
+				overrides.putAll( p );
+			}
+			return MetadataDescriptorFactory
+					.createJpaDescriptor(persistenceUnit, overrides);
+		} 
+		catch(HibernateException t) {
+			Throwable cause = t.getCause();
+			if (cause != null) {
+				throw new BuildException(cause);
+			} else {
+				throw new BuildException("Problems in creating a configuration for JPA. Have you remembered to add hibernate EntityManager jars to the classpath ?",t);	
+			}
+		}
+		
+	}
+	
+	public String getPersistenceUnit() {
+		return persistenceUnit;
+	}
+	
+	public void setPersistenceUnit(String persistenceUnit) {
+		this.persistenceUnit = persistenceUnit;
+	}
+	
+	public void setConfigurationFile(File configurationFile) {
+		complain("configurationfile");
+	}
+
+	private void complain(String param) {
+		throw new BuildException("<" + getTaskName() + "> currently only support autodiscovery from META-INF/persistence.xml. Thus setting the " + param + " attribute is not allowed");
+	}
+	
+	
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/JavaFormatterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/JavaFormatterTask.java
@@ -1,0 +1,122 @@
+package org.hibernate.tool.ant.old;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.types.FileSet;
+import org.hibernate.tool.api.java.Formatter;
+
+public class JavaFormatterTask extends Task {
+	
+	private List<FileSet> fileSets = new ArrayList<FileSet>();
+	private boolean failOnError;
+	private File configurationFile;
+	
+	public void addConfiguredFileSet(FileSet fileSet) {
+		fileSets.add(fileSet);
+	}
+
+	public void setConfigurationFile(File configurationFile) {
+		this.configurationFile = configurationFile;
+	}
+	
+	private Properties readConfig(File cfgfile) throws IOException {
+		BufferedInputStream stream = null;
+		try {
+			stream = new BufferedInputStream(new FileInputStream(cfgfile));
+			final Properties settings = new Properties();
+			settings.load(stream);
+			return settings;
+		} catch (IOException e) {
+			throw e;
+		} finally {
+			if (stream != null) {
+				try {
+					stream.close();
+				} catch (IOException e) {
+					
+				}
+			}
+		}		
+	}
+
+	
+	public void execute() throws BuildException {
+		
+		Map<Object, Object> settings = null;
+		if(configurationFile!=null) {
+			 try {
+				settings = readConfig( configurationFile );
+			}
+			catch (IOException e) {
+				throw new BuildException("Could not read configurationfile " + configurationFile, e);
+			}
+		}
+		
+		File[] files = getFiles();
+		
+		int failed = 0;
+	
+		if(files.length>0) {
+			
+			Formatter formatter = new Formatter(settings);
+			for (int i = 0; i < files.length; i++) {
+				File file = files[i];			
+				try {
+					boolean ok = formatter.formatFile( file );
+					if(!ok) {
+						failed++;
+						getProject().log(this, "Formatting failed - skipping " + file, Project.MSG_WARN);						
+					} else {
+						getProject().log(this, "Formatted " + file, Project.MSG_VERBOSE);
+					}
+				} catch(RuntimeException ee) {
+					failed++;
+					if(failOnError) {
+						throw new BuildException("Java formatting failed on " + file, ee);
+					} else {
+						getProject().log(this, "Java formatting failed on " + file + ", " + ee.getLocalizedMessage(), Project.MSG_ERR);
+					}
+				}
+			}			
+		}
+		
+		getProject().log( this, "Java formatting of " + files.length + " files completed. Skipped " + failed + " file(s).", Project.MSG_INFO );
+		
+	}
+
+	private File[] getFiles() {
+
+		List<File> files = new LinkedList<File>();
+		for ( Iterator<FileSet> i = fileSets.iterator(); i.hasNext(); ) {
+
+			FileSet fs = i.next();
+			DirectoryScanner ds = fs.getDirectoryScanner( getProject() );
+
+			String[] dsFiles = ds.getIncludedFiles();
+			for (int j = 0; j < dsFiles.length; j++) {
+				File f = new File(dsFiles[j]);
+				if ( !f.isFile() ) {
+					f = new File( ds.getBasedir(), dsFiles[j] );
+				}
+
+				files.add( f );
+			}
+		}
+
+		return (File[]) files.toArray(new File[files.size()]);
+	}
+
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/old/QueryExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/old/QueryExporterTask.java
@@ -1,0 +1,96 @@
+package org.hibernate.tool.ant.old;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.tools.ant.BuildException;
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.internal.export.query.QueryExporter;
+import org.hibernate.internal.util.StringHelper;
+
+public class QueryExporterTask extends ExporterTask {
+
+	private String query = "";
+	private String filename;
+	List<HQL> queries = new ArrayList<HQL>();
+
+	public QueryExporterTask(HibernateToolTask parent) {
+		super( parent );		
+	}
+
+	protected Exporter configureExporter(Exporter exp) {
+		QueryExporter exporter = (QueryExporter) exp;
+		List<String> queryStrings = new ArrayList<String>();
+		if(StringHelper.isNotEmpty(query)) {
+			queryStrings.add(query);
+		}
+		for (Iterator<HQL> iter = queries.iterator(); iter.hasNext();) {
+			HQL hql = iter.next();
+			if(StringHelper.isNotEmpty(hql.query)) {
+				queryStrings.add(hql.query);
+			}
+		}
+		exporter.setQueries(queryStrings);
+		exporter.setFilename(filename);
+		super.configureExporter( exp );		
+        return exporter;
+	}
+
+	public void validateParameters() {
+		super.validateParameters();
+		if(StringHelper.isEmpty(query) && queries.isEmpty()) {
+			throw new BuildException("Need to specify at least one query.");
+		}
+		
+		for (Iterator<HQL> iter = queries.iterator(); iter.hasNext();) {
+			HQL hql = iter.next();
+			if(StringHelper.isEmpty(hql.query)) {
+				throw new BuildException("Query must not be empty");
+			}
+		}
+	}
+	protected Exporter createExporter() {
+		QueryExporter exporter = new QueryExporter();
+		return exporter;
+	}
+
+	public void addText(String text) {
+		if(StringHelper.isNotEmpty(text)) {
+		  query += trim(text);
+		}
+	}
+	
+	static private String trim(String text) {
+		return text.trim();
+	}
+
+	public static class HQL {
+		String query = "";
+		public void addText(String text) {
+			if(StringHelper.isNotEmpty(text)) {
+				query += trim(text);
+			}
+		}		
+	}
+	
+	public HQL createHql() {
+		HQL hql = new HQL();
+		queries.add(hql);
+		return hql;
+	}
+	
+	public void setDestFile(String filename) {
+		this.filename = filename;
+	}
+	 
+	public void execute() {
+		parent.log("Executing: [" + query + "]");
+		super.execute();
+	}
+	public String getName() {
+		return "query (Executes queries)";
+	}
+	
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>