### PR TITLE
HBX-1882: Remove instance variables and setters from class 'org.hibernate.tool.internal.export.query.QueryExporter' - Remove QueryExporter#setQueries(List<String>)

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
@@ -32,7 +32,7 @@ public class QueryExporterTask extends ExporterTask {
 				queryStrings.add(hql.query);
 			}
 		}
-		exporter.setQueries(queryStrings);
+		exporter.getProperties().put(ExporterConstants.QUERY_LIST, queryStrings);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, filename);
 		super.configureExporter( exp );		
         return exporter;

--- a/orm/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
@@ -32,7 +32,7 @@ public class QueryExporterTask extends ExporterTask {
 				queryStrings.add(hql.query);
 			}
 		}
-		exporter.setQueries(queryStrings);
+		exporter.getProperties().put(ExporterConstants.QUERY_LIST, queryStrings);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, filename);
 		super.configureExporter( exp );		
         return exporter;

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterConstants.java
@@ -15,6 +15,7 @@ public interface ExporterConstants {
 	public static final String HALT_ON_ERROR = "org.hibernate.tool.api.export.ExporterConstants.HaltOnError";
 	public static final String METADATA_DESCRIPTOR = "org.hibernate.tool.api.export.ExporterConstants.MetadataDescriptor";
 	public static final String OUTPUT_FILE_NAME = "org.hibernate.tool.api.export.ExporterConstants.OutputFileName";
+	public static final String QUERY_LIST = "org.hibernate.tool.api.export.ExporterConstants.QueryList";
 	public static final String SCHEMA_UPDATE = "org.hibernate.tool.api.export.ExporterConstants.SchemaUpdate";
 	public static final String TEMPLATE_NAME = "org.hibernate.tool.api.export.ExporterConstants.TemplateName";
 	public static final String TEMPLATE_PATH = "org.hibernate.tool.api.export.ExporterConstants.TemplatePath";

--- a/orm/src/main/java/org/hibernate/tool/internal/export/query/QueryExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/query/QueryExporter.java
@@ -19,8 +19,6 @@ import org.hibernate.tool.internal.export.common.AbstractExporter;
  **/
 public class QueryExporter extends AbstractExporter {
 
-	private List<String> queryStrings;
-
 	@SuppressWarnings({ "unchecked" })
 	public void doStart() {
 		Session session = null;
@@ -30,7 +28,7 @@ public class QueryExporter extends AbstractExporter {
 			sessionFactory = buildMetadata().buildSessionFactory();
 			session = sessionFactory.openSession();
 			transaction = session.beginTransaction();
-			for (Iterator<String> iter = queryStrings.iterator(); iter.hasNext();) {
+			for (Iterator<?> iter = getQueryList().iterator(); iter.hasNext();) {
 				String query = (String) iter.next();
 				
 				List<Object> list = session.createQuery(query).getResultList();
@@ -79,9 +77,13 @@ public class QueryExporter extends AbstractExporter {
 	private String getFileName() {
 		return (String)getProperties().get(OUTPUT_FILE_NAME);
 	}
+	
+	private List<?> getQueryList() {
+		return (List<?>)getProperties().get(QUERY_LIST);
+	}
 
 	public void setQueries(List<String> queryStrings) {
-		this.queryStrings = queryStrings;		
+		getProperties().put(QUERY_LIST, queryStrings);		
 	}
 
 }

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
@@ -73,7 +73,7 @@ public class TestCase {
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, "queryresult.txt");
 		List<String> queries = new ArrayList<String>();
 		queries.add("from java.lang.Object");
-		exporter.setQueries( queries );		
+		exporter.getProperties().put(ExporterConstants.QUERY_LIST, queries);
 		exporter.start();
 		JUnitUtil.assertIsNonEmptyFile(new File(destinationDir, "queryresult.txt"));		
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>