### PR TITLE
HBX-1854: Move 'org.hibernate.tool.internal.util.ReflectHelper' in 'hibernate-tools-orm' to 'org.hibernate.tool.util.ReflectHelper' in 'hibernate-tools-utils'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/GenericExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/GenericExporterTask.java
@@ -7,7 +7,7 @@ package org.hibernate.tool.ant;
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.internal.export.common.GenericExporter;
-import org.hibernate.tool.internal.util.ReflectHelper;
+import org.hibernate.tool.util.ReflectHelper;
 
 /**
  * @author max

--- a/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -16,7 +16,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
-import org.hibernate.tool.internal.util.ReflectHelper;
+import org.hibernate.tool.util.ReflectHelper;
 
 
 /**

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -94,6 +94,10 @@
 			<artifactId>hibernate-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.hibernate.tool</groupId>
+			<artifactId>hibernate-tools-utils</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.hibernate.common</groupId>
 			<artifactId>hibernate-commons-annotations</artifactId>
 		</dependency>

--- a/orm/src/main/java/org/hibernate/tool/ant/GenericExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/GenericExporterTask.java
@@ -7,7 +7,7 @@ package org.hibernate.tool.ant;
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.internal.export.common.GenericExporter;
-import org.hibernate.tool.internal.util.ReflectHelper;
+import org.hibernate.tool.util.ReflectHelper;
 
 /**
  * @author max

--- a/orm/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -16,7 +16,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
-import org.hibernate.tool.internal.util.ReflectHelper;
+import org.hibernate.tool.util.ReflectHelper;
 
 
 /**

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterFactory.java
@@ -1,6 +1,6 @@
 package org.hibernate.tool.api.export;
 
-import org.hibernate.tool.internal.util.ReflectHelper;
+import org.hibernate.tool.util.ReflectHelper;
 
 public class ExporterFactory {
 	

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactory.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
-import org.hibernate.tool.internal.util.ReflectHelper;
+import org.hibernate.tool.util.ReflectHelper;
 
 public class ReverseEngineeringStrategyFactory {
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/H2MetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/H2MetaDataDialect.java
@@ -8,7 +8,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.internal.util.StringHelper;
-import org.hibernate.tool.internal.util.ReflectHelper;
+import org.hibernate.tool.util.ReflectHelper;
 
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,11 @@
         		<artifactId>hibernate-tools-tests-utils</artifactId>
         		<version>${project.version}</version>
         	</dependency>
+        	<dependency>
+        		<groupId>org.hibernate.tool</groupId>
+        		<artifactId>hibernate-tools-utils</artifactId>
+        		<version>${project.version}</version>
+        	</dependency>
             <dependency>
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>

--- a/utils/src/main/java/org/hibernate/tool/util/ReflectHelper.java
+++ b/utils/src/main/java/org/hibernate/tool/util/ReflectHelper.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.util;
+package org.hibernate.tool.util;
 
 public class ReflectHelper {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>