### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Use ExporterFactory#createExporter(ExporterType) to create CfgExporter

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
@@ -5,7 +5,8 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.cfg.CfgExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class Hbm2CfgXmlExporterTask extends ExporterTask {
 
@@ -16,7 +17,7 @@ public class Hbm2CfgXmlExporterTask extends ExporterTask {
 	}
 
 	public Exporter createExporter() {
-		return new CfgExporter();
+		return ExporterFactory.createExporter(ExporterType.CFG);
 	}
 
 	public void setEjb3(boolean ejb3) {
@@ -28,8 +29,9 @@ public class Hbm2CfgXmlExporterTask extends ExporterTask {
 	}
 	
 	protected Exporter configureExporter(Exporter exporter) {
-		CfgExporter hce = (CfgExporter)super.configureExporter( exporter );
-        hce.getProperties().setProperty("ejb3", ""+ejb3);
-		return hce;
+		super.configureExporter( exporter );
+        exporter.getProperties().setProperty("ejb3", ""+ejb3);
+		return exporter;
 	}
+
 }

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2CfgXmlExporterTask.java
@@ -5,7 +5,8 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.cfg.CfgExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class Hbm2CfgXmlExporterTask extends ExporterTask {
 
@@ -16,7 +17,7 @@ public class Hbm2CfgXmlExporterTask extends ExporterTask {
 	}
 
 	public Exporter createExporter() {
-		return new CfgExporter();
+		return ExporterFactory.createExporter(ExporterType.CFG);
 	}
 
 	public void setEjb3(boolean ejb3) {
@@ -28,8 +29,8 @@ public class Hbm2CfgXmlExporterTask extends ExporterTask {
 	}
 	
 	protected Exporter configureExporter(Exporter exporter) {
-		CfgExporter hce = (CfgExporter)super.configureExporter( exporter );
-        hce.getProperties().setProperty("ejb3", ""+ejb3);
-		return hce;
+		super.configureExporter( exporter );
+        exporter.getProperties().setProperty("ejb3", ""+ejb3);
+		return exporter;
 	}
 }

--- a/orm/src/main/java/org/hibernate/tool/internal/export/cfg/CfgExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/cfg/CfgExporter.java
@@ -30,8 +30,8 @@ public class CfgExporter extends AbstractExporter {
 
 	private Writer output;
     private Properties customProperties = new Properties();
-
-	public Properties getCustomProperties() {
+    
+ 	public Properties getCustomProperties() {
 		return customProperties;
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -25,7 +25,6 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
-import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.internal.export.doc.DocExporter;
 import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
@@ -99,7 +98,7 @@ public class TestCase {
 	
 	@Test
 	public void testGenerateCfgXml() throws DocumentException {	
-		Exporter exporter = new CfgExporter();
+		Exporter exporter = ExporterFactory.createExporter(ExporterType.CFG);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.start();				
@@ -124,8 +123,7 @@ public class TestCase {
 	
 	@Test
 	public void testGenerateAnnotationCfgXml() throws DocumentException {
-		CfgExporter exporter = 
-				new CfgExporter();
+		Exporter exporter = ExporterFactory.createExporter(ExporterType.CFG);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "true");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>