### PR TITLE
HBX-1938: Use List<?> instead of List<Column> as arguments in ReverseEngineeringStrategy#excludeForeignKeyAsCollection(...) and ReverseEngineeringStrategy#excludeForeignKeyAsCollection(...)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategy.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.Table;
@@ -137,7 +136,7 @@ public interface ReverseEngineeringStrategy {
 	public Map<String, MetaAttribute> columnToMetaAttributes(TableIdentifier identifier, String column);
 	
 	/** Should this foreignkey be excluded as a oneToMany */
-	public boolean excludeForeignKeyAsCollection(String keyname, TableIdentifier fromTable, List<Column> fromColumns, TableIdentifier referencedTable, List<Column> referencedColumns);
+	public boolean excludeForeignKeyAsCollection(String keyname, TableIdentifier fromTable, List<?> fromColumns, TableIdentifier referencedTable, List<?> referencedColumns);
 
 	/** Should this foreignkey be excluded as a many-to-one */
 	public boolean excludeForeignKeyAsManytoOne(String keyname, TableIdentifier fromTable, List<?> fromColumns, TableIdentifier referencedTable, List<?> referencedColumns);

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DefaultReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DefaultReverseEngineeringStrategy.java
@@ -212,7 +212,7 @@ public class DefaultReverseEngineeringStrategy implements ReverseEngineeringStra
 		return null;
 	}
 
-	public boolean excludeForeignKeyAsCollection(String keyname, TableIdentifier fromTable, List<Column> fromColumns, TableIdentifier referencedTable, List<Column> referencedColumns) {
+	public boolean excludeForeignKeyAsCollection(String keyname, TableIdentifier fromTable, List<?> fromColumns, TableIdentifier referencedTable, List<?> referencedColumns) {
 		return !settings.createCollectionForForeignKey();		
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.Table;
@@ -99,7 +98,7 @@ public class DelegatingReverseEngineeringStrategy implements ReverseEngineeringS
 		return delegate==null?null:delegate.tableToCompositeIdName(identifier);
 	}
 
-	public boolean excludeForeignKeyAsCollection(String keyname, TableIdentifier fromTable, List<Column> fromColumns, TableIdentifier referencedTable, List<Column> referencedColumns) {
+	public boolean excludeForeignKeyAsCollection(String keyname, TableIdentifier fromTable, List<?> fromColumns, TableIdentifier referencedTable, List<?> referencedColumns) {
 		return delegate==null?false:delegate.excludeForeignKeyAsCollection(keyname, fromTable, fromColumns, referencedTable, referencedColumns);
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/OverrideRepository.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/OverrideRepository.java
@@ -22,7 +22,6 @@ import org.apache.commons.collections4.MultiValuedMap;
 import org.hibernate.MappingException;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.xml.ErrorLogger;
-import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.Table;
@@ -463,9 +462,9 @@ public class OverrideRepository  {
 			public boolean excludeForeignKeyAsCollection(
 					String keyname, 
 					TableIdentifier fromTable, 
-					List<Column> fromColumns, 
+					List<?> fromColumns, 
 					TableIdentifier referencedTable, 
-					List<Column> referencedColumns) {
+					List<?> referencedColumns) {
 				Boolean bool = foreignKeyInverseExclude.get(keyname);
 				if(bool!=null) {
 					return bool.booleanValue();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>