### PR TITLE
HBX-1917: Remove the uses of 'org.hibernate.exception.spi.SQLExceptionConverter' - Replace ResultSetIterator(ResultSet, SQLExceptionConverter) by ResultSetIterator(ResultSet)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/H2MetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/H2MetaDataDialect.java
@@ -77,7 +77,7 @@ public class H2MetaDataDialect extends JDBCMetaDataDialect {
 									
 				PreparedStatement statement = getConnection().prepareStatement( sql );
 				
-				return new ResultSetIterator(statement.executeQuery(), getSQLExceptionConverter()) {
+				return new ResultSetIterator(statement.executeQuery()) {
 					
 					Map<String, Object> element = new HashMap<String, Object>();
 					protected Map<String, Object> convertRow(ResultSet tableRs) throws SQLException {

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/HSQLMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/HSQLMetaDataDialect.java
@@ -39,8 +39,7 @@ public class HSQLMetaDataDialect extends JDBCMetaDataDialect {
 				
 				final String sc = schema;
 				final String cat = catalog;
-				return new ResultSetIterator(getMetaData().getTables(catalog, schema, table, new String[]{"TABLE"}),
-						getSQLExceptionConverter()) {
+				return new ResultSetIterator(getMetaData().getTables(catalog, schema, table, new String[]{"TABLE"})) {
 					
 					Map<String, Object> element = new HashMap<String, Object>();
 					protected Map<String, Object> convertRow(ResultSet tableRs) throws SQLException{

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/JDBCMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/JDBCMetaDataDialect.java
@@ -26,7 +26,7 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 			
 			ResultSet tableRs = getMetaData().getTables(catalog , schema , table, new String[] { "TABLE", "VIEW" });
 			
-			return new ResultSetIterator(tableRs, getSQLExceptionConverter()) {
+			return new ResultSetIterator(tableRs) {
 				
 				Map<String, Object> element = new HashMap<String, Object>();
 				protected Map<String, Object> convertRow(ResultSet tableResultSet) throws SQLException {
@@ -61,7 +61,7 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 			log.debug("getIndexInfo(" + catalog + "." + schema + "." + table + ")");
 			ResultSet tableRs = getMetaData().getIndexInfo(catalog , schema , table, false, true);
 			
-			return new ResultSetIterator(tableRs, getSQLExceptionConverter()) {
+			return new ResultSetIterator(tableRs) {
 				
 				Map<String, Object> element = new HashMap<String, Object>();
 				protected Map<String, Object> convertRow(ResultSet rs) throws SQLException {
@@ -98,7 +98,7 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 			log.debug("getColumns(" + catalog + "." + schema + "." + table + "." + column + ")");
 			ResultSet tableRs = getMetaData().getColumns(catalog, schema, table, column);
 			
-			return new ResultSetIterator(tableRs, getSQLExceptionConverter()) {
+			return new ResultSetIterator(tableRs) {
 				
 				Map<String, Object> element = new HashMap<String, Object>();
 				protected Map<String, Object> convertRow(ResultSet rs) throws SQLException {
@@ -131,7 +131,7 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 			log.debug("getPrimaryKeys(" + catalog + "." + schema + "." + table + ")");
 			ResultSet tableRs = getMetaData().getPrimaryKeys(catalog, schema, table);
 			
-			return new ResultSetIterator(tableRs, getSQLExceptionConverter()) {
+			return new ResultSetIterator(tableRs) {
 				
 				Map<String, Object> element = new HashMap<String, Object>();
 				protected Map<String, Object> convertRow(ResultSet rs) throws SQLException {
@@ -160,7 +160,7 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 			log.debug("getExportedKeys(" + catalog + "." + schema + "." + table + ")");
 			ResultSet tableRs = getMetaData().getExportedKeys(catalog, schema, table);
 			
-			return new ResultSetIterator(tableRs, getSQLExceptionConverter()) {
+			return new ResultSetIterator(tableRs) {
 				
 				Map<String, Object> element = new HashMap<String, Object>();
 				protected Map<String, Object> convertRow(ResultSet rs) throws SQLException {

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/MySQLMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/MySQLMetaDataDialect.java
@@ -27,7 +27,7 @@ public class MySQLMetaDataDialect extends JDBCMetaDataDialect {
 				
 				final String sc = schema;
 				final String cat = catalog;
-				return new ResultSetIterator(statement.executeQuery(), getSQLExceptionConverter()) {
+				return new ResultSetIterator(statement.executeQuery()) {
 					
 					Map<String, Object> element = new HashMap<String, Object>();
 					protected Map<String, Object> convertRow(ResultSet tableRs) throws SQLException {

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/OracleMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/OracleMetaDataDialect.java
@@ -264,8 +264,7 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 			
 			ResultSet tableRs = getTableResultSet( schema, table );
 
-			return new ResultSetIterator(null, tableRs,
-					getSQLExceptionConverter()) {
+			return new ResultSetIterator(null, tableRs) {
 
 				Map<String, Object> element = new HashMap<String, Object>();
 
@@ -313,8 +312,7 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 			ResultSet indexRs;
 			indexRs = getIndexInfoResultSet( schema, table );
 
-			return new ResultSetIterator(null, indexRs,
-					getSQLExceptionConverter()) {
+			return new ResultSetIterator(null, indexRs) {
 
 				Map<String, Object> element = new HashMap<String, Object>();
 
@@ -358,8 +356,7 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 			ResultSet columnRs;
 			columnRs = getColumnsResultSet( schema, table, column );
 
-			return new ResultSetIterator(null, columnRs,
-					getSQLExceptionConverter()) {
+			return new ResultSetIterator(null, columnRs) {
 
 				Map<String, Object> element = new HashMap<String, Object>();
 
@@ -405,8 +402,7 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 			ResultSet pkeyRs;
 			pkeyRs = getPrimaryKeysResultSet( schema, table );
 
-			return new ResultSetIterator(null, pkeyRs,
-					getSQLExceptionConverter()) {
+			return new ResultSetIterator(null, pkeyRs) {
 
 				Map<String, Object> element = new HashMap<String, Object>();
 
@@ -447,8 +443,7 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 
 			ResultSet pExportRs = getExportedKeysResultSet( schema, table );
 
-			return new ResultSetIterator(null, pExportRs,
-					getSQLExceptionConverter()) {
+			return new ResultSetIterator(null, pExportRs) {
 
 				Map<String, Object> element = new HashMap<String, Object>();
 

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/ResultSetIterator.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/ResultSetIterator.java
@@ -7,8 +7,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import org.hibernate.exception.spi.SQLExceptionConverter;
-
 
 /**
  * Iterator over a resultset; intended usage only for metadata reading.  
@@ -21,24 +19,17 @@ public abstract class ResultSetIterator implements Iterator<Map<String, Object>>
 
 	protected boolean endOfRows = false;
 
-	private SQLExceptionConverter sec;
-
 	private Statement statement = null;
 
-	protected ResultSetIterator(ResultSet resultset, SQLExceptionConverter sec) {
-		this(null, resultset, sec);
+	protected ResultSetIterator(ResultSet resultset) {
+		this(null, resultset);
 	}
 
-	public ResultSetIterator(Statement stmt, ResultSet resultset, SQLExceptionConverter exceptionConverter) {
+	public ResultSetIterator(Statement stmt, ResultSet resultset) {
 		this.rs = resultset;
-		this.sec = exceptionConverter;
 		this.statement  = stmt;		
 	}
 
-	protected SQLExceptionConverter getSQLExceptionConverter() {
-		return sec;
-	}
-	
 	public boolean hasNext() {
 		try {
 			advance();

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/SQLServerMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/SQLServerMetaDataDialect.java
@@ -33,7 +33,7 @@ public class SQLServerMetaDataDialect extends JDBCMetaDataDialect {
 				
 				final String sc = schema;
 				final String cat = catalog;
-				return new ResultSetIterator(statement.executeQuery(), getSQLExceptionConverter()) {
+				return new ResultSetIterator(statement.executeQuery()) {
 					
 					Map<String, Object> element = new HashMap<String, Object>();
 					protected Map<String, Object> convertRow(ResultSet tableRs) throws SQLException {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>