### PR TITLE
HBX-1872: Remove instance variables and setters from class 'org.hibernate.tool.internal.export.ddl.DdlExporter' - Remove DdlExporter#setExport(boolean)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -36,7 +36,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 	protected Exporter configureExporter(Exporter exp) {
 		DdlExporter exporter = (DdlExporter) exp;
 		super.configureExporter( exp );
-		exporter.setExport(exportToDatabase);
+		exporter.getProperties().put(ExporterConstants.EXPORT_TO_DATABASE, exportToDatabase);
 		exporter.setConsole(scriptToConsole);
 		exporter.setUpdate(schemaUpdate);
 		exporter.setDelimiter(delimiter);

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -36,7 +36,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 	protected Exporter configureExporter(Exporter exp) {
 		DdlExporter exporter = (DdlExporter) exp;
 		super.configureExporter( exp );
-		exporter.setExport(exportToDatabase);
+		exporter.getProperties().put(ExporterConstants.EXPORT_TO_DATABASE, exportToDatabase);
 		exporter.setConsole(scriptToConsole);
 		exporter.setUpdate(schemaUpdate);
 		exporter.setDelimiter(delimiter);

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
@@ -4,6 +4,7 @@ public interface ExporterConstants {
 	
 	public static final String ARTIFACT_COLLECTOR = "org.hibernate.tool.api.export.ExporterConstants.ArtifactCollector";
 	public static final String DESTINATION_FOLDER = "org.hibernate.tool.api.export.ExporterConstants.DestinationFolder";
+	public static final String EXPORT_TO_DATABASE = "org.hibernate.tool.api.export.ExporterConstants.ExportToDatabase";
 	public static final String FILE_PATTERN = "org.hibernate.tool.api.export.ExporterConstants.FilePattern";
 	public static final String FOR_EACH = "org.hibernate.tool.api.export.ExporterConstants.ForEach";
 	public static final String METADATA_DESCRIPTOR = "org.hibernate.tool.api.export.ExporterConstants.MetadataDescriptor";

--- a/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
@@ -35,7 +35,6 @@ import org.hibernate.tool.schema.TargetType;
  */
 public class DdlExporter extends AbstractExporter {
 
-	protected boolean exportToDatabase = true; 
 	protected boolean scriptToConsole = true;
 	protected boolean schemaUpdate = false;
 	protected String delimiter = ";";
@@ -54,7 +53,6 @@ public class DdlExporter extends AbstractExporter {
 	}
 
 	protected void setupContext() {
-		exportToDatabase = setupBoolProperty("exportToDatabase", exportToDatabase);
 		scriptToConsole = setupBoolProperty("scriptToConsole", scriptToConsole);
 		schemaUpdate = setupBoolProperty("schemaUpdate", schemaUpdate);
 		delimiter = getProperties().getProperty("delimiter", delimiter);
@@ -74,7 +72,7 @@ public class DdlExporter extends AbstractExporter {
 		Metadata metadata = getMetadata();
 		final EnumSet<TargetType> targetTypes = EnumSet.noneOf( TargetType.class );
 		if (scriptToConsole) targetTypes.add(TargetType.STDOUT);
-		if (exportToDatabase) targetTypes.add(TargetType.DATABASE);
+		if (getExportToDatabase()) targetTypes.add(TargetType.DATABASE);
 		if (null != outputFileName) targetTypes.add(TargetType.SCRIPT);
 		if (schemaUpdate) {
 			SchemaUpdate update = new SchemaUpdate();
@@ -136,10 +134,6 @@ public class DdlExporter extends AbstractExporter {
 	}
 
 
-	public void setExport(boolean export) {
-		exportToDatabase = export;
-	}
-
 	/**
 	 * Run SchemaUpdate instead of SchemaExport
 	 */
@@ -186,5 +180,13 @@ public class DdlExporter extends AbstractExporter {
 
 	public void setHaltonerror(boolean haltOnError) {
 		this.haltOnError = haltOnError;
+	}
+	
+	private boolean getExportToDatabase() {
+		if (!getProperties().containsKey(EXPORT_TO_DATABASE)) {
+			return true;
+		} else {
+			return (boolean)getProperties().get(EXPORT_TO_DATABASE);
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>