### PR TITLE
HBX-1872: Remove instance variables and setters from class 'org.hibernate.tool.internal.export.ddl.DdlExporter' - Remove DdlExporter#setCreate(boolean)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -41,7 +41,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		exporter.getProperties().put(ExporterConstants.SCHEMA_UPDATE, schemaUpdate);
 		exporter.getProperties().put(ExporterConstants.DELIMITER, delimiter);
 		exporter.getProperties().put(ExporterConstants.DROP_DATABASE, drop);
-		exporter.setCreate(create);
+		exporter.getProperties().put(ExporterConstants.CREATE_DATABASE, create);
 		exporter.setFormat(format);
 		exporter.setOutputFileName(outputFileName);
 		exporter.setHaltonerror(haltOnError);		

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -41,7 +41,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		exporter.getProperties().put(ExporterConstants.SCHEMA_UPDATE, schemaUpdate);
 		exporter.getProperties().put(ExporterConstants.DELIMITER, delimiter);
 		exporter.getProperties().put(ExporterConstants.DROP_DATABASE, drop);
-		exporter.setCreate(create);
+		exporter.getProperties().put(ExporterConstants.CREATE_DATABASE, create);
 		exporter.setFormat(format);
 		exporter.setOutputFileName(outputFileName);
 		exporter.setHaltonerror(haltOnError);		

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.api.export;
 public interface ExporterConstants {
 	
 	public static final String ARTIFACT_COLLECTOR = "org.hibernate.tool.api.export.ExporterConstants.ArtifactCollector";
+	public static final String CREATE_DATABASE = "org.hibernate.tool.api.export.ExporterConstants.CreateDatabase";
 	public static final String DELIMITER = "org.hibernate.tool.api.export.ExporterConstants.Delimiter";
 	public static final String DESTINATION_FOLDER = "org.hibernate.tool.api.export.ExporterConstants.DestinationFolder";
 	public static final String DROP_DATABASE = "org.hibernate.tool.api.export.ExporterConstants.DropDatabase";

--- a/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
@@ -35,7 +35,6 @@ import org.hibernate.tool.schema.TargetType;
  */
 public class DdlExporter extends AbstractExporter {
 
-	protected boolean create = true;
 	protected boolean format = false;
 
 	protected String outputFileName = null;
@@ -49,7 +48,6 @@ public class DdlExporter extends AbstractExporter {
 	}
 
 	protected void setupContext() {
-		create = setupBoolProperty("create", create);
 		format = setupBoolProperty("format", format);
 		outputFileName = getProperties().getProperty("outputFileName", outputFileName);
 		haltOnError = setupBoolProperty("haltOnError", haltOnError);
@@ -112,11 +110,11 @@ public class DdlExporter extends AbstractExporter {
 			}
 			export.setHaltOnError(haltOnError);
 			export.setFormat(format);
-			if (getDrop() && create) {
+			if (getDrop() && getCreate()) {
 				export.execute(targetTypes, Action.BOTH, metadata);
 			} else if (getDrop()) {
 				export.execute(targetTypes, Action.DROP, metadata);
-			} else if (create) {
+			} else if (getCreate()) {
 				export.execute(targetTypes, Action.CREATE, metadata);
 			} else {
 				export.execute(targetTypes, Action.NONE, metadata);
@@ -141,7 +139,7 @@ public class DdlExporter extends AbstractExporter {
 	}
 
 	public void setCreate(boolean create) {
-		this.create = create;
+		getProperties().put(CREATE_DATABASE, create);
 	}
 
 	public void setHaltonerror(boolean haltOnError) {
@@ -161,6 +159,14 @@ public class DdlExporter extends AbstractExporter {
 			return true;
 		} else {
 			return (boolean)getProperties().get(EXPORT_TO_CONSOLE);
+		}
+	}
+	
+	private boolean getCreate() {
+		if (!getProperties().containsKey(CREATE_DATABASE)) {
+			return true;
+		} else {
+			return (boolean)getProperties().get(CREATE_DATABASE);
 		}
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>