### PR TITLE
HBX-1926: Pull up common implementation details of the Binder classes into an AbstractBinder common superclass - Create AbstractBinder#getDeefaultSchema()

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
@@ -29,4 +29,8 @@ public abstract class AbstractBinder {
 		return binderContext.properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 	}
 	
+	String getDefaultSchema() {
+		return binderContext.properties.getProperty(AvailableSettings.DEFAULT_SCHEMA);
+	}
+	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>