### PR TITLE
HBX-1875: Replace the use of 'org.hibernate.tool.internal.util.StringUtil#isNotEmpty(String) by 'org.hibernate.tool.util.StringUtil#isEmptyOrNull(String)'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -20,7 +20,7 @@ import org.apache.tools.ant.types.PropertySet;
 import org.hibernate.boot.MappingNotFoundException;
 import org.hibernate.boot.jaxb.Origin;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.internal.util.StringUtil;
+import org.hibernate.tool.util.StringUtil;
 
 /**
  * @author max
@@ -199,7 +199,7 @@ public class HibernateToolTask extends Task {
 				cause=cause.getCause();
 			}
 		}
-		if(StringUtil.isNotEmpty(ex)) {
+		if(!StringUtil.isEmptyOrNull(ex)) {
 			log(ex, Project.MSG_ERR);
 		}
 

--- a/orm/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -20,7 +20,7 @@ import org.apache.tools.ant.types.PropertySet;
 import org.hibernate.boot.MappingNotFoundException;
 import org.hibernate.boot.jaxb.Origin;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.internal.util.StringUtil;
+import org.hibernate.tool.util.StringUtil;
 
 /**
  * @author max
@@ -199,7 +199,7 @@ public class HibernateToolTask extends Task {
 				cause=cause.getCause();
 			}
 		}
-		if(StringUtil.isNotEmpty(ex)) {
+		if(!StringUtil.isEmptyOrNull(ex)) {
 			log(ex, Project.MSG_ERR);
 		}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/util/StringUtil.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/util/StringUtil.java
@@ -58,8 +58,4 @@ public final class StringUtil {
         return str;
     }
 
-	public static boolean isNotEmpty(String string) {
-		return string != null && string.length() > 0;
-	}
-
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>