### PR TITLE
HBX-1873: Rename 'org.hibernate.tool.internal.export.hbm.HibernateMappingExporter' to 'org.hibernate.tool.internal.export.hbm.HbmExporter'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
@@ -5,7 +5,7 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 
 public class Hbm2HbmXmlExporterTask extends ExporterTask {
 
@@ -14,7 +14,7 @@ public class Hbm2HbmXmlExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		return new HibernateMappingExporter();
+		return new HbmExporter();
 	}	
 	
 	public String getName() {

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
@@ -5,7 +5,7 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 
 public class Hbm2HbmXmlExporterTask extends ExporterTask {
 
@@ -14,7 +14,7 @@ public class Hbm2HbmXmlExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		return new HibernateMappingExporter();
+		return new HbmExporter();
 	}	
 	
 	public String getName() {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HbmExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HbmExporter.java
@@ -17,7 +17,7 @@ import org.hibernate.tool.internal.export.pojo.POJOClass;
 /**
  * @author david and max
  */
-public class HibernateMappingExporter extends GenericExporter {
+public class HbmExporter extends GenericExporter {
     
 	protected HibernateMappingGlobalSettings globalSettings = new HibernateMappingGlobalSettings();
 	
@@ -52,7 +52,7 @@ public class HibernateMappingExporter extends GenericExporter {
     	getProperties().put(FILE_PATTERN, "{package-name}/{class-name}.hbm.xml");
 	}
 
-	public HibernateMappingExporter() {
+	public HbmExporter() {
 		init();		
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -26,7 +26,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.internal.export.doc.DocExporter;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -79,7 +79,7 @@ public class TestCase {
 	
 	@Test
 	public void testGenerateMappings() {
-		Exporter exporter = new HibernateMappingExporter();	
+		Exporter exporter = new HbmExporter();	
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.start();	

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -28,7 +28,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JavaUtil;
@@ -167,7 +167,7 @@ public class TestCase {
     @Test
     public void testGeneration() throws Exception {
         final File testFolder = temporaryFolder.getRoot();        
-        Exporter exporter = new HibernateMappingExporter();	
+        Exporter exporter = new HbmExporter();	
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, testFolder);
         Exporter javaExp = ExporterFactory.createExporter(ExporterType.POJO);

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -25,7 +25,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JavaUtil;
@@ -150,7 +150,7 @@ public class TestCase {
 	@Test
 	public void testGeneration() throws Exception {
 		final File testFolder = temporaryFolder.getRoot();
-		Exporter exporter = new HibernateMappingExporter();
+		Exporter exporter = new HbmExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, testFolder);
 		Exporter javaExp = ExporterFactory.createExporter(ExporterType.POJO);

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -14,7 +14,7 @@ import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -126,7 +126,7 @@ public class TestCase {
 		
 		Assert.assertNotNull(metadataDescriptor.createMetadata());
 		
-		HibernateMappingExporter hme = new HibernateMappingExporter();
+		HbmExporter hme = new HbmExporter();
 		hme.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hme.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hme.start();		

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
@@ -29,7 +29,7 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.hbm2ddl.SchemaValidator;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.metadata.NativeMetadataDescriptor;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JavaUtil;
@@ -131,7 +131,7 @@ public class TestCase {
 	@Test
 	public void testGenerateMappingAndReadable() throws MalformedURLException {
 		File outputDir = temporaryFolder.getRoot();
-		HibernateMappingExporter hme = new HibernateMappingExporter();
+		HbmExporter hme = new HbmExporter();
 		hme.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hme.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hme.start();		

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
@@ -18,7 +18,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.export.common.DefaultValueVisitor;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -74,7 +74,7 @@ public class TestCase {
 	@Test
 	public void testGeneration() {		
 		File outputFolder = temporaryFolder.getRoot();
-		HibernateMappingExporter hme = new HibernateMappingExporter();
+		HbmExporter hme = new HbmExporter();
 		hme.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hme.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputFolder);
 		hme.start();			

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
@@ -13,7 +13,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.type.BigDecimalType;
 import org.hibernate.type.IntegerType;
@@ -68,7 +68,7 @@ public class TestCase {
 	@Test
 	public void testGenerateMappings() {
 		File testFolder = temporaryFolder.getRoot();
-        Exporter exporter = new HibernateMappingExporter();		
+        Exporter exporter = new HbmExporter();		
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, testFolder);
  		exporter.start();		

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
@@ -7,7 +7,7 @@ import java.util.Properties;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -42,7 +42,7 @@ public class TestCase {
 				.createNativeDescriptor(null, new File[] { fooHbmXmlOrigin }, properties); 		
 		final File outputDir = new File(temporaryFolder.getRoot(), "output");
 		outputDir.mkdir();
-		HibernateMappingExporter exporter = new HibernateMappingExporter();
+		HbmExporter exporter = new HbmExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		final File fooHbmXml = new File(outputDir, "Foo.hbm.xml");

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
@@ -20,7 +20,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -58,7 +58,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		Exporter hbmexporter = new HibernateMappingExporter();	
+		Exporter hbmexporter = new HbmExporter();	
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();		

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/PropertiesTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/PropertiesTest/TestCase.java
@@ -20,7 +20,7 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -61,7 +61,7 @@ public class TestCase {
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
-		Exporter hbmexporter = new HibernateMappingExporter();
+		Exporter hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/AbstractTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/AbstractTest/TestCase.java
@@ -32,7 +32,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -66,7 +66,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/BackrefTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/BackrefTest/TestCase.java
@@ -29,7 +29,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -65,7 +65,7 @@ public class TestCase {
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		metadata = metadataDescriptor.createMetadata();
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/CompositeElementTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/CompositeElementTest/TestCase.java
@@ -32,7 +32,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -67,7 +67,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
@@ -32,7 +32,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -67,7 +67,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/FormulaTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/FormulaTest/TestCase.java
@@ -25,7 +25,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,7 +58,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -21,7 +21,7 @@ import org.dom4j.io.SAXReader;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.export.hbm.HibernateMappingGlobalSettings;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -64,7 +64,7 @@ public class TestCase {
 	private MetadataDescriptor metadataDescriptor = null;
 	private File outputDir = null;
 	private File resourcesDir = null;
-	private HibernateMappingExporter hbmexporter = null;
+	private HbmExporter hbmexporter = null;
 
 	@Before
 	public void setUp() throws Exception {
@@ -74,7 +74,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();
@@ -117,10 +117,10 @@ public class TestCase {
 		hgs.setDefaultPackage("org.hibernate.tool.hbm2x.hbm2hbmxml.Hbm2HbmXmlTest");
 		hgs.setSchemaName("myschema");
 		hgs.setCatalogName("mycatalog");		
-		Exporter gsExporter = new HibernateMappingExporter();
+		Exporter gsExporter = new HbmExporter();
 		gsExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		gsExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
-		( (HibernateMappingExporter)gsExporter).setGlobalSettings(hgs);
+		( (HbmExporter)gsExporter).setGlobalSettings(hgs);
 		gsExporter.start();
 		File outputXml = new File(
 				outputDir, 
@@ -147,10 +147,10 @@ public class TestCase {
 		hgs.setDefaultPackage("org.hibernate.tool.hbm2x.hbm2hbmxml.Hbm2HbmXmlTest");
 		hgs.setDefaultAccess("field");
 		hgs.setDefaultCascade("save-update");
-		Exporter gbsExporter = new HibernateMappingExporter();
+		Exporter gbsExporter = new HbmExporter();
 		gbsExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		gbsExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
-		( (HibernateMappingExporter)gbsExporter).setGlobalSettings(hgs);
+		( (HbmExporter)gbsExporter).setGlobalSettings(hgs);
 		gbsExporter.start();
 		File outputXml = new File(
 				outputDir,
@@ -263,10 +263,10 @@ public class TestCase {
 		hgs.setDefaultPackage("org.hibernate.tool.hbm2x.hbm2hbmxml.Hbm2HbmXmlTest");
 		hgs.setDefaultAccess("property");
 		hgs.setDefaultCascade("none");	
-		Exporter gbsExporter = new HibernateMappingExporter();
+		Exporter gbsExporter = new HbmExporter();
 		gbsExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		gbsExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
-		( (HibernateMappingExporter)gbsExporter).setGlobalSettings(hgs);
+		( (HbmExporter)gbsExporter).setGlobalSettings(hgs);
 		gbsExporter.start();
 		File outputXml = new File(
 				outputDir,
@@ -294,10 +294,10 @@ public class TestCase {
 		hgs.setDefaultPackage("org.hibernate.tool.hbm2x.hbm2hbmxml.Hbm2HbmXmlTest");
 		hgs.setDefaultLazy(false);
 		hgs.setAutoImport(false);		
-		Exporter gbsExporter = new HibernateMappingExporter();
+		Exporter gbsExporter = new HbmExporter();
 		gbsExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		gbsExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
-		( (HibernateMappingExporter)gbsExporter).setGlobalSettings(hgs);
+		( (HbmExporter)gbsExporter).setGlobalSettings(hgs);
 		gbsExporter.start();
 		File outputXml = new File(
 				outputDir,

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
@@ -31,7 +31,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -56,7 +56,7 @@ public class TestCase {
 	private File outputDir = null;
 	private File resourcesDir = null;
 	
-	private HibernateMappingExporter hbmexporter = null;
+	private HbmExporter hbmexporter = null;
 
 	@Before
 	public void setUp() throws Exception {
@@ -66,7 +66,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
@@ -22,7 +22,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -49,7 +49,7 @@ public class TestCase {
 	private File outputDir = null;
 	private File resourcesDir = null;
 	
-	private HibernateMappingExporter hbmexporter = null;
+	private HbmExporter hbmexporter = null;
 
 	@Before
 	public void setUp() throws Exception {
@@ -59,7 +59,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/TestCase.java
@@ -25,7 +25,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,7 +58,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/TestCase.java
@@ -32,7 +32,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -65,7 +65,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		Exporter hbmexporter = new HibernateMappingExporter();
+		Exporter hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ManyToManyTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ManyToManyTest/TestCase.java
@@ -22,7 +22,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -40,7 +40,7 @@ public class TestCase {
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 	
-	private HibernateMappingExporter hbmexporter = null;
+	private HbmExporter hbmexporter = null;
 	private File outputDir = null;
 	private File resourcesDir = null;
 	
@@ -52,7 +52,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/MapAndAnyTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/MapAndAnyTest/TestCase.java
@@ -36,7 +36,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -73,7 +73,7 @@ public class TestCase {
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		metadata = metadataDescriptor.createMetadata();
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/TestCase.java
@@ -21,7 +21,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -43,7 +43,7 @@ public class TestCase {
 	
 	private File outputDir = null;
 	private File resourcesDir = null;
-	private HibernateMappingExporter hbmexporter = null;
+	private HbmExporter hbmexporter = null;
 	
 	@Before
 	public void setUp() throws Exception {
@@ -53,7 +53,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();		

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
@@ -31,7 +31,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -65,7 +65,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		hbmexporter = new HibernateMappingExporter();
+		hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/TypeParamsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/TypeParamsTest/TestCase.java
@@ -34,7 +34,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.internal.export.hbm.HibernateMappingExporter;
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.Assert;
@@ -67,7 +67,7 @@ public class TestCase {
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
-		Exporter hbmexporter = new HibernateMappingExporter();
+		Exporter hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		hbmexporter.start();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>