### PR TITLE
HBX-1871: Rename class 'org.hibernate.tool.internal.export.ddl.Hbm2DDLExporter' to 'org.hibernate.tool.internal.export.ddl.DdlExporter'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -6,7 +6,7 @@ package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
-import org.hibernate.tool.internal.export.ddl.Hbm2DDLExporter;
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
 
 /**
  * @author max
@@ -34,7 +34,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 	}
 
 	protected Exporter configureExporter(Exporter exp) {
-		Hbm2DDLExporter exporter = (Hbm2DDLExporter) exp;
+		DdlExporter exporter = (DdlExporter) exp;
 		super.configureExporter( exp );
 		exporter.setExport(exportToDatabase);
 		exporter.setConsole(scriptToConsole);
@@ -49,7 +49,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		Hbm2DDLExporter exporter = new Hbm2DDLExporter();
+		DdlExporter exporter = new DdlExporter();
 		exporter.getProperties().putAll(parent.getProperties());
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getProperties());
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, parent.getDestDir());

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -6,7 +6,7 @@ package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
-import org.hibernate.tool.internal.export.ddl.Hbm2DDLExporter;
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
 
 /**
  * @author max
@@ -34,7 +34,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 	}
 
 	protected Exporter configureExporter(Exporter exp) {
-		Hbm2DDLExporter exporter = (Hbm2DDLExporter) exp;
+		DdlExporter exporter = (DdlExporter) exp;
 		super.configureExporter( exp );
 		exporter.setExport(exportToDatabase);
 		exporter.setConsole(scriptToConsole);
@@ -49,7 +49,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		Hbm2DDLExporter exporter = new Hbm2DDLExporter();
+		DdlExporter exporter = new DdlExporter();
 		exporter.getProperties().putAll(parent.getProperties());
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, parent.getProperties());
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, parent.getDestDir());

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -4,7 +4,7 @@ public enum ExporterType {
 	
 	CFG ("org.hibernate.tool.internal.export.cfg.CfgExporter"),
 	DAO ("org.hibernate.tool.internal.export.dao.DaoExporter"),
-	DDL ("org.hibernate.tool.internal.export.ddl.Hbm2DDLExporter"),
+	DDL ("org.hibernate.tool.internal.export.ddl.DdlExporter"),
 	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
 	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
@@ -33,7 +33,7 @@ import org.hibernate.tool.schema.TargetType;
  * @author Vitali
  * 
  */
-public class Hbm2DDLExporter extends AbstractExporter {
+public class DdlExporter extends AbstractExporter {
 
 	protected boolean exportToDatabase = true; 
 	protected boolean scriptToConsole = true;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>