### PR TITLE
HBX-1917: Remove the uses of 'org.hibernate.exception.spi.SQLExceptionConverter' - Remove AbstractMetaDataDialect#getSQLExceptionConverter()

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/AbstractMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/AbstractMetaDataDialect.java
@@ -31,16 +31,11 @@ public abstract class AbstractMetaDataDialect implements MetaDataDialect {
 	private DatabaseMetaData metaData;
 	
 	private ConnectionProvider connectionProvider = null;
-	private SQLExceptionConverter exceptionConverter = null;
-
-//	private ReverseEngineeringRuntimeInfo info;
-
 
 	public void configure(
 			ConnectionProvider connectionProvider, 
 			SQLExceptionConverter sqlExceptionConverter) {
 		this.connectionProvider = connectionProvider;	
-		this.exceptionConverter = sqlExceptionConverter;
 	}
 	
 	public void close() {
@@ -50,7 +45,7 @@ public abstract class AbstractMetaDataDialect implements MetaDataDialect {
 				connectionProvider.closeConnection(connection);				
 			}
 			catch (SQLException e) {
-				throw getSQLExceptionConverter().convert(e, "Problem while closing connection", null);
+				throw new RuntimeException("Problem while closing connection", e);
 			} finally {
 				connection = null;
 			}
@@ -131,10 +126,6 @@ public abstract class AbstractMetaDataDialect implements MetaDataDialect {
 		if(iterator instanceof ResultSetIterator) {
 			((ResultSetIterator)iterator).close();
 		}
-	}
-	
-	protected SQLExceptionConverter getSQLExceptionConverter() {
-		return exceptionConverter;
 	}
 	
 	public boolean needQuote(String name) {

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/H2MetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/H2MetaDataDialect.java
@@ -90,12 +90,12 @@ public class H2MetaDataDialect extends JDBCMetaDataDialect {
 					protected Throwable handleSQLException(SQLException e) {
 						// schemaRs and catalogRs are only used for error reporting if
 						// we get an exception
-						throw getSQLExceptionConverter().convert( e,
-								"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", null );					
+						throw new RuntimeException(
+								"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", e );					
 					}
 				};
 			} catch (SQLException e) {
-				throw getSQLExceptionConverter().convert(e, "Could not get list of suggested identity strategies from database. Probably a JDBC driver problem.", null);		         
+				throw new RuntimeException("Could not get list of suggested identity strategies from database. Probably a JDBC driver problem.", e);		         
 			} 		
 	}
 }

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/HSQLMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/HSQLMetaDataDialect.java
@@ -29,7 +29,6 @@ public class HSQLMetaDataDialect extends JDBCMetaDataDialect {
 	}
 	   
 	public Iterator<Map<String, Object>> getSuggestedPrimaryKeyStrategyName(String catalog, String schema, String table) {
-		String sql = null;
 			try {			
 				catalog = caseForSearch( catalog );
 				schema = caseForSearch( schema );
@@ -73,8 +72,8 @@ public class HSQLMetaDataDialect extends JDBCMetaDataDialect {
 									statement.close();
 								}
 								catch (SQLException e) {
-									throw getSQLExceptionConverter().convert(e,
-											"Problem while closing prepared statement", null);				
+									throw new RuntimeException(
+											"Problem while closing prepared statement", e);				
 								}
 							}
 						}
@@ -89,12 +88,12 @@ public class HSQLMetaDataDialect extends JDBCMetaDataDialect {
 					protected Throwable handleSQLException(SQLException e) {
 						// schemaRs and catalogRs are only used for error reporting if
 						// we get an exception
-						throw getSQLExceptionConverter().convert( e,
-								"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", null);					
+						throw new RuntimeException(
+								"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", e);					
 					}
 				};
 			} catch (SQLException e) {
-				throw getSQLExceptionConverter().convert(e, "Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", sql);		         
+				throw new RuntimeException("Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", e);		         
 			} 		
 		}
 }

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/JDBCMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/JDBCMetaDataDialect.java
@@ -40,15 +40,17 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 					// schemaRs and catalogRs are only used for error reporting if
 					// we get an exception
 					String databaseStructure = getDatabaseStructure( catalog, schema );
-					throw getSQLExceptionConverter().convert( e,
+					throw new RuntimeException(
 							"Could not get list of tables from database. Probably a JDBC driver problem. "
-									+ databaseStructure, null );					
+									+ databaseStructure, 
+							e );					
 				}
 			};
 		} catch (SQLException e) {
 			// schemaRs and catalogRs are only used for error reporting if we get an exception
 			String databaseStructure = getDatabaseStructure(xcatalog,xschema);
-			throw getSQLExceptionConverter().convert(e, "Could not get list of tables from database. Probably a JDBC driver problem. " + databaseStructure, null);		         
+			throw new RuntimeException(
+					"Could not get list of tables from database. Probably a JDBC driver problem. " + databaseStructure, e);		         
 		} 		
 	}
 	
