### PR TITLE
HBX-1887: Update eclipse-jdt-core dependency to version 3.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.18.0</version>
+            <version>3.19.0</version>
             <scope>compile</scope>
         </dependency>
  		<dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>