### PR TITLE
HBX-1926: Pull up common implementation details of the Binder classes into an AbstractBinder common superclass - Make AbstractBinder constructor package protected

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
@@ -6,7 +6,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 
-public abstract class AbstractBinder {
+abstract class AbstractBinder {
 	
 	final BinderContext binderContext;
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>