### PR TITLE
HBX-1948: Rename class 'org.hibernate.tool.internal.reveng.JdbcMetadataBuilder' to 'org.hibernate.tool.internal.reveng.RevengMetadataBuilder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
@@ -7,7 +7,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.JdbcMetadataBuilder;
+import org.hibernate.tool.internal.reveng.RevengMetadataBuilder;
 
 public class RevengMetadataDescriptor implements MetadataDescriptor {
 	
@@ -36,7 +36,7 @@ public class RevengMetadataDescriptor implements MetadataDescriptor {
 	}
     
 	public Metadata createMetadata() {
-		return JdbcMetadataBuilder
+		return RevengMetadataBuilder
 				.create(properties, reverseEngineeringStrategy)
 				.build();
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
@@ -32,16 +32,16 @@ import org.jboss.logging.Logger;
  * @author max
  * @author koen
  */
-public class JdbcMetadataBuilder {
+public class RevengMetadataBuilder {
 	
 	
-	public static JdbcMetadataBuilder create(
+	public static RevengMetadataBuilder create(
 			Properties properties, 
 			ReverseEngineeringStrategy reverseEngineeringStrategy) {
-		return new JdbcMetadataBuilder(properties, reverseEngineeringStrategy);
+		return new RevengMetadataBuilder(properties, reverseEngineeringStrategy);
 	}
 	
-	private static final Logger LOGGER = Logger.getLogger(JdbcMetadataBuilder.class);
+	private static final Logger LOGGER = Logger.getLogger(RevengMetadataBuilder.class);
 
 	private final Properties properties;
 	private final MetadataBuildingContext metadataBuildingContext;	
@@ -53,7 +53,7 @@ public class JdbcMetadataBuilder {
 	private final String defaultCatalog;
 	private final String defaultSchema;
 	
-	private JdbcMetadataBuilder(
+	private RevengMetadataBuilder(
 			Properties properties,
 			ReverseEngineeringStrategy reverseEngineeringStrategy) {
 		this.properties = properties;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>