### PR TITLE
HBX-1863: Rename 'org.hibernate.tool.internal.export.dao.DAOExporter' to 'org.hibernate.tool.internal.export.dao.DaoExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -3,7 +3,7 @@ package org.hibernate.tool.api.export;
 public enum ExporterType {
 	
 	CFG ("org.hibernate.tool.internal.export.cfg.CfgExporter"),
-	DAO ("org.hibernate.tool.internal.export.dao.DAOExporter"),
+	DAO ("org.hibernate.tool.internal.export.dao.DaoExporter"),
 	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
 	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/export/dao/DaoExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/dao/DaoExporter.java
@@ -5,13 +5,13 @@ import java.util.Map;
 import org.hibernate.tool.internal.export.pojo.POJOClass;
 import org.hibernate.tool.internal.export.pojo.POJOExporter;
 
-public class DAOExporter extends POJOExporter {
+public class DaoExporter extends POJOExporter {
 
     private static final String DAO_DAOHOME_FTL = "dao/daohome.ftl";
 
     private String sessionFactoryName = "SessionFactory";
 
-    public DAOExporter() {
+    public DaoExporter() {
     		super();
     }
     

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2EJBDaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2EJBDaoTest/TestCase.java
@@ -18,7 +18,7 @@ import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.internal.export.dao.DAOExporter;
+import org.hibernate.tool.internal.export.dao.DaoExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>