### PR TITLE
HBX-1872: Remove instance variables and setters from class 'org.hibernate.tool.internal.export.ddl.DdlExporter' - Remove DdlExporter#setFormat(boolean)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -42,7 +42,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		exporter.getProperties().put(ExporterConstants.DELIMITER, delimiter);
 		exporter.getProperties().put(ExporterConstants.DROP_DATABASE, drop);
 		exporter.getProperties().put(ExporterConstants.CREATE_DATABASE, create);
-		exporter.setFormat(format);
+		exporter.getProperties().put(ExporterConstants.FORMAT, format);
 		exporter.setOutputFileName(outputFileName);
 		exporter.setHaltonerror(haltOnError);		
 		return exporter;

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -42,7 +42,7 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		exporter.getProperties().put(ExporterConstants.DELIMITER, delimiter);
 		exporter.getProperties().put(ExporterConstants.DROP_DATABASE, drop);
 		exporter.getProperties().put(ExporterConstants.CREATE_DATABASE, create);
-		exporter.setFormat(format);
+		exporter.getProperties().put(ExporterConstants.FORMAT, format);
 		exporter.setOutputFileName(outputFileName);
 		exporter.setHaltonerror(haltOnError);		
 		return exporter;

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
@@ -11,6 +11,7 @@ public interface ExporterConstants {
 	public static final String EXPORT_TO_DATABASE = "org.hibernate.tool.api.export.ExporterConstants.ExportToDatabase";
 	public static final String FILE_PATTERN = "org.hibernate.tool.api.export.ExporterConstants.FilePattern";
 	public static final String FOR_EACH = "org.hibernate.tool.api.export.ExporterConstants.ForEach";
+	public static final String FORMAT = "org.hibernate.tool.api.export.ExporterConstants.Format";
 	public static final String METADATA_DESCRIPTOR = "org.hibernate.tool.api.export.ExporterConstants.MetadataDescriptor";
 	public static final String SCHEMA_UPDATE = "org.hibernate.tool.api.export.ExporterConstants.SchemaUpdate";
 	public static final String TEMPLATE_NAME = "org.hibernate.tool.api.export.ExporterConstants.TemplateName";

--- a/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
@@ -35,8 +35,6 @@ import org.hibernate.tool.schema.TargetType;
  */
 public class DdlExporter extends AbstractExporter {
 
-	protected boolean format = false;
-
 	protected String outputFileName = null;
 	protected boolean haltOnError = false;
 
@@ -48,7 +46,6 @@ public class DdlExporter extends AbstractExporter {
 	}
 
 	protected void setupContext() {
-		format = setupBoolProperty("format", format);
 		outputFileName = getProperties().getProperty("outputFileName", outputFileName);
 		haltOnError = setupBoolProperty("haltOnError", haltOnError);
 		super.setupContext();
@@ -66,7 +63,7 @@ public class DdlExporter extends AbstractExporter {
 		if (null != outputFileName) targetTypes.add(TargetType.SCRIPT);
 		if (getSchemaUpdate()) {
 			SchemaUpdate update = new SchemaUpdate();
-			if(outputFileName == null && getDelimiter() == null && haltOnError && format)  {
+			if(outputFileName == null && getDelimiter() == null && haltOnError && getFormat())  {
 				update.execute(targetTypes, metadata);
 			}
 			else {				
@@ -75,7 +72,7 @@ public class DdlExporter extends AbstractExporter {
 					update.setOutputFile(outputFile.getPath());		
 					log.debug("delimiter ='"+ getDelimiter() + "'");
 					update.setDelimiter(getDelimiter());
-					update.setFormat(Boolean.valueOf(format));	
+					update.setFormat(Boolean.valueOf(getFormat()));	
 				}
 				
 				if (haltOnError) {
@@ -109,7 +106,7 @@ public class DdlExporter extends AbstractExporter {
 				export.setDelimiter(getDelimiter());
 			}
 			export.setHaltOnError(haltOnError);
-			export.setFormat(format);
+			export.setFormat(getFormat());
 			if (getDrop() && getCreate()) {
 				export.execute(targetTypes, Action.BOTH, metadata);
 			} else if (getDrop()) {
@@ -128,7 +125,7 @@ public class DdlExporter extends AbstractExporter {
 	 * Format the generated sql
 	 */
 	public void setFormat(boolean format) {
-		this.format = format;
+		getProperties().put(FORMAT, format);
 	}
 
 	/**
@@ -138,29 +135,10 @@ public class DdlExporter extends AbstractExporter {
 		outputFileName = fileName;
 	}
 
-	public void setCreate(boolean create) {
-		getProperties().put(CREATE_DATABASE, create);
-	}
-
 	public void setHaltonerror(boolean haltOnError) {
 		this.haltOnError = haltOnError;
 	}
 	
-	
-	private String getDelimiter() {
-		if (!getProperties().containsKey(DELIMITER)) {
-			return ";";
-		}
-		return (String)getProperties().get(DELIMITER);
-	}
-
-	private boolean getExportToConsole() {
-		if (!getProperties().containsKey(EXPORT_TO_CONSOLE)) {
-			return true;
-		} else {
-			return (boolean)getProperties().get(EXPORT_TO_CONSOLE);
-		}
-	}
 	
 	private boolean getCreate() {
 		if (!getProperties().containsKey(CREATE_DATABASE)) {
@@ -170,6 +148,13 @@ public class DdlExporter extends AbstractExporter {
 		}
 	}
 	
+	private String getDelimiter() {
+		if (!getProperties().containsKey(DELIMITER)) {
+			return ";";
+		}
+		return (String)getProperties().get(DELIMITER);
+	}
+
 	private boolean getDrop() {
 		if (!getProperties().containsKey(DROP_DATABASE)) {
 			return false;
@@ -178,11 +163,27 @@ public class DdlExporter extends AbstractExporter {
 		}
 	}
 	
+	private boolean getExportToConsole() {
+		if (!getProperties().containsKey(EXPORT_TO_CONSOLE)) {
+			return true;
+		} else {
+			return (boolean)getProperties().get(EXPORT_TO_CONSOLE);
+		}
+	}
+	
 	private boolean getExportToDatabase() {
 		if (!getProperties().containsKey(EXPORT_TO_DATABASE)) {
 			return true;
 		} else {
 			return (boolean)getProperties().get(EXPORT_TO_DATABASE);
+		}
+	}
+	
+	private boolean getFormat() {
+		if (!getProperties().containsKey(FORMAT)) {
+			return false;
+		} else {
+			return (boolean)getProperties().get(FORMAT);
 		}
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>