@@ -74,11 +76,13 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 					return element;					
 				}
 				protected Throwable handleSQLException(SQLException e) {
-					throw getSQLExceptionConverter().convert(e, "Exception while getting index info for " + TableNameQualifier.qualify(catalog, schema, table), null);
+					throw new RuntimeException(
+							"Exception while getting index info for " + TableNameQualifier.qualify(catalog, schema, table), e);
 				}
 			};
 		} catch (SQLException e) {
-			throw getSQLExceptionConverter().convert(e, "Exception while getting index info for " + TableNameQualifier.qualify(xcatalog, xschema, xtable), null);
+			throw new RuntimeException(
+					"Exception while getting index info for " + TableNameQualifier.qualify(xcatalog, xschema, xtable), e);
 		} 		
 	}
 
@@ -114,11 +118,11 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 					return element;					
 				}
 				protected Throwable handleSQLException(SQLException e) {
-					throw getSQLExceptionConverter().convert(e, "Error while reading column meta data for " + TableNameQualifier.qualify(catalog, schema, table), null);
+					throw new RuntimeException("Error while reading column meta data for " + TableNameQualifier.qualify(catalog, schema, table), e);
 				}
 			};
 		} catch (SQLException e) {
-			throw getSQLExceptionConverter().convert(e, "Error while reading column meta data for " + TableNameQualifier.qualify(xcatalog, xschema, xtable), null);
+			throw new RuntimeException("Error while reading column meta data for " + TableNameQualifier.qualify(xcatalog, xschema, xtable), e);
 		}	
 	}
 
@@ -143,11 +147,14 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 					return element;					
 				}
 				protected Throwable handleSQLException(SQLException e) {
-					throw getSQLExceptionConverter().convert(e, "Error while reading primary key meta data for " + TableNameQualifier.qualify(catalog, schema, table), null);
+					throw new RuntimeException(
+							"Error while reading primary key meta data for " + TableNameQualifier.qualify(catalog, schema, table), 
+							e);
 				}
 			};
 		} catch (SQLException e) {
-			throw getSQLExceptionConverter().convert(e, "Error while reading primary key meta data for " + TableNameQualifier.qualify(xcatalog, xschema, xtable), null);
+			throw new RuntimeException(
+					"Error while reading primary key meta data for " + TableNameQualifier.qualify(xcatalog, xschema, xtable), e);
 		}	
 	}
 
@@ -169,11 +176,13 @@ public class JDBCMetaDataDialect extends AbstractMetaDataDialect {
 					return element;					
 				}
 				protected Throwable handleSQLException(SQLException e) {
-					throw getSQLExceptionConverter().convert(e, "Error while reading exported keys meta data for " + TableNameQualifier.qualify(catalog, schema, table), null);
+					throw new RuntimeException(
+							"Error while reading exported keys meta data for " + TableNameQualifier.qualify(catalog, schema, table), e);
 				}
 			};
 		} catch (SQLException e) {
-			throw getSQLExceptionConverter().convert(e, "Error while reading exported keys meta data for " + TableNameQualifier.qualify(xcatalog, xschema, xtable), null);
+			throw new RuntimeException(
+					"Error while reading exported keys meta data for " + TableNameQualifier.qualify(xcatalog, xschema, xtable), e);
 		}	
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/MySQLMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/MySQLMetaDataDialect.java
@@ -47,12 +47,12 @@ public class MySQLMetaDataDialect extends JDBCMetaDataDialect {
 					protected Throwable handleSQLException(SQLException e) {
 						// schemaRs and catalogRs are only used for error reporting if
 						// we get an exception
-						throw getSQLExceptionConverter().convert( e,
-								"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", null);					
+						throw new RuntimeException(
+								"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", e);					
 					}
 				};
 			} catch (SQLException e) {
-				throw getSQLExceptionConverter().convert(e, "Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", sql);		         
+				throw new RuntimeException("Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", e);		         
 			} 		
 		}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/OracleMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/OracleMetaDataDialect.java
@@ -287,20 +287,20 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 					// we get an exception
 					String databaseStructure = getDatabaseStructure(catalog,
 							schema);
