### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Use ExporterFactory#createExporter(ExporterType) to create HbmLintExporter

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/HbmLintExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HbmLintExporterTask.java
@@ -1,7 +1,8 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.lint.HbmLintExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class HbmLintExporterTask extends ExporterTask {
 
@@ -10,7 +11,7 @@ public class HbmLintExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		return new HbmLintExporter();
+		return ExporterFactory.createExporter(ExporterType.HBM_LINT);
 	}
 		
 

--- a/orm/src/main/java/org/hibernate/tool/ant/HbmLintExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/HbmLintExporterTask.java
@@ -1,7 +1,8 @@
 package org.hibernate.tool.ant;
 
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.internal.export.lint.HbmLintExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 
 public class HbmLintExporterTask extends ExporterTask {
 
@@ -10,7 +11,7 @@ public class HbmLintExporterTask extends ExporterTask {
 	}
 
 	protected Exporter createExporter() {
-		return new HbmLintExporter();
+		return ExporterFactory.createExporter(ExporterType.HBM_LINT);
 	}
 		
 

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -8,6 +8,7 @@ public enum ExporterType {
 	DOC ("org.hibernate.tool.internal.export.doc.DocExporter"),
 	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
 	HBM ("org.hibernate.tool.internal.export.hbm.HbmExporter"),
+	HBM_LINT ("org.hibernate.tool.internal.export.lint.HbmLintExporter"),
 	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
 	
 	private String className;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>