### PR TITLE
HBX-1910: Refactor JdbcMetadataBuilder into smaller responsibilities - Extract JdbcMetadataBuilder#columnMatches(...) into new class 'org.hibernate.tool.internal.reveng.binder.ForeignKeyUtils'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
@@ -56,6 +56,7 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.binder.BasicPropertyBinder;
 import org.hibernate.tool.internal.reveng.binder.BinderUtils;
+import org.hibernate.tool.internal.reveng.binder.ForeignKeyUtils;
 import org.hibernate.tool.internal.reveng.binder.PropertyBinder;
 import org.hibernate.tool.internal.reveng.binder.SimpleValueBinder;
 import org.hibernate.tool.internal.reveng.binder.TypeUtils;
@@ -975,8 +976,8 @@ public class JdbcMetadataBuilder {
     		foreignKeyIterator = tempList.iterator();
     		while(foreignKeyIterator.hasNext()) {
     			ForeignKey key = (ForeignKey) foreignKeyIterator.next();
-    			List<Column> matchingColumns = columnMatches(myPkColumns, i, key);
-    			if(matchingColumns!=null) {
+    			List<Column> matchingColumns = ForeignKeyUtils.columnMatches(myPkColumns, i, key);
+    			if(!matchingColumns.isEmpty()) {
     				result.add(new ForeignKeyForColumns(key, matchingColumns));
     				i+=matchingColumns.size()-1;
     				foreignKeyIterator.remove();
@@ -992,24 +993,6 @@ public class JdbcMetadataBuilder {
 
     	return result;
     }
-
-    private List<Column> columnMatches(Column[] myPkColumns, int offset, ForeignKey key) {
-
-    	if(key.getColumnSpan()>(myPkColumns.length-offset)) {
-    		return null; // not enough columns in the key
-    	}
-
-    	List<Column> columns = new ArrayList<Column>();
-    	for (int j = 0; j < key.getColumnSpan(); j++) {
-			Column column = myPkColumns[j+offset];
-			if(!column.equals(key.getColumn(j))) {
-				return null;
-			} else {
-				columns.add(column);
-			}
-		}
-		return columns.isEmpty()?null:columns;
-	}
 
 	static class ForeignKeyForColumns {
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
@@ -9,7 +9,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.internal.util.collections.JoinedIterator;
+import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Component;
+import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyUtils.java
@@ -1,0 +1,31 @@
+package org.hibernate.tool.internal.reveng.binder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.ForeignKey;
+
+public class ForeignKeyUtils {
+
+    public static List<Column> columnMatches(
+    		Column[] pkColumns, 
+    		int offset, 
+    		ForeignKey fk) {
+    	List<Column> result = new ArrayList<Column>();
+    	int columnSpan = fk.getColumnSpan();
+    	if (columnSpan <= pkColumns.length-offset) {
+    		for (int i = 0; i < columnSpan; i++) {
+    			Column column = pkColumns[i + offset];
+    			if(column.equals(fk.getColumn(i))) {
+    				result.add(column);
+    			} else {
+    				result.clear();
+    				break;
+    			}
+			}
+		}
+		return result;
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>