### PR TITLE
HBX-1917: Remove the uses of 'org.hibernate.exception.spi.SQLExceptionConverter' - Replace MetaDataDialect#configure(ConnectionProvider,SQLExceptionConverter) by MetaDataDialect#configure(ConnectionProvider)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/dialect/MetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/api/dialect/MetaDataDialect.java
@@ -4,7 +4,6 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
-import org.hibernate.exception.spi.SQLExceptionConverter;
 
 /**
  * Interface for fetching metadata from databases.
@@ -22,9 +21,8 @@ public interface MetaDataDialect {
 	/**
 	 * Configure the metadatadialect. 
 	 * @param connectionProvider a {@link ConnectionProvider} 
-     * @param sqlExceptionConverter a {@link SQLExceptionConverter}
 	 */
-	public void configure(ConnectionProvider connectionProvider, SQLExceptionConverter sqlExceptionConverter);
+	public void configure(ConnectionProvider connectionProvider);
 	
 	/** 
 	 * Return iterator over the tables that mathces catalog, schema and table

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/AbstractMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/AbstractMetaDataDialect.java
@@ -12,7 +12,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
-import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.jboss.logging.Logger;
 
@@ -33,8 +32,7 @@ public abstract class AbstractMetaDataDialect implements MetaDataDialect {
 	private ConnectionProvider connectionProvider = null;
 
 	public void configure(
-			ConnectionProvider connectionProvider, 
-			SQLExceptionConverter sqlExceptionConverter) {
+			ConnectionProvider connectionProvider) {
 		this.connectionProvider = connectionProvider;	
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/dialect/CachedMetaDataDialect.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/dialect/CachedMetaDataDialect.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
-import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 
 public class CachedMetaDataDialect implements MetaDataDialect {
@@ -29,9 +28,8 @@ public class CachedMetaDataDialect implements MetaDataDialect {
 	}
 
 	public void configure(
-			ConnectionProvider connectionProvider, 
-			SQLExceptionConverter sqlExceptionConverter) {
-        delegate.configure(connectionProvider, sqlExceptionConverter);       
+			ConnectionProvider connectionProvider) {
+        delegate.configure(connectionProvider);       
     }
 	
 	public void close(Iterator<?> iterator) {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
@@ -50,7 +50,7 @@ public class JDBCReader {
 		
 	public List<Table> readDatabaseSchema(DatabaseCollector dbs, String catalog, String schema, ProgressListener progress) {
 		try {
-			getMetaDataDialect().configure(provider, sec);
+			getMetaDataDialect().configure(provider);
 			revengStrategy.configure(dbs);
 			
 			Set<Table> hasIndices = new HashSet<Table>();

--- a/test/common/src/main/java/org/hibernate/tool/cfg/DriverMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/cfg/DriverMetaData/TestCase.java
@@ -12,7 +12,6 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
@@ -51,12 +50,9 @@ public class TestCase {
 		MetaDataDialect dialect = new JDBCMetaDataDialect();
 		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
 		ServiceRegistry serviceRegistry = ssrb.build();
-		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
 		ConnectionProvider connectionProvider = 
 				serviceRegistry.getService(ConnectionProvider.class);			
-		dialect.configure(
-				connectionProvider,
-				jdbcServices.getSqlExceptionHelper().getSqlExceptionConverter());
+		dialect.configure(connectionProvider);
 		String catalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		String schema = properties.getProperty(AvailableSettings.DEFAULT_SCHEMA);		
 		Iterator<Map<String,Object>> tables = 
@@ -92,12 +88,9 @@ public class TestCase {
 	public void testDataType() {	
 		MetaDataDialect dialect = MetaDataDialectFactory
 				.fromDialectName(properties.getProperty(AvailableSettings.DIALECT));
-		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
 		ConnectionProvider connectionProvider = 
 				serviceRegistry.getService(ConnectionProvider.class);	
-		dialect.configure(
-				connectionProvider,
-				jdbcServices.getSqlExceptionHelper().getSqlExceptionConverter());
+		dialect.configure(connectionProvider);
 		String catalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		String schema = properties.getProperty(AvailableSettings.DEFAULT_SCHEMA);		
 		Iterator<?> tables = 
@@ -115,12 +108,9 @@ public class TestCase {
 	@Test
 	public void testCaseTest() {
 		MetaDataDialect dialect = new JDBCMetaDataDialect();
-		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
 		ConnectionProvider connectionProvider = 
 				serviceRegistry.getService(ConnectionProvider.class);
-		dialect.configure( 
-				connectionProvider,
-				jdbcServices.getSqlExceptionHelper().getSqlExceptionConverter());
+		dialect.configure(connectionProvider);
 		String catalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		String schema = properties.getProperty(AvailableSettings.DEFAULT_SCHEMA);		
 		Iterator<Map<String, Object>> tables = 

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
@@ -13,7 +13,6 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
-import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
@@ -56,8 +55,8 @@ public class TestCase {
 			delegate.close( iterator );
 		}
 
-		public void configure(ConnectionProvider cp, SQLExceptionConverter sec) {
-			delegate.configure(cp, sec);			
+		public void configure(ConnectionProvider cp) {
+			delegate.configure(cp);			
 		}
 		
 		public Iterator<Map<String, Object>> getColumns(String catalog, String schema, String table, String column) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>