### PR TITLE
HBX-1929: Improve implementation of class OneToManyBinder - Remove unused 'Set<Column> processed' argument from OneToManyBinder#bind(...)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyBinder.java
@@ -54,7 +54,7 @@ public class ForeignKeyBinder extends AbstractBinder {
         					true);
 			persistentClass.addProperty(property);
 		} else {
-			Property property = oneToManyBinder.bind(persistentClass, foreignKey, processed);
+			Property property = oneToManyBinder.bind(persistentClass, foreignKey);
 			persistentClass.addProperty(property);
 		}		
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
@@ -3,7 +3,6 @@ package org.hibernate.tool.internal.reveng.binder;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import org.hibernate.FetchMode;
 import org.hibernate.internal.util.StringHelper;
@@ -34,7 +33,7 @@ class OneToManyBinder extends AbstractBinder {
 		this.collectionPropertyBinder = CollectionPropertyBinder.create(binderContext);
 	}
 
-	Property bind(PersistentClass rc, ForeignKey foreignKey, Set<Column> processed) {
+	Property bind(PersistentClass rc, ForeignKey foreignKey) {
 		Collection collection = bindCollection(rc, foreignKey);
 		getMetadataCollector().addCollectionBinding(collection);
 		return collectionPropertyBinder


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>