### PR TITLE
HBX-1872: Remove instance variables and setters from class 'org.hibernate.tool.internal.export.ddl.DdlExporter' - Remove DdlExporter#setOutputFileName(String)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -43,7 +43,11 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		exporter.getProperties().put(ExporterConstants.DROP_DATABASE, drop);
 		exporter.getProperties().put(ExporterConstants.CREATE_DATABASE, create);
 		exporter.getProperties().put(ExporterConstants.FORMAT, format);
-		exporter.setOutputFileName(outputFileName);
+		if (outputFileName == null) {
+			exporter.getProperties().remove(ExporterConstants.OUTPUT_FILE_NAME);
+		} else {
+			exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, outputFileName);
+		}
 		exporter.setHaltonerror(haltOnError);		
 		return exporter;
 	}

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DDLExporterTask.java
@@ -43,7 +43,11 @@ public class Hbm2DDLExporterTask extends ExporterTask {
 		exporter.getProperties().put(ExporterConstants.DROP_DATABASE, drop);
 		exporter.getProperties().put(ExporterConstants.CREATE_DATABASE, create);
 		exporter.getProperties().put(ExporterConstants.FORMAT, format);
-		exporter.setOutputFileName(outputFileName);
+		if (outputFileName == null) {
+			exporter.getProperties().remove(ExporterConstants.OUTPUT_FILE_NAME);
+		} else {
+			exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, outputFileName);
+		}
 		exporter.setHaltonerror(haltOnError);		
 		return exporter;
 	}

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
@@ -13,6 +13,7 @@ public interface ExporterConstants {
 	public static final String FOR_EACH = "org.hibernate.tool.api.export.ExporterConstants.ForEach";
 	public static final String FORMAT = "org.hibernate.tool.api.export.ExporterConstants.Format";
 	public static final String METADATA_DESCRIPTOR = "org.hibernate.tool.api.export.ExporterConstants.MetadataDescriptor";
+	public static final String OUTPUT_FILE_NAME = "org.hibernate.tool.api.export.ExporterConstants.OutputFileName";
 	public static final String SCHEMA_UPDATE = "org.hibernate.tool.api.export.ExporterConstants.SchemaUpdate";
 	public static final String TEMPLATE_NAME = "org.hibernate.tool.api.export.ExporterConstants.TemplateName";
 	public static final String TEMPLATE_PATH = "org.hibernate.tool.api.export.ExporterConstants.TemplatePath";

--- a/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/ddl/DdlExporter.java
@@ -35,7 +35,6 @@ import org.hibernate.tool.schema.TargetType;
  */
 public class DdlExporter extends AbstractExporter {
 
-	protected String outputFileName = null;
 	protected boolean haltOnError = false;
 
 	protected boolean setupBoolProperty(String property, boolean defaultVal) {
@@ -46,7 +45,6 @@ public class DdlExporter extends AbstractExporter {
 	}
 
 	protected void setupContext() {
-		outputFileName = getProperties().getProperty("outputFileName", outputFileName);
 		haltOnError = setupBoolProperty("haltOnError", haltOnError);
 		super.setupContext();
 	}
@@ -56,6 +54,7 @@ public class DdlExporter extends AbstractExporter {
 	}
 
 	protected void doStart() {
+		String outputFileName = getProperties().getProperty(OUTPUT_FILE_NAME);
 		Metadata metadata = getMetadata();
 		final EnumSet<TargetType> targetTypes = EnumSet.noneOf( TargetType.class );
 		if (getExportToConsole()) targetTypes.add(TargetType.STDOUT);
@@ -126,13 +125,6 @@ public class DdlExporter extends AbstractExporter {
 	 */
 	public void setFormat(boolean format) {
 		getProperties().put(FORMAT, format);
-	}
-
-	/**
-	 * File out put name (default: empty)
-	 */
-	public void setOutputFileName(String fileName) {
-		outputFileName = fileName;
 	}
 
 	public void setHaltonerror(boolean haltOnError) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>