### PR TITLE
HBX-1947: Rename class 'org.hibernate.tool.internal.metadata.JdbcMetadataDescriptor' into 'org.hibernate.tool.internal.metadata.RevengMetadataDescriptor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptorFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptorFactory.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.Properties;
 
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
-import org.hibernate.tool.internal.metadata.JdbcMetadataDescriptor;
+import org.hibernate.tool.internal.metadata.RevengMetadataDescriptor;
 import org.hibernate.tool.internal.metadata.JpaMetadataDescriptor;
 import org.hibernate.tool.internal.metadata.NativeMetadataDescriptor;
 
@@ -13,7 +13,7 @@ public class MetadataDescriptorFactory {
 	public static MetadataDescriptor createReverseEngineeringDescriptor(
 			ReverseEngineeringStrategy reverseEngineeringStrategy, 
 			Properties properties) {
-		return new JdbcMetadataDescriptor(
+		return new RevengMetadataDescriptor(
 				reverseEngineeringStrategy, 
 				properties);
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
@@ -9,12 +9,12 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.JdbcMetadataBuilder;
 
-public class JdbcMetadataDescriptor implements MetadataDescriptor {
+public class RevengMetadataDescriptor implements MetadataDescriptor {
 	
 	private ReverseEngineeringStrategy reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
     private Properties properties = new Properties();
 
-	public JdbcMetadataDescriptor(
+	public RevengMetadataDescriptor(
 			ReverseEngineeringStrategy reverseEngineeringStrategy, 
 			Properties properties) {
 		this.properties.putAll(Environment.getProperties());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>