### PR TITLE
HBX-1926: Pull up common implementation details of the Binder classes into an AbstractBinder common superclass - Create AbstractBinder#getDeefaultCatalog()

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
@@ -2,6 +2,7 @@ package org.hibernate.tool.internal.reveng.binder;
 
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 
 public abstract class AbstractBinder {
@@ -22,6 +23,10 @@ public abstract class AbstractBinder {
 	
 	ReverseEngineeringStrategy getRevengStrategy() {
 		return binderContext.revengStrategy;
+	}
+	
+	String getDefaultCatalog() {
+		return binderContext.properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>