### PR TITLE
HBX-1919: Move 'org.hibernate.tool.internal.reveng.BinderUtils' to 'org.hibernate.tool.internal.reveng.binder.BinderUtils'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
@@ -54,6 +54,7 @@ import org.hibernate.tool.api.reveng.AssociationInfo;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.binder.BinderUtils;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.hibernate.type.ForeignKeyDirection;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.binder;
 
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>