### PR TITLE
HBX-1932: Improve implementation of class CollectionPropertyBinder- Rewrite CollectionPropertyBinder#create(...) and CollectionPropertyBinder constructor with only BinderContext argument

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/CollectionPropertyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/CollectionPropertyBinder.java
@@ -1,6 +1,7 @@
 package org.hibernate.tool.internal.reveng.binder;
 
 import org.hibernate.FetchMode;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Property;
@@ -10,27 +11,18 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 
 public class CollectionPropertyBinder {
 	
-	public static CollectionPropertyBinder create(
-			ReverseEngineeringStrategy revengStrategy,
-			String defaultCatalog,
-			String defaultSchema) {
-		return new CollectionPropertyBinder(
-				revengStrategy,
-				defaultCatalog,
-				defaultSchema);
+	public static CollectionPropertyBinder create(BinderContext binderContext) {
+		return new CollectionPropertyBinder(binderContext);
 	}
 	
 	private final ReverseEngineeringStrategy revengStrategy;
 	private final String defaultCatalog;
 	private final String defaultSchema;
 	
-	private CollectionPropertyBinder(
-			ReverseEngineeringStrategy revengStrategy,
-			String defaultCatalog,
-			String defaultSchema) {
-		this.revengStrategy = revengStrategy;
-		this.defaultCatalog = defaultCatalog;
-		this.defaultSchema = defaultSchema;
+	private CollectionPropertyBinder(BinderContext binderContext) {
+		this.revengStrategy = binderContext.revengStrategy;
+		this.defaultCatalog = binderContext.properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
+		this.defaultSchema = binderContext.properties.getProperty(AvailableSettings.DEFAULT_SCHEMA);
 	}
 
     public Property bind(

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import org.hibernate.FetchMode;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Collection;
@@ -35,15 +34,13 @@ public class OneToManyBinder {
 	private final MetadataBuildingContext metadataBuildingContext;
 	private final InFlightMetadataCollector metadataCollector;
 	private final ReverseEngineeringStrategy revengStrategy;
-	private final String defaultCatalog;
-	private final String defaultSchema;
+	private final CollectionPropertyBinder collectionPropertyBinder;
 	
 	private OneToManyBinder(BinderContext binderContext) {
 		this.metadataBuildingContext = binderContext.metadataBuildingContext;
 		this.metadataCollector = binderContext.metadataCollector;
 		this.revengStrategy = binderContext.revengStrategy;
-		this.defaultCatalog = binderContext.properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
-		this.defaultSchema = binderContext.properties.getProperty(AvailableSettings.DEFAULT_SCHEMA);
+		this.collectionPropertyBinder = CollectionPropertyBinder.create(binderContext);
 	}
 
 	public Property bind(
@@ -151,11 +148,7 @@ public class OneToManyBinder {
 
 		metadataCollector.addCollectionBinding(collection);
 
-		return CollectionPropertyBinder
-				.create(
-						revengStrategy, 
-						defaultCatalog, 
-						defaultSchema)
+		return collectionPropertyBinder
 				.bind(
 						StringHelper.unqualify( collection.getRole()), 
 						true, rc.getTable(), 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>