### PR TITLE
HBX-1882: Remove instance variables and setters from class 'org.hibernate.tool.internal.export.query.QueryExporter' - Remove QueryExporter#setFileName(String)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.util.StringUtil;
 
@@ -32,7 +33,7 @@ public class QueryExporterTask extends ExporterTask {
 			}
 		}
 		exporter.setQueries(queryStrings);
-		exporter.setFilename(filename);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, filename);
 		super.configureExporter( exp );		
         return exporter;
 	}

--- a/orm/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.util.StringUtil;
 
@@ -32,7 +33,7 @@ public class QueryExporterTask extends ExporterTask {
 			}
 		}
 		exporter.setQueries(queryStrings);
-		exporter.setFilename(filename);
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, filename);
 		super.configureExporter( exp );		
         return exporter;
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/export/query/QueryExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/query/QueryExporter.java
@@ -19,7 +19,6 @@ import org.hibernate.tool.internal.export.common.AbstractExporter;
  **/
 public class QueryExporter extends AbstractExporter {
 
-	private String filename;
 	private List<String> queryStrings;
 
 	@SuppressWarnings({ "unchecked" })
@@ -78,13 +77,9 @@ public class QueryExporter extends AbstractExporter {
 	}
 
 	private String getFileName() {
-		return filename;
+		return (String)getProperties().get(OUTPUT_FILE_NAME);
 	}
 
-	public void setFilename(String filename) {
-		this.filename = filename;
-	}
-	
 	public void setQueries(List<String> queryStrings) {
 		this.queryStrings = queryStrings;		
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
@@ -70,7 +70,7 @@ public class TestCase {
 		exporter.getProperties().put(AvailableSettings.HBM2DDL_AUTO, "update");
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, destinationDir);
-		exporter.setFilename("queryresult.txt");
+		exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, "queryresult.txt");
 		List<String> queries = new ArrayList<String>();
 		queries.add("from java.lang.Object");
 		exporter.setQueries( queries );		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>