### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Use ExporterFactory#createExporter(ExporterType) to create DAOExporter

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
@@ -2,7 +2,8 @@ package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
-import org.hibernate.tool.internal.export.dao.DAOExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 /**
  * @author Dennis Byrne
@@ -13,14 +14,8 @@ public class Hbm2DAOExporterTask extends Hbm2JavaExporterTask {
 		super(parent);
 	}
 	
-	protected Exporter configureExporter(Exporter exp) {
-		DAOExporter exporter = (DAOExporter)exp;
-		super.configureExporter(exp);
-		return exporter;
-	}
-	
 	protected Exporter createExporter() {
-		Exporter result = new DAOExporter();
+		Exporter result = ExporterFactory.createExporter(ExporterType.DAO);
 		result.getProperties().putAll(parent.getProperties());
 		result.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getMetadataDescriptor());
 		result.getProperties().put(ExporterConstants.DESTINATION_FOLDER, getDestdir());

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DAOExporterTask.java
@@ -2,7 +2,8 @@ package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
-import org.hibernate.tool.internal.export.dao.DAOExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 /**
  * @author Dennis Byrne
@@ -13,14 +14,8 @@ public class Hbm2DAOExporterTask extends Hbm2JavaExporterTask {
 		super(parent);
 	}
 	
-	protected Exporter configureExporter(Exporter exp) {
-		DAOExporter exporter = (DAOExporter)exp;
-		super.configureExporter(exp);
-		return exporter;
-	}
-	
 	protected Exporter createExporter() {
-		Exporter result = new DAOExporter();
+		Exporter result = ExporterFactory.createExporter(ExporterType.DAO);
 		result.getProperties().putAll(parent.getProperties());
 		result.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getMetadataDescriptor());
 		result.getProperties().put(ExporterConstants.DESTINATION_FOLDER, getDestdir());

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.api.export;
 public enum ExporterType {
 	
 	CFG ("org.hibernate.tool.internal.export.cfg.CfgExporter"),
+	DAO ("org.hibernate.tool.internal.export.dao.DAOExporter"),
 	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
 	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
@@ -12,7 +12,6 @@ import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.internal.export.dao.DAOExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -51,7 +50,7 @@ public class TestCase {
 		Exporter javaExporter = ExporterFactory.createExporter(ExporterType.POJO);
 		javaExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		javaExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
-		Exporter exporter = new DAOExporter();
+		Exporter exporter = ExporterFactory.createExporter(ExporterType.DAO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "false");

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2EJBDaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2EJBDaoTest/TestCase.java
@@ -57,7 +57,7 @@ public class TestCase {
 		Exporter javaExporter = ExporterFactory.createExporter(ExporterType.POJO);;
 		javaExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		javaExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
-		Exporter exporter = new DAOExporter();
+		Exporter exporter = ExporterFactory.createExporter(ExporterType.DAO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "true");

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2HibernateDAOTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2HibernateDAOTest/TestCase.java
@@ -18,7 +18,6 @@ import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.internal.export.dao.DAOExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -57,7 +56,7 @@ public class TestCase {
 		Exporter javaExporter = ExporterFactory.createExporter(ExporterType.POJO);
 		javaExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		javaExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
-		Exporter exporter = new DAOExporter();
+		Exporter exporter = ExporterFactory.createExporter(ExporterType.DAO);
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.getProperties().setProperty("ejb3", "false");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>