### PR TITLE
HBX-1926: Pull up common implementation details of the Binder classes into an AbstractBinder common superclass - Create and use AbstractBinder#getMetadataCollector()

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
@@ -1,5 +1,6 @@
 package org.hibernate.tool.internal.reveng.binder;
 
+import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 
 public abstract class AbstractBinder {
@@ -12,6 +13,10 @@ public abstract class AbstractBinder {
 	
 	MetadataBuildingContext getMetadataBuildingContext() {
 		return binderContext.metadataBuildingContext;
+	}
+	
+	InFlightMetadataCollector getMetadataCollector() {
+		return binderContext.metadataCollector;
 	}
 	
 }

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/SimpleValueBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/SimpleValueBinder.java
@@ -23,7 +23,7 @@ public class SimpleValueBinder extends AbstractBinder {
 		SimpleValue value = new SimpleValue(getMetadataBuildingContext(), table);
 		value.addColumn(column);
 		value.setTypeName(TypeUtils.determinePreferredType(
-				binderContext.metadataCollector, 
+				getMetadataCollector(), 
 				binderContext.revengStrategy,
 				table, 
 				column, 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>