### PR TITLE
HBX-1903: Rename class 'org.hibernate.tool.maven.Hbm2JavaMojo' to ''org.hibernate.tool.maven.GenerateJavaMojo'

### DIFF
--- a/maven/src/main/java/org/hibernate/tool/maven/GenerateJavaMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/GenerateJavaMojo.java
@@ -18,7 +18,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
  * See: https://docs.jboss.org/tools/latest/en/hibernatetools/html_single/#d0e4821
  */
 @Mojo(name = "hbm2java", defaultPhase = GENERATE_SOURCES)
-public class Hbm2JavaMojo extends AbstractGenerationMojo {
+public class GenerateJavaMojo extends AbstractGenerationMojo {
 
     /** The directory into which the JPA entities will be generated. */
     @Parameter(defaultValue = "${project.build.directory}/generated-sources/")


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>