### PR TITLE
HBX-1885: Replace the use of the deprecated classes 'MultiMap' and 'MultiValueMap' by 'MultiValuedMap' and 'HashSetValuedHashMap'

### DIFF
--- a/src/java/org/hibernate/cfg/reveng/MetaAttributeBinder.java
+++ b/src/java/org/hibernate/cfg/reveng/MetaAttributeBinder.java
@@ -5,8 +5,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.collections4.MultiMap;
-import org.apache.commons.collections4.map.MultiValueMap;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.dom4j.Element;
 import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.tool.hbm2x.MetaAttributeHelper;
@@ -22,19 +22,19 @@ public class MetaAttributeBinder {
 	 * @return a MultiMap with all values from local and extra values
 	 * from inherited
 	 */
-	public static MultiMap mergeMetaMaps(MultiMap specific, MultiMap general) {
-		MultiValueMap result = new MultiValueMap();
+	public static MultiValuedMap<String, SimpleMetaAttribute> mergeMetaMaps(
+			MultiValuedMap<String, SimpleMetaAttribute> specific, 
+			MultiValuedMap<String, SimpleMetaAttribute> general) {
+		MultiValuedMap<String, SimpleMetaAttribute> result = new HashSetValuedHashMap<String, SimpleMetaAttribute>();
 		MetaAttributeHelper.copyMultiMap(result, specific);
-		
 		if (general != null) {
-			for (Iterator<?> iter = general.keySet().iterator();iter.hasNext();) {
-				Object key = iter.next();
-	
+			for (Iterator<String> iter = general.keySet().iterator();iter.hasNext();) {
+				String key = iter.next();
 				if (!specific.containsKey(key) ) {
 					// inheriting a meta attribute only if it is inheritable
-					Collection<?> ml = (Collection<?>)general.get(key);
-					for (Iterator<?> iterator = ml.iterator(); iterator.hasNext();) {
-						SimpleMetaAttribute element = (SimpleMetaAttribute) iterator.next();
+					Collection<SimpleMetaAttribute> ml = general.get(key);
+					for (Iterator<SimpleMetaAttribute> iterator = ml.iterator(); iterator.hasNext();) {
+						SimpleMetaAttribute element = iterator.next();
 						if (element.inheritable) {
 							result.put(key, element);
 						}
@@ -47,16 +47,15 @@ public class MetaAttributeBinder {
 	
 	}
 
-	public static MetaAttribute toRealMetaAttribute(String name, List<?> values) {
+	public static MetaAttribute toRealMetaAttribute(String name, Collection<SimpleMetaAttribute> values) {
 		MetaAttribute attribute = new MetaAttribute(name);
-		for (Iterator<?> iter = values.iterator(); iter.hasNext();) {
-			SimpleMetaAttribute element = (SimpleMetaAttribute) iter.next();
+		for (Iterator<SimpleMetaAttribute> iter = values.iterator(); iter.hasNext();) {
+			SimpleMetaAttribute element = iter.next();
 			attribute.addValue(element.value);
 		}
 		
 		return attribute;
 	}
-
 
 	/**
 	 * Method loadAndMergeMetaMap.
@@ -64,9 +63,9 @@ public class MetaAttributeBinder {
 	 * @param inheritedMeta
 	 * @return MultiMap
 	 */
-	public static MultiMap loadAndMergeMetaMap(
+	public static MultiValuedMap<String, SimpleMetaAttribute> loadAndMergeMetaMap(
 		Element classElement,
-		MultiMap inheritedMeta) {
+		MultiValuedMap<String, SimpleMetaAttribute> inheritedMeta) {
 		return MetaAttributeBinder.mergeMetaMaps(loadMetaMap(classElement), inheritedMeta);
 	}
 
@@ -77,8 +76,8 @@ public class MetaAttributeBinder {
 	 * @param element
 	 * @return MultiMap
 	 */
-	 protected static MultiMap loadMetaMap(Element element) {
-		MultiMap result = new MultiValueMap();
+	 protected static MultiValuedMap<String, SimpleMetaAttribute> loadMetaMap(Element element) {
+		MultiValuedMap<String, SimpleMetaAttribute> result = new HashSetValuedHashMap<String, SimpleMetaAttribute>();
 		List<Element> metaAttributeList = new ArrayList<Element>();
 		for (Object obj : element.elements("meta")) {
 			metaAttributeList.add((Element)obj);

--- a/src/java/org/hibernate/cfg/reveng/OverrideBinder.java
+++ b/src/java/org/hibernate/cfg/reveng/OverrideBinder.java
@@ -5,8 +5,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.collections4.MultiMap;
-import org.apache.commons.collections4.map.MultiValueMap;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.dom4j.Document;
 import org.dom4j.Element;
 import org.hibernate.MappingException;
@@ -123,7 +123,10 @@ public final class OverrideBinder {
 	}
 
 	private static void bindMetaAttributes(Element element, Table table, OverrideRepository repository) {
-		MultiMap map = MetaAttributeBinder.loadAndMergeMetaMap( element, new MultiValueMap());
+		MultiValuedMap<String, SimpleMetaAttribute> map = 
+				MetaAttributeBinder.loadAndMergeMetaMap(
+						element, 
+						new HashSetValuedHashMap<String, SimpleMetaAttribute>());
 		if(map!=null && !map.isEmpty()) {
 			repository.addMetaAttributeInfo( table, map);
 		} 
@@ -320,7 +323,10 @@ public final class OverrideBinder {
 				throw new MappingException("Column " + column.getName() + " already exists in table " + tableIdentifier );
 			}
 			
-			MultiMap map = MetaAttributeBinder.loadAndMergeMetaMap( element, new MultiValueMap());
+			MultiValuedMap<String, SimpleMetaAttribute> map = 
+					MetaAttributeBinder.loadAndMergeMetaMap( 
+							element, 
+							new HashSetValuedHashMap<String, SimpleMetaAttribute>());
 			if(map!=null && !map.isEmpty()) {
 				repository.addMetaAttributeInfo( tableIdentifier, column.getName(), map);
 			} 
@@ -383,7 +389,10 @@ public final class OverrideBinder {
 			filter.setExclude(Boolean.valueOf(element.attributeValue("exclude") ) );
 			filter.setPackage(element.attributeValue("package") );
 			
-			MultiMap map = MetaAttributeBinder.loadAndMergeMetaMap( element, new MultiValueMap());
+			MultiValuedMap<String, SimpleMetaAttribute> map = 
+					MetaAttributeBinder.loadAndMergeMetaMap( 
+							element, 
+							new HashSetValuedHashMap<String, SimpleMetaAttribute>());
 			if(map!=null && !map.isEmpty()) {
 				filter.setMetaAttributes( map );
 			} else {

--- a/src/java/org/hibernate/cfg/reveng/OverrideRepository.java
+++ b/src/java/org/hibernate/cfg/reveng/OverrideRepository.java
@@ -5,16 +5,17 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.commons.collections4.MultiMap;
+import org.apache.commons.collections4.MapIterator;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.dom4j.Document;
 import org.hibernate.MappingException;
 import org.hibernate.internal.util.StringHelper;
@@ -70,9 +71,9 @@ public class OverrideRepository  {
 	final private Map<String, AssociationInfo> foreignKeyToEntityInfo;
 	final private Map<String, AssociationInfo> foreignKeyToInverseEntityInfo;
 
-	final private Map<TableIdentifier, MultiMap> tableMetaAttributes; // TI -> MultiMap of SimpleMetaAttributes
+	final private Map<TableIdentifier, MultiValuedMap<String, SimpleMetaAttribute>> tableMetaAttributes; // TI -> MultiMap of SimpleMetaAttributes
 
-	final private Map<TableColumnKey, MultiMap> columnMetaAttributes;
+	final private Map<TableColumnKey, MultiValuedMap<String, SimpleMetaAttribute>> columnMetaAttributes;
 
 	//private String defaultCatalog;
 	//private String defaultSchema;
@@ -98,8 +99,8 @@ public class OverrideRepository  {
 		foreignKeyToInverseName = new HashMap<String, String>();
 		foreignKeyInverseExclude = new HashMap<String, Boolean>();
 		foreignKeyToOneExclude = new HashMap<String, Boolean>();
-		tableMetaAttributes = new HashMap<TableIdentifier, MultiMap>();
-		columnMetaAttributes = new HashMap<TableColumnKey, MultiMap>();
+		tableMetaAttributes = new HashMap<TableIdentifier, MultiValuedMap<String, SimpleMetaAttribute>>();
+		columnMetaAttributes = new HashMap<TableColumnKey, MultiValuedMap<String, SimpleMetaAttribute>>();
 		foreignKeyToEntityInfo = new HashMap<String, AssociationInfo>();
 		foreignKeyToInverseEntityInfo = new HashMap<String, AssociationInfo>();
 	}
@@ -501,7 +502,7 @@ public class OverrideRepository  {
 	}
 
 	protected Map<String, MetaAttribute> columnToMetaAttributes(TableIdentifier tableIdentifier, String column) {
-		MultiMap specific = columnMetaAttributes.get( new TableColumnKey(tableIdentifier, column) );
+		MultiValuedMap<String, SimpleMetaAttribute> specific = columnMetaAttributes.get( new TableColumnKey(tableIdentifier, column) );
 		if(specific!=null && !specific.isEmpty()) {
 			return toMetaAttributes(specific);
 		}
@@ -511,11 +512,11 @@ public class OverrideRepository  {
 
 	// TODO: optimize
 	protected Map<String,MetaAttribute> tableToMetaAttributes(TableIdentifier identifier) {
-		MultiMap specific = tableMetaAttributes.get( identifier );
+		MultiValuedMap<String, SimpleMetaAttribute> specific = tableMetaAttributes.get( identifier );
 		if(specific!=null && !specific.isEmpty()) {
 			return toMetaAttributes(specific);
 		}
-		Map<?,?> general = findGeneralAttributes( identifier );
+		MultiValuedMap<String, SimpleMetaAttribute> general = findGeneralAttributes( identifier );
 		if(general!=null && !general.isEmpty()) {
 			return toMetaAttributes(general);
 		}
@@ -537,11 +538,11 @@ public class OverrideRepository  {
 		*/
 	}
 
-	private Map<?,?> findGeneralAttributes(TableIdentifier identifier) {
+	private MultiValuedMap<String, SimpleMetaAttribute> findGeneralAttributes(TableIdentifier identifier) {
 		Iterator<TableFilter> iterator = tableFilters.iterator();
 		while(iterator.hasNext() ) {
 			TableFilter tf = iterator.next();
-			Map<?,?> value = tf.getMetaAttributes(identifier);
+			MultiValuedMap<String, SimpleMetaAttribute> value = tf.getMetaAttributes(identifier);
 			if(value!=null) {
 				return value;
 			}
@@ -549,20 +550,15 @@ public class OverrideRepository  {
 		return null;
 	}
 
-	private Map<String, MetaAttribute> toMetaAttributes(Map<?,?> value) {
+	private Map<String, MetaAttribute> toMetaAttributes(MultiValuedMap<String, SimpleMetaAttribute> mvm) {
 		Map<String, MetaAttribute> result = new HashMap<String, MetaAttribute>();
-
-		Set<?> set = value.entrySet();
-		for (Iterator<?> iter = set.iterator(); iter.hasNext();) {
-			Entry<?, ?> entry = (Entry<?,?>)iter.next();
-			String name = (String) entry.getKey();
-			List<?> values = (List<?>) entry.getValue();
-
-			result.put(name, MetaAttributeBinder.toRealMetaAttribute(name, values));
+		for (MapIterator<String, SimpleMetaAttribute> iter = mvm.mapIterator(); iter.hasNext();) {
+			String key = iter.next();
+			Collection<SimpleMetaAttribute> values = mvm.get(key);
+			result.put(key, MetaAttributeBinder.toRealMetaAttribute(key, values));
 		}
-
 		return result;
-	}
+ 	}
 
 	public ReverseEngineeringStrategy getReverseEngineeringStrategy() {
 		return getReverseEngineeringStrategy(null);
@@ -703,21 +699,23 @@ public class OverrideRepository  {
 
 	}
 
-	public void addMetaAttributeInfo(Table table, MultiMap map) {
+	public void addMetaAttributeInfo(
+			Table table, 
+			MultiValuedMap<String, SimpleMetaAttribute> map) {
 		if(map!=null && !map.isEmpty()) {
 			tableMetaAttributes.put(TableIdentifier.create(table), map);
 		}
 
 	}
 
-	public void addMetaAttributeInfo(TableIdentifier tableIdentifier, String name, MultiMap map) {
+	public void addMetaAttributeInfo(
+			TableIdentifier tableIdentifier, 
+			String name, 
+			MultiValuedMap<String, SimpleMetaAttribute> map) {
 		if(map!=null && !map.isEmpty()) {
 			columnMetaAttributes.put(new TableColumnKey( tableIdentifier, name ), map);
 		}
 
 	}
-
-
-
 
 }

--- a/src/java/org/hibernate/cfg/reveng/TableFilter.java
+++ b/src/java/org/hibernate/cfg/reveng/TableFilter.java
@@ -1,6 +1,6 @@
 package org.hibernate.cfg.reveng;
 
-import java.util.Map;
+import org.apache.commons.collections4.MultiValuedMap;
 
 
 /**
@@ -73,7 +73,7 @@ public class TableFilter {
 	private Matcher catalogMatcher;
 	private Matcher schemaMatcher;
 	private Matcher nameMatcher;
-	private Map<?,?> metaAttributes;
+	private MultiValuedMap<String, SimpleMetaAttribute> metaAttributes;
 
 	
 	
@@ -147,11 +147,11 @@ public class TableFilter {
 		return exclude;
 	}
 
-	public Map<?,?> getMetaAttributes(TableIdentifier identifier) {
+	public MultiValuedMap<String, SimpleMetaAttribute> getMetaAttributes(TableIdentifier identifier) {
 		return isRelevantFor(identifier) ? metaAttributes : null;	
 	}
 	
-	public void setMetaAttributes(Map<?,?> metaAttributes) {
+	public void setMetaAttributes(MultiValuedMap<String, SimpleMetaAttribute> metaAttributes) {
 		this.metaAttributes = metaAttributes;
 	}
 }

--- a/src/java/org/hibernate/tool/hbm2x/MetaAttributeHelper.java
+++ b/src/java/org/hibernate/tool/hbm2x/MetaAttributeHelper.java
@@ -3,7 +3,8 @@ package org.hibernate.tool.hbm2x;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.apache.commons.collections4.MultiMap;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.hibernate.cfg.reveng.SimpleMetaAttribute;
 import org.hibernate.mapping.MetaAttribute;
 
 /**
@@ -62,27 +63,18 @@ public final class MetaAttributeHelper {
 		return getMetaAsString(c, "");
 	}
 
-    /**
-     * Copies all the values from one MultiMap to another.
-     * This method is needed because the (undocumented) behaviour of 
-     * MultiHashMap.putAll in versions of Commons Collections prior to 3.0
-     * was to replace the collection in the destination, whereas in 3.0
-     * it adds the collection from the source as an _element_ of the collection
-     * in the destination.  This method makes no assumptions about the implementation
-     * of the MultiMap, and should work with all versions.
-     * 
-     * @param destination
-     * @param specific
-     */
-     public static void copyMultiMap(MultiMap destination, MultiMap specific) {
-        for (Iterator<?> keyIterator = specific.keySet().iterator(); keyIterator.hasNext(); ) {
-            Object key = keyIterator.next();
-            Collection<?> c = (Collection<?>)specific.get(key);
-            for (Iterator<?> valueIterator = c.iterator(); valueIterator.hasNext(); ) 
+    public static void copyMultiMap(
+    		MultiValuedMap<String, SimpleMetaAttribute> destination, 
+    		MultiValuedMap<String, SimpleMetaAttribute> specific) {
+        for (Iterator<String> keyIterator = specific.keySet().iterator(); keyIterator.hasNext(); ) {
+            String key = keyIterator.next();
+            Collection<SimpleMetaAttribute> c = specific.get(key);
+            for (Iterator<SimpleMetaAttribute> valueIterator = c.iterator(); valueIterator.hasNext();) { 
                 destination.put(key, valueIterator.next() );
+            }
         }
     }
-
+    
 	public static boolean getMetaAsBool(org.hibernate.mapping.MetaAttribute metaAttribute, boolean defaultValue) {
 		return getMetaAsBool(metaAttribute==null?null:metaAttribute.getValues(), defaultValue);
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>