### PR TITLE
 HBX-1872: Remove instance variables and setters from class 'org.hibernate.tool.internal.export.ddl.DdlExporter' - Remove DdlExporter#setDrop(boolean)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -40,7 +40,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		exporter.getProperties().put(ExporterConstants.EXPORT_TO_CONSOLE, scriptToConsole);
 		exporter.getProperties().put(ExporterConstants.SCHEMA_UPDATE, schemaUpdate);
 		exporter.getProperties().put(ExporterConstants.DELIMITER, delimiter);
-		exporter.setDrop(drop);
+		exporter.getProperties().put(ExporterConstants.DROP_DATABASE, drop);
 		exporter.setCreate(create);
 		exporter.setFormat(format);
 		exporter.setOutputFileName(outputFileName);

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -40,7 +40,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		exporter.getProperties().put(ExporterConstants.EXPORT_TO_CONSOLE, scriptToConsole);
 		exporter.getProperties().put(ExporterConstants.SCHEMA_UPDATE, schemaUpdate);
 		exporter.getProperties().put(ExporterConstants.DELIMITER, delimiter);
-		exporter.setDrop(drop);
+		exporter.getProperties().put(ExporterConstants.DROP_DATABASE, drop);
 		exporter.setCreate(create);
 		exporter.setFormat(format);
 		exporter.setOutputFileName(outputFileName);

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
@@ -5,6 +5,7 @@ public interface ExporterConstants {
 	public static final String ARTIFACT_COLLECTOR = "org.hibernate.tool.api.export.ExporterConstants.ArtifactCollector";
 	public static final String DELIMITER = "org.hibernate.tool.api.export.ExporterConstants.Delimiter";
 	public static final String DESTINATION_FOLDER = "org.hibernate.tool.api.export.ExporterConstants.DestinationFolder";
+	public static final String DROP_DATABASE = "org.hibernate.tool.api.export.ExporterConstants.DropDatabase";
 	public static final String EXPORT_TO_CONSOLE = "org.hibernate.tool.api.export.ExporterConstants.ExportToConsole";
 	public static final String EXPORT_TO_DATABASE = "org.hibernate.tool.api.export.ExporterConstants.ExportToDatabase";
 	public static final String FILE_PATTERN = "org.hibernate.tool.api.export.ExporterConstants.FilePattern";

--- a/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
@@ -35,7 +35,6 @@ import org.hibernate.tool.schema.TargetType;
  */
 public class DdlExporter extends AbstractExporter {
 
-	protected boolean drop = false;
 	protected boolean create = true;
 	protected boolean format = false;
 
@@ -50,7 +49,6 @@ public class DdlExporter extends AbstractExporter {
 	}
 
 	protected void setupContext() {
-		drop = setupBoolProperty("drop", drop);
 		create = setupBoolProperty("create", create);
 		format = setupBoolProperty("format", format);
 		outputFileName = getProperties().getProperty("outputFileName", outputFileName);
@@ -114,9 +112,9 @@ public class DdlExporter extends AbstractExporter {
 			}
 			export.setHaltOnError(haltOnError);
 			export.setFormat(format);
-			if (drop && create) {
+			if (getDrop() && create) {
 				export.execute(targetTypes, Action.BOTH, metadata);
-			} else if (drop) {
+			} else if (getDrop()) {
 				export.execute(targetTypes, Action.DROP, metadata);
 			} else if (create) {
 				export.execute(targetTypes, Action.CREATE, metadata);
@@ -142,10 +140,6 @@ public class DdlExporter extends AbstractExporter {
 		outputFileName = fileName;
 	}
 
-	public void setDrop(boolean drop) {
-		this.drop = drop;
-	}
-
 	public void setCreate(boolean create) {
 		this.create = create;
 	}
@@ -167,6 +161,14 @@ public class DdlExporter extends AbstractExporter {
 			return true;
 		} else {
 			return (boolean)getProperties().get(EXPORT_TO_CONSOLE);
+		}
+	}
+	
+	private boolean getDrop() {
+		if (!getProperties().containsKey(DROP_DATABASE)) {
+			return false;
+		} else {
+			return (boolean)getProperties().get(DROP_DATABASE);
 		}
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>