### PR TITLE
HBX-1926: Pull up common implementation details of the Binder classes into an AbstractBinder common superclass - Make SimpleValueBinder a subclass of AbstractBinder

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/SimpleValueBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/SimpleValueBinder.java
@@ -5,16 +5,14 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 
-public class SimpleValueBinder {
+public class SimpleValueBinder extends AbstractBinder {
 	
 	public static SimpleValueBinder create(BinderContext binderContext) {
 		return new SimpleValueBinder(binderContext);
 	}
 	
-	private final BinderContext binderContext;
-	
 	public SimpleValueBinder(BinderContext binderContext) {
-		this.binderContext = binderContext;
+		super(binderContext);
 	}
 	
 	public SimpleValue bind(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>