### PR TITLE
HBX-1928: Improve implementation of OneToOneBinder- Rewrite OneToOneBinder#create(...) and OneToOneBinder constructor with only BinderContext argument

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyBinder.java
@@ -29,8 +29,10 @@ public class ForeignKeyBinder {
 	private ReverseEngineeringStrategy revengStrategy;
 	private String defaultCatalog;
 	private String defaultSchema;
+	private final OneToOneBinder oneToOneBinder;
 	
 	private ForeignKeyBinder(BinderContext binderContext) {
+		this.oneToOneBinder = OneToOneBinder.create(binderContext);
 		this.metadataBuildingContext = binderContext.metadataBuildingContext;
 		this.metadataCollector = binderContext.metadataCollector;
 		this.revengStrategy = binderContext.revengStrategy;
@@ -51,12 +53,7 @@ public class ForeignKeyBinder {
 				foreignKey.getReferencedColumns())) {
 			LOGGER.log(Level.INFO, "Rev.eng excluded one-to-many or one-to-one for foreignkey " + foreignKey.getName());
 		} else if (revengStrategy.isOneToOne(foreignKey)){
-        	Property property = OneToOneBinder
-        			.create(
-        					metadataBuildingContext, 
-        					revengStrategy, 
-        					defaultCatalog, 
-        					defaultSchema)
+        	Property property = oneToOneBinder
         			.bind(
         					persistentClass, 
         					foreignKey.getTable(), 
@@ -97,12 +94,7 @@ public class ForeignKeyBinder {
         	// TODO: if many-to-one is excluded should the column be marked as processed so it won't show up at all ?
         	LOGGER.log(Level.INFO, "Rev.eng excluded *-to-one for foreignkey " + foreignKey.getName());
         } else if (revengStrategy.isOneToOne(foreignKey)){
-        	Property property = OneToOneBinder
-        			.create(
-        					metadataBuildingContext, 
-        					revengStrategy, 
-        					defaultCatalog, 
-        					defaultSchema)
+        	Property property = oneToOneBinder
         			.bind(
         					rc, 
         					foreignKey.getReferencedTable(), 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToOneBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToOneBinder.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.hibernate.FetchMode;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.OneToOne;
@@ -17,16 +18,8 @@ import org.hibernate.type.ForeignKeyDirection;
 
 public class OneToOneBinder {
 	
-	public static OneToOneBinder create(
-			MetadataBuildingContext metadataBuildingContext,
-			ReverseEngineeringStrategy revengStrategy,
-			String defaultCatalog,
-			String defaultSchema) {
-		return new OneToOneBinder(
-				metadataBuildingContext, 
-				revengStrategy, 
-				defaultCatalog, 
-				defaultSchema); 
+	public static OneToOneBinder create(BinderContext binderContext) {
+		return new OneToOneBinder(binderContext); 
 	}
 	
 	private final MetadataBuildingContext metadataBuildingContext;
@@ -34,15 +27,11 @@ public class OneToOneBinder {
 	private final String defaultCatalog;
 	private final String defaultSchema;
 	
-	private OneToOneBinder(
-			MetadataBuildingContext metadataBuildingContext,
-			ReverseEngineeringStrategy revengStrategy,
-			String defaultCatalog,
-			String defaultSchema) {
-		this.metadataBuildingContext = metadataBuildingContext;
-		this.revengStrategy = revengStrategy;
-		this.defaultCatalog = defaultCatalog;
-		this.defaultSchema = defaultSchema;
+	private OneToOneBinder(BinderContext binderContext) {
+		this.metadataBuildingContext = binderContext.metadataBuildingContext;
+		this.revengStrategy = binderContext.revengStrategy;
+		this.defaultCatalog = binderContext.properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
+		this.defaultSchema = binderContext.properties.getProperty(AvailableSettings.DEFAULT_SCHEMA);
 	}
 
     public Property bind(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>