### PR TITLE
HBX-1910: Refactor JdbcMetadataBuilder into smaller responsibilities - Move class BinderContext from 'org.hibernate.tool.internal.reveng' to 'org.hibernate.tool.internal.reveng.binder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
@@ -23,6 +23,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.binder.BinderContext;
 import org.hibernate.tool.internal.reveng.binder.RootClassBinder;
 import org.jboss.logging.Logger;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderContext.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderContext.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.binder;
 
 import java.util.Properties;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
@@ -25,7 +25,6 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.PrimaryKeyInfo;
 import org.hibernate.tool.internal.reveng.RevEngUtils;
-import org.hibernate.tool.internal.reveng.BinderContext;
 
 public class RootClassBinder {
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>