### PR TITLE
HBX-1909: Move most logic from 'JdbcMetadataDescriptor#createMetadata()' to a new 'JdbcBinder#create()' method

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/metadata/JdbcMetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/metadata/JdbcMetadataDescriptor.java
@@ -3,16 +3,6 @@ package org.hibernate.tool.internal.metadata;
 import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.boot.internal.BootstrapContextImpl;
-import org.hibernate.boot.internal.InFlightMetadataCollectorImpl;
-import org.hibernate.boot.internal.MetadataBuilderImpl.MetadataBuildingOptionsImpl;
-import org.hibernate.boot.internal.MetadataBuildingContextRootImpl;
-import org.hibernate.boot.internal.MetadataImpl;
-import org.hibernate.boot.registry.StandardServiceRegistry;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.boot.spi.BootstrapContext;
-import org.hibernate.boot.spi.MetadataBuildingContext;
-import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.cfg.Environment;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
@@ -46,42 +36,9 @@ public class JdbcMetadataDescriptor implements MetadataDescriptor {
 	}
     
 	public Metadata createMetadata() {
-		StandardServiceRegistry serviceRegistry = new StandardServiceRegistryBuilder()
-				.applySettings(getProperties())
-				.build();
-		MetadataBuildingOptionsImpl metadataBuildingOptions = 
-				new MetadataBuildingOptionsImpl( serviceRegistry );	
-		BootstrapContextImpl bootstrapContext = new BootstrapContextImpl(
-				serviceRegistry, 
-				metadataBuildingOptions);
-		metadataBuildingOptions.setBootstrapContext(bootstrapContext);
-		InFlightMetadataCollectorImpl metadataCollector = 
-				getMetadataCollector(
-						bootstrapContext, 
-						metadataBuildingOptions);
-		MetadataBuildingContext metadataBuildingContext = 
-				new MetadataBuildingContextRootImpl(
-						bootstrapContext,
-						metadataBuildingOptions, 
-						metadataCollector);
-		MetadataImpl metadata = metadataCollector
-				.buildMetadataInstance(metadataBuildingContext);
-		metadata.getTypeConfiguration().scope(metadataBuildingContext);
-		JdbcBinder binder = new JdbcBinder(
-				serviceRegistry, 
-				getProperties(), 
-				metadataBuildingContext, 
-				reverseEngineeringStrategy, 
-				(Boolean)this.properties.get(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS));
-		return binder.readFromDatabase(metadata);
-	}
-	
-	private InFlightMetadataCollectorImpl getMetadataCollector(
-		BootstrapContext bootstrapContext,
-		MetadataBuildingOptions metadataBuildingOptions) {
-		return new InFlightMetadataCollectorImpl(
-			bootstrapContext,
-			metadataBuildingOptions);	
+		return JdbcBinder
+				.create(properties, reverseEngineeringStrategy)
+				.readFromDatabase();
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>