### PR TITLE
HBX-1910: Refactor JdbcMetadataBuilder into smaller responsibilities - Move class PropertyBinder from org.hibernate.tool.internal.reveng to org.hibernate.tool.internal.reveng.binder

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
@@ -55,6 +55,7 @@ import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.binder.BinderUtils;
+import org.hibernate.tool.internal.reveng.binder.PropertyBinder;
 import org.hibernate.tool.internal.reveng.binder.SimpleValueBinder;
 import org.hibernate.tool.internal.reveng.binder.TypeUtils;
 import org.hibernate.type.ForeignKeyDirection;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PropertyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PropertyBinder.java
@@ -1,9 +1,10 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.binder;
 
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.MetaAttributesBinder;
 import org.jboss.logging.Logger;
 
 public class PropertyBinder {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/SimpleValueBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/SimpleValueBinder.java
@@ -23,7 +23,8 @@ public class SimpleValueBinder {
 		value.setTypeName(TypeUtils.determinePreferredType(
 				metadataCollector, 
 				revengStrategy,
-				table, column, 
+				table, 
+				column, 
 				mapping, 
 				generatedIdentifier));
 		return value;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>