-					throw getSQLExceptionConverter().convert(
-							e,
+					throw new RuntimeException(
 							"Could not get list of tables from database. Probably a JDBC driver problem. "
-									+ databaseStructure, null);
+									+ databaseStructure, 
+							e);
 				}
 			};
 		} catch (SQLException e) {
 			// schemaRs and catalogRs are only used for error reporting if we
 			// get an exception
 			String databaseStructure = getDatabaseStructure(catalog, schema);
-			throw getSQLExceptionConverter().convert(
-					e,
+			throw new RuntimeException(
 					"Could not get list of tables from database. Probably a JDBC driver problem. "
-							+ databaseStructure, null);
+							+ databaseStructure, 
+					e);
 		}
 	}
 	
@@ -332,18 +332,17 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 				}
 
 				protected Throwable handleSQLException(SQLException e) {
-					throw getSQLExceptionConverter().convert(
-							e,
+					throw new RuntimeException(
 							"Exception while getting index info for "
 									+ TableNameQualifier.qualify(catalog, schema, table),
-							null);
+							e);
 				}
 			};
 		} catch (SQLException e) {
-			throw getSQLExceptionConverter().convert(
-					e,
+			throw new RuntimeException (
 					"Exception while getting index info for "
-							+ TableNameQualifier.qualify(catalog, schema, table) + ": " + e.getMessage(), null);
+							+ TableNameQualifier.qualify(catalog, schema, table) + ": " + e.getMessage(),
+					e);
 		}
 	}
 
@@ -377,18 +376,17 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 				}
 
 				protected Throwable handleSQLException(SQLException e) {
-					throw getSQLExceptionConverter().convert(
-							e,
+					throw new RuntimeException(
 							"Error while reading column meta data for "
 									+ TableNameQualifier.qualify(catalog, schema, table),
-							null);
+							e);
 				}
 			};
 		} catch (SQLException e) {
-			throw getSQLExceptionConverter().convert(
-					e,
+			throw new RuntimeException(
 					"Error while reading column meta data for "
-							+ TableNameQualifier.qualify(catalog, schema, table), null);
+							+ TableNameQualifier.qualify(catalog, schema, table), 
+					e);
 		}
 	}
 
@@ -419,18 +417,17 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 				}
 
 				protected Throwable handleSQLException(SQLException e) {
-					throw getSQLExceptionConverter().convert(
-							e,
+					throw new RuntimeException(
 							"Error while reading primary key meta data for "
 									+ TableNameQualifier.qualify(catalog, schema, table),
-							null);
+							e);
 				}
 			};
 		} catch (SQLException e) {
-			throw getSQLExceptionConverter().convert(
-					e,
+			throw new RuntimeException(
 					"Error while reading primary key meta data for "
-							+ TableNameQualifier.qualify(catalog, schema, table), null);
+							+ TableNameQualifier.qualify(catalog, schema, table), 
+					e);
 		}
 	}
 
@@ -464,18 +461,17 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 				}
 
 				protected Throwable handleSQLException(SQLException e) {
-					throw getSQLExceptionConverter().convert(
-							e,
+					throw new RuntimeException(
 							"Error while reading exported keys meta data for "
 									+ TableNameQualifier.qualify(catalog, schema, table),
-							null);
+							e);
 				}
 			};
 		} catch (SQLException e) {
-			throw getSQLExceptionConverter().convert(
-					e,
+			throw new RuntimeException(
 					"Error while reading exported keys meta data for "
-							+ TableNameQualifier.qualify(catalog, schema, table), null);
+							+ TableNameQualifier.qualify(catalog, schema, table), 
+					e);
 		}
 	}	
 	
@@ -519,8 +515,8 @@ public class OracleMetaDataDialect extends AbstractMetaDataDialect {
 				ps.close();
 			}
 			catch (SQLException e) {
-				throw getSQLExceptionConverter().convert(e,
-						"Problem while closing prepared statement", null);				
+				throw new RuntimeException(
+						"Problem while closing prepared statement", e);				
 			}
 			return null;
 		}

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/SQLServerMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/SQLServerMetaDataDialect.java
@@ -61,12 +61,13 @@ public class SQLServerMetaDataDialect extends JDBCMetaDataDialect {
 					protected Throwable handleSQLException(SQLException e) {
 						// schemaRs and catalogRs are only used for error reporting if
 						// we get an exception
-						throw getSQLExceptionConverter().convert( e,
-								"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", null);					
+						throw new RuntimeException(
+								"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", e);					
 					}
 				};
 			} catch (SQLException e) {
-				throw getSQLExceptionConverter().convert(e, "Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", sql);		         
+				throw new RuntimeException(
+						"Could not get list of suggested identity strategies from database. Probably a JDBC driver problem. ", e);		         
 			} 		
 		}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>