### PR TITLE
HBX-1910: Refactor JdbcMetadataBuilder into smaller responsibilities - Move 'metadataCollector.processSecondPasses(metadataBuildingContext)' to JdbcMetadataBuilder#createPersistentClasses(...)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
@@ -111,7 +111,6 @@ public class JdbcMetadataBuilder {
 		Metadata result = createMetadata();		
 	    DatabaseCollector collector = readFromDatabase();
         createPersistentClasses(collector, result); //move this to a different step!
-		metadataCollector.processSecondPasses(metadataBuildingContext);		
 		return result;
 	}
 	
@@ -204,7 +203,8 @@ public class JdbcMetadataBuilder {
 			updatePrimaryKey(rc, pki);
 
 		}
-
+		
+		metadataCollector.processSecondPasses(metadataBuildingContext);		
 	}
 
 	private void updatePrimaryKey(RootClass rc, PrimaryKeyInfo pki) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>