### PR TITLE
HBX-1836: Move the ant tasks from the core hibernate tools into the hibernate-tools-ant project - Use ExporterFactory#createExporter(ExporterType) to create QueryExporter

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
@@ -7,7 +7,8 @@ import java.util.List;
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
-import org.hibernate.tool.internal.export.query.QueryExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.util.StringUtil;
 
 public class QueryExporterTask extends ExporterTask {
@@ -21,7 +22,7 @@ public class QueryExporterTask extends ExporterTask {
 	}
 
 	protected Exporter configureExporter(Exporter exp) {
-		QueryExporter exporter = (QueryExporter) exp;
+		Exporter exporter = super.configureExporter( exp );		
 		List<String> queryStrings = new ArrayList<String>();
 		if(!StringUtil.isEmptyOrNull(query)) {
 			queryStrings.add(query);
@@ -34,7 +35,6 @@ public class QueryExporterTask extends ExporterTask {
 		}
 		exporter.getProperties().put(ExporterConstants.QUERY_LIST, queryStrings);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, filename);
-		super.configureExporter( exp );		
         return exporter;
 	}
 
@@ -52,8 +52,7 @@ public class QueryExporterTask extends ExporterTask {
 		}
 	}
 	protected Exporter createExporter() {
-		QueryExporter exporter = new QueryExporter();
-		return exporter;
+		return ExporterFactory.createExporter(ExporterType.QUERY);
 	}
 
 	public void addText(String text) {

--- a/orm/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
+++ b/orm/src/main/java/org/hibernate/tool/ant/QueryExporterTask.java
@@ -7,7 +7,8 @@ import java.util.List;
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
-import org.hibernate.tool.internal.export.query.QueryExporter;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.util.StringUtil;
 
 public class QueryExporterTask extends ExporterTask {
@@ -21,7 +22,7 @@ public class QueryExporterTask extends ExporterTask {
 	}
 
 	protected Exporter configureExporter(Exporter exp) {
-		QueryExporter exporter = (QueryExporter) exp;
+		Exporter exporter = super.configureExporter( exp );		
 		List<String> queryStrings = new ArrayList<String>();
 		if(!StringUtil.isEmptyOrNull(query)) {
 			queryStrings.add(query);
@@ -34,7 +35,6 @@ public class QueryExporterTask extends ExporterTask {
 		}
 		exporter.getProperties().put(ExporterConstants.QUERY_LIST, queryStrings);
 		exporter.getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, filename);
-		super.configureExporter( exp );		
         return exporter;
 	}
 
@@ -52,8 +52,7 @@ public class QueryExporterTask extends ExporterTask {
 		}
 	}
 	protected Exporter createExporter() {
-		QueryExporter exporter = new QueryExporter();
-		return exporter;
+		return ExporterFactory.createExporter(ExporterType.QUERY);
 	}
 
 	public void addText(String text) {

--- a/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
+++ b/orm/src/main/java/org/hibernate/tool/api/export/ExporterType.java
@@ -9,7 +9,8 @@ public enum ExporterType {
 	GENERIC ("org.hibernate.tool.internal.export.common.GenericExporter"),
 	HBM ("org.hibernate.tool.internal.export.hbm.HbmExporter"),
 	HBM_LINT ("org.hibernate.tool.internal.export.lint.HbmLintExporter"),
-	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter");
+	POJO ("org.hibernate.tool.internal.export.pojo.POJOExporter"),
+	QUERY ("org.hibernate.tool.internal.export.query.QueryExporter");
 	
 	private String className;
 	

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
@@ -11,11 +11,13 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.api.export.ExporterFactory;
+import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
-import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -61,7 +63,7 @@ public class TestCase {
 	
 	@Test
 	public void testQueryExporter() throws Exception {		
-		QueryExporter exporter = new QueryExporter();
+		Exporter exporter = ExporterFactory.createExporter(ExporterType.QUERY);
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(
 						null, 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>