### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Use ExporterFactory#createExporter(ExporterType) to create DocExporter

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2DocExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2DocExporterTask.java
@@ -5,7 +5,8 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.doc.DocExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class Hbm2DocExporterTask extends ExporterTask {
 
@@ -18,6 +19,6 @@ public class Hbm2DocExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		return new DocExporter();
+		return ExporterFactory.createExporter(ExporterType.DOC);
 	}
 }

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2DocExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2DocExporterTask.java
@@ -5,7 +5,8 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.doc.DocExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class Hbm2DocExporterTask extends ExporterTask {
 
@@ -18,6 +19,6 @@ public class Hbm2DocExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		return new DocExporter();
+		return ExporterFactory.createExporter(ExporterType.DOC);
 	}
 }

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -5,6 +5,7 @@ public enum ExporterType {
 	CFG ("org.hibernate.tool.internal.export.cfg.CfgExporter"),
 	DAO ("org.hibernate.tool.internal.export.dao.DaoExporter"),
 	DDL ("org.hibernate.tool.internal.export.ddl.DdlExporter"),
+	DOC ("org.hibernate.tool.internal.export.doc.DocExporter"),
 	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
 	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>