### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Move the old ant tasks from 'org.hibernate.tool.ant.old' back to 'org.hibernate.tool.ant' for now

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/ConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ConfigurationTask.java
@@ -2,7 +2,7 @@
  * Created on 13-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/ant/src/main/java/org/hibernate/tool/ant/ExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/ExporterTask.java
@@ -2,7 +2,7 @@
  * Created on 13-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import java.io.File;
 import java.util.Properties;

--- a/ant/src/main/java/org/hibernate/tool/ant/GenericExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/GenericExporterTask.java
@@ -2,7 +2,7 @@
  * Created on 14-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;

--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
@@ -2,7 +2,7 @@
  * Created on 25-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;

--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;

--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -2,7 +2,7 @@
  * Created on 13-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;

--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DocExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DocExporterTask.java
@@ -2,7 +2,7 @@
  * Created on 25-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.internal.export.doc.DocExporter;

--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
@@ -2,7 +2,7 @@
  * Created on 25-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;

--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
@@ -2,7 +2,7 @@
  * Created on 14-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterFactory;

--- a/ant/src/main/java/org/hibernate/tool/ant/HbmLintExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HbmLintExporterTask.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.internal.export.lint.HbmLintExporter;

--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -2,7 +2,7 @@
  * Created on 13-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -2,7 +2,7 @@
  * Created on 15-Feb-2005
  *
  */
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import java.io.File;
 import java.lang.reflect.Constructor;

--- a/ant/src/main/java/org/hibernate/tool/ant/JPAConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JPAConfigurationTask.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import java.io.File;
 import java.util.Properties;

--- a/ant/src/main/java/org/hibernate/tool/ant/JavaFormatterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JavaFormatterTask.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import java.io.BufferedInputStream;
 import java.io.File;

--- a/ant/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.ant.old;
+package org.hibernate.tool.ant;
 
 import java.util.ArrayList;
 import java.util.Iterator;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>