### PR TITLE
HBX-1929: Improve implementation of class OneToManyBinder - Remove argument 'mapping' from OneToManyBinder#bind(...)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyBinder.java
@@ -54,12 +54,7 @@ public class ForeignKeyBinder extends AbstractBinder {
         					true);
 			persistentClass.addProperty(property);
 		} else {
-			Property property = oneToManyBinder
-					.bind(
-							persistentClass, 
-							foreignKey, 
-							processed, 
-							mapping);
+			Property property = oneToManyBinder.bind(persistentClass, foreignKey, processed);
 			persistentClass.addProperty(property);
 		}		
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.FetchMode;
-import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Column;
@@ -35,11 +34,7 @@ public class OneToManyBinder extends AbstractBinder {
 		this.collectionPropertyBinder = CollectionPropertyBinder.create(binderContext);
 	}
 
-	public Property bind(
-			PersistentClass rc, 
-			ForeignKey foreignKey, 
-			Set<Column> processed, 
-			Mapping mapping) {
+	public Property bind(PersistentClass rc, ForeignKey foreignKey, Set<Column> processed) {
 
 		Table collectionTable = foreignKey.getTable();
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>