### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Move the new ant tasks to package 'org.hibernate.tool.ant.fresh' for now

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ExportDdlTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExportDdlTask.java
@@ -1,5 +1,0 @@
-package org.hibernate.tool.ant;
-
-public class ExportDdlTask {
-
-}

--- a/ant/src/main/java/org/hibernate/tool/ant/fresh/ExportCfgTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/fresh/ExportCfgTask.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant;
+package org.hibernate.tool.ant.fresh;
 
 import java.io.File;
 import java.nio.file.Path;

--- a/ant/src/main/java/org/hibernate/tool/ant/fresh/ExportDdlTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/fresh/ExportDdlTask.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.ant.fresh;
+
+public class ExportDdlTask {
+
+}

--- a/ant/src/main/java/org/hibernate/tool/ant/fresh/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/fresh/HibernateToolTask.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant;
+package org.hibernate.tool.ant.fresh;
 
 import org.hibernate.tool.api.export.ExporterConstants;
 

--- a/ant/src/main/java/org/hibernate/tool/ant/fresh/MetadataTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/fresh/MetadataTask.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant;
+package org.hibernate.tool.ant.fresh;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/ant/src/test/java/org/hibernate/tool/ant/fresh/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/fresh/ExportCfgTaskTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant;
+package org.hibernate.tool.ant.fresh;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -12,6 +12,8 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 import org.apache.tools.ant.types.Environment.Variable;
+import org.hibernate.tool.ant.fresh.ExportCfgTask;
+import org.hibernate.tool.ant.fresh.HibernateToolTask;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;

--- a/ant/src/test/java/org/hibernate/tool/ant/fresh/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/fresh/HibernateToolTaskTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant;
+package org.hibernate.tool.ant.fresh;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -7,6 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.tool.ant.fresh.ExportCfgTask;
+import org.hibernate.tool.ant.fresh.ExportDdlTask;
+import org.hibernate.tool.ant.fresh.HibernateToolTask;
+import org.hibernate.tool.ant.fresh.MetadataTask;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.junit.jupiter.api.Test;

--- a/ant/src/test/java/org/hibernate/tool/ant/fresh/MetadataTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/fresh/MetadataTaskTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant;
+package org.hibernate.tool.ant.fresh;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -13,7 +13,8 @@ import java.util.ArrayList;
 
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.selectors.FilenameSelector;
-import org.hibernate.tool.ant.MetadataTask.Type;
+import org.hibernate.tool.ant.fresh.MetadataTask;
+import org.hibernate.tool.ant.fresh.MetadataTask.Type;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/ant/src/test/java/org/hibernate/tool/ant/test/it/BasicHibernateToolTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/test/it/BasicHibernateToolTest.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Target;
 import org.apache.tools.ant.Task;
-import org.hibernate.tool.ant.HibernateToolTask;
+import org.hibernate.tool.ant.fresh.HibernateToolTask;
 import org.hibernate.tool.ant.test.util.ProjectUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -26,7 +26,7 @@ public class BasicHibernateToolTest {
 				"<project name='HibernateToolTaskTest'>                       " +
 				"  <taskdef                                                   " +
                 "      name='hibernatetool'                                   " +
-				"      classname='org.hibernate.tool.ant.HibernateToolTask' />" +
+				"      classname='org.hibernate.tool.ant.fresh.HibernateToolTask' />" +
 		        "  <target name='testHibernateToolTask'>                      " +
 				"    <hibernatetool/>                                         " +
 		        "  </target>                                                  " +

--- a/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataCfgTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataCfgTest.java
@@ -50,7 +50,7 @@ public class NativeMetadataCfgTest {
 				"<project name='HibernateToolTaskTest'>                       " +
 				"  <taskdef                                                   " +
                 "      name='hibernatetool'                                   " +
-				"      classname='org.hibernate.tool.ant.HibernateToolTask'/> " +
+				"      classname='org.hibernate.tool.ant.fresh.HibernateToolTask'/> " +
 		        "  <target name='testNativeMetadataExportCfg'>                " +
 				"    <hibernatetool>                                          " +
 				"      <metadata                                              " +

--- a/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataDdlTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataDdlTest.java
@@ -32,7 +32,7 @@ public class NativeMetadataDdlTest {
 				"<project name='NativeMetadataDdlTest'>                       " +
 				"  <taskdef                                                   " +
                 "      name='hibernatetool'                                   " +
-				"      classname='org.hibernate.tool.ant.HibernateToolTask'/> " +
+				"      classname='org.hibernate.tool.ant.fresh.HibernateToolTask'/> " +
 		        "  <target name='testNativeMetadataExportDdl'>                " +
 				"    <hibernatetool>                                          " +
 				"      <metadata                                              " +


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>