### PR TITLE
HBX-1917: Remove the uses of 'org.hibernate.exception.spi.SQLExceptionConverter' - Remove the SQLExceptionConverter instance variable from JDBCReader and the SQLExceptionConverter argument from the JDBCReader(...) constructor

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JDBCReader.java
@@ -14,7 +14,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
-import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
@@ -31,15 +30,12 @@ public class JDBCReader {
 
 	private final ConnectionProvider provider;
 
-	private final SQLExceptionConverter sec;
-
 	private final String defaultSchema;
 	private final String defaultCatalog;
 	
-	public JDBCReader(MetaDataDialect dialect, ConnectionProvider provider, SQLExceptionConverter sec, String defaultCatalog, String defaultSchema, ReverseEngineeringStrategy reveng) {
+	public JDBCReader(MetaDataDialect dialect, ConnectionProvider provider, String defaultCatalog, String defaultSchema, ReverseEngineeringStrategy reveng) {
 		this.metadataDialect = dialect;
 		this.provider = provider;
-		this.sec = sec;
 		this.revengStrategy = reveng;
 		this.defaultCatalog = defaultCatalog;
 		this.defaultSchema = defaultSchema;
@@ -168,7 +164,7 @@ public class JDBCReader {
 					}
 
 				} catch (SQLException e) {
-					sec.convert(e, "Problem while closing connection", null);
+					throw new RuntimeException("Problem while closing connection", e);
 				}
 				finally {
 					if(connection!=null)
@@ -176,7 +172,7 @@ public class JDBCReader {
 							provider.closeConnection( connection );
 						}
 						catch (SQLException e) {
-							sec.convert(e, "Problem while closing connection", null);
+							throw new RuntimeException("Problem while closing connection", e);
 						}
 				} 
 			}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcReaderFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcReaderFactory.java
@@ -5,7 +5,6 @@ import java.util.Properties;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
-import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
@@ -30,10 +29,6 @@ final public class JdbcReaderFactory {
 			ReverseEngineeringStrategy revengStrategy, 
 			MetaDataDialect mdd,
 			ServiceRegistry serviceRegistry) {
-		SQLExceptionConverter sqlExceptionConverter = serviceRegistry
-				.getService(JdbcServices.class)
-				.getSqlExceptionHelper()
-				.getSqlExceptionConverter();
 		ConnectionProvider connectionProvider = serviceRegistry
 				.getService(ConnectionProvider.class);
 		String defaultCatalogName = properties
@@ -43,7 +38,6 @@ final public class JdbcReaderFactory {
 		return new JDBCReader(
 				mdd, 
 				connectionProvider, 
-				sqlExceptionConverter, 
 				defaultCatalogName, 
 				defaultSchemaName, 
 				revengStrategy );


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>