### PR TITLE
HBX-1926: Pull up common implementation details of the Binder classes into an AbstractBinder common superclass - Create and use AbstractBinder#getMetadataBuildingContext()

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
@@ -1,5 +1,7 @@
 package org.hibernate.tool.internal.reveng.binder;
 
+import org.hibernate.boot.spi.MetadataBuildingContext;
+
 public abstract class AbstractBinder {
 	
 	final BinderContext binderContext;
@@ -7,5 +9,9 @@ public abstract class AbstractBinder {
 	AbstractBinder(BinderContext binderContext) {
 		this.binderContext = binderContext;
 	}
-
+	
+	MetadataBuildingContext getMetadataBuildingContext() {
+		return binderContext.metadataBuildingContext;
+	}
+	
 }

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/SimpleValueBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/SimpleValueBinder.java
@@ -20,7 +20,7 @@ public class SimpleValueBinder extends AbstractBinder {
 			Column column,
 			Mapping mapping,
 			boolean generatedIdentifier) {
-		SimpleValue value = new SimpleValue(binderContext.metadataBuildingContext, table);
+		SimpleValue value = new SimpleValue(getMetadataBuildingContext(), table);
 		value.addColumn(column);
 		value.setTypeName(TypeUtils.determinePreferredType(
 				binderContext.metadataCollector, 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>