### PR TITLE
HBX-1910: Refactor JdbcMetadataBuilder into smaller responsibilities - Move class BinderMapping from 'org.hibernate.tool.internal.reveng' to 'org.hibernate.tool.internal.reveng.binder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/JdbcMetadataBuilder.java
@@ -24,6 +24,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.binder.BinderContext;
+import org.hibernate.tool.internal.reveng.binder.BinderMapping;
 import org.hibernate.tool.internal.reveng.binder.RootClassBinder;
 import org.jboss.logging.Logger;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderMapping.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderMapping.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.binder;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.Metadata;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>