### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Use ExporterFactory#createExporter(ExporterType) to create HbmExporter

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
@@ -5,7 +5,8 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.hbm.HbmExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class Hbm2HbmXmlExporterTask extends ExporterTask {
 
@@ -14,7 +15,7 @@ public class Hbm2HbmXmlExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		return new HbmExporter();
+		return ExporterFactory.createExporter(ExporterType.HBM);
 	}	
 	
 	public String getName() {

--- a/orm/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/Hbm2HbmXmlExporterTask.java
@@ -5,7 +5,8 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.hbm.HbmExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class Hbm2HbmXmlExporterTask extends ExporterTask {
 
@@ -14,7 +15,7 @@ public class Hbm2HbmXmlExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		return new HbmExporter();
+		return ExporterFactory.createExporter(ExporterType.HBM);
 	}	
 	
 	public String getName() {

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -7,6 +7,7 @@ public enum ExporterType {
 	DDL ("org.hibernate.tool.internal.export.ddl.DdlExporter"),
 	DOC ("org.hibernate.tool.internal.export.doc.DocExporter"),
 	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
+	HBM ("org.hibernate.tool.internal.export.hbm.HbmExporter"),
 	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
 	
 	private String className;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>