### PR TITLE
HBX-1910: Refactor JdbcMetadataBuilder into smaller responsibilities - Create class 'org.hibernate.tool.internal.reveng.ReverseEngineeringContext' to aggregate the binding context and use it in RootClassBinder

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
@@ -22,7 +22,6 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
-import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.binder.RootClassBinder;
@@ -48,8 +47,8 @@ public class JdbcMetadataBuilder {
 	private final MetadataBuildingContext metadataBuildingContext;	
 	private final InFlightMetadataCollectorImpl metadataCollector;	
 	private final ReverseEngineeringStrategy revengStrategy;
+	private final ReverseEngineeringContext reverseEngineeringContext;
 	
-	private boolean preferBasicCompositeIds;
 	private final StandardServiceRegistry serviceRegistry;
 	private final String defaultCatalog;
 	private final String defaultSchema;
@@ -73,9 +72,14 @@ public class JdbcMetadataBuilder {
 						bootstrapContext,
 						metadataBuildingOptions);
 		this.metadataBuildingContext = new MetadataBuildingContextRootImpl(bootstrapContext, metadataBuildingOptions, metadataCollector);
-		this.preferBasicCompositeIds = (Boolean)properties.get(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS);
 		this.defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		this.defaultSchema = properties.getProperty(AvailableSettings.DEFAULT_SCHEMA);
+		this.reverseEngineeringContext = ReverseEngineeringContext
+				.create(
+						metadataBuildingContext, 
+						metadataCollector, 
+						reverseEngineeringStrategy, 
+						properties);
 	}
 
 	public Metadata build() {
@@ -122,13 +126,7 @@ public class JdbcMetadataBuilder {
                 // TODO: just create one big embedded composite id instead.
             }*/
 			RootClassBinder
-				.create(
-						metadataBuildingContext,
-						metadataCollector, 
-						revengStrategy, 
-						defaultCatalog, 
-						defaultSchema, 
-						preferBasicCompositeIds)
+				.create(reverseEngineeringContext)
 				.bind(table, collector, mapping);
 		}		
 		metadataCollector.processSecondPasses(metadataBuildingContext);		

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/ReverseEngineeringContext.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/ReverseEngineeringContext.java
@@ -1,0 +1,39 @@
+package org.hibernate.tool.internal.reveng;
+
+import java.util.Properties;
+
+import org.hibernate.boot.spi.InFlightMetadataCollector;
+import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+
+public class ReverseEngineeringContext {
+	
+	public static ReverseEngineeringContext create(
+			MetadataBuildingContext metadataBuildingContext,
+			InFlightMetadataCollector metadataCollector,
+			ReverseEngineeringStrategy revengStrategy,
+			Properties properties) {
+		return new ReverseEngineeringContext(
+				metadataBuildingContext, 
+				metadataCollector, 
+				revengStrategy, 
+				properties);
+	}
+	
+	public final MetadataBuildingContext metadataBuildingContext;
+	public final InFlightMetadataCollector metadataCollector;
+	public final ReverseEngineeringStrategy revengStrategy;
+	public final Properties properties;
+	
+	private ReverseEngineeringContext(
+			MetadataBuildingContext metadataBuildingContext,
+			InFlightMetadataCollector metadataCollector,
+			ReverseEngineeringStrategy revengStrategy,
+			Properties properties) {
+		this.metadataBuildingContext = metadataBuildingContext;
+		this.metadataCollector = metadataCollector;
+		this.revengStrategy = revengStrategy;
+		this.properties = properties;
+	}
+
+}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 import org.hibernate.DuplicateMappingException;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Column;
@@ -18,30 +19,27 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Table;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.PrimaryKeyInfo;
 import org.hibernate.tool.internal.reveng.RevEngUtils;
+import org.hibernate.tool.internal.reveng.ReverseEngineeringContext;
 
 public class RootClassBinder {
 	
 	private static final Logger LOGGER = Logger.getLogger(RootClassBinder.class.getName());
 	
 	public static RootClassBinder create(
-			MetadataBuildingContext metadataBuildingContext,
-			InFlightMetadataCollector metadataCollector,
-			ReverseEngineeringStrategy revengStrategy,
-			String defaultCatalog,
-			String defaultSchema,
-			boolean preferBasicCompositeIds) {
+			ReverseEngineeringContext binderContext) {
 		return new RootClassBinder(
-				metadataBuildingContext, 
-				metadataCollector, 
-				revengStrategy, 
-				defaultCatalog, 
-				defaultSchema, 
-				preferBasicCompositeIds);
+				binderContext.metadataBuildingContext, 
+				binderContext.metadataCollector, 
+				binderContext.revengStrategy, 
+				binderContext.properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
+				binderContext.properties.getProperty(AvailableSettings.DEFAULT_SCHEMA),
+				(Boolean)binderContext.properties.get(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS));
 	}
 	
 	private final MetadataBuildingContext metadataBuildingContext;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>