### PR TITLE
HBX-1949: Rename class 'org.hibernate.tool.internal.reveng.JDBCReader' to 'org.hibernate.tool.internal.reveng.DatabaseReader'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
@@ -32,7 +32,7 @@ import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.JDBCReader;
+import org.hibernate.tool.internal.reveng.DatabaseReader;
 import org.hibernate.tool.internal.reveng.TableSelectorStrategy;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
@@ -43,7 +43,7 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 		return "schema";
 	}
 	
-	JDBCReader reader;
+	DatabaseReader reader;
 
 	private TableSelectorStrategy tableSelector;
 
@@ -70,7 +70,7 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 				.createMetaDataDialect(
 						dialect, 
 						properties );
-		reader = JDBCReader.create( 
+		reader = DatabaseReader.create( 
 				properties,
 				tableSelector, 
 				mdd,

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DatabaseReader.java
@@ -25,9 +25,9 @@ import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 
-public class JDBCReader {
+public class DatabaseReader {
 
-	public static JDBCReader create(
+	public static DatabaseReader create(
 			Properties properties, 
 			ReverseEngineeringStrategy revengStrategy, 
 			MetaDataDialect mdd,
@@ -38,7 +38,7 @@ public class JDBCReader {
 				.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		String defaultSchemaName = properties
 				.getProperty(AvailableSettings.DEFAULT_SCHEMA);
-		return new JDBCReader(
+		return new DatabaseReader(
 				mdd, 
 				connectionProvider, 
 				defaultCatalogName, 
@@ -55,7 +55,7 @@ public class JDBCReader {
 	private final String defaultSchema;
 	private final String defaultCatalog;
 	
-	public JDBCReader(MetaDataDialect dialect, ConnectionProvider provider, String defaultCatalog, String defaultSchema, ReverseEngineeringStrategy reveng) {
+	public DatabaseReader(MetaDataDialect dialect, ConnectionProvider provider, String defaultCatalog, String defaultSchema, ReverseEngineeringStrategy reveng) {
 		this.metadataDialect = dialect;
 		this.provider = provider;
 		this.revengStrategy = reveng;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
@@ -100,7 +100,7 @@ public class RevengMetadataBuilder {
 				.createMetaDataDialect(
 						serviceRegistry.getService(JdbcServices.class).getDialect(), 
 						properties );
-	    JDBCReader reader = JDBCReader.create(properties,revengStrategy,mdd, serviceRegistry);
+	    DatabaseReader reader = DatabaseReader.create(properties,revengStrategy,mdd, serviceRegistry);
 	    DatabaseCollector collector = new MappingsDatabaseCollector(metadataCollector, reader.getMetaDataDialect());
         reader.readDatabaseSchema(collector, defaultCatalog, defaultSchema);
         return collector;

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
@@ -21,7 +21,7 @@ import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.internal.dialect.CachedMetaDataDialect;
 import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.JDBCReader;
+import org.hibernate.tool.internal.reveng.DatabaseReader;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -140,7 +140,7 @@ public class TestCase {
 				Environment.getProperties() );
 		MockedMetaDataDialect mock = new MockedMetaDataDialect(realMetaData);
 		CachedMetaDataDialect dialect = new CachedMetaDataDialect(mock);
-		JDBCReader reader = JDBCReader.create( 
+		DatabaseReader reader = DatabaseReader.create( 
 				properties, 
 				new DefaultReverseEngineeringStrategy(), 
 				dialect, 
@@ -153,7 +153,7 @@ public class TestCase {
 				properties.getProperty(AvailableSettings.DEFAULT_SCHEMA) );
 		validate( dc );				
 		mock.setFailOnDelegateAccess(true);	
-		reader = JDBCReader.create( 
+		reader = DatabaseReader.create( 
 				properties, 
 				new DefaultReverseEngineeringStrategy(), 
 				dialect, 

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -31,7 +31,7 @@ import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.JDBCReader;
+import org.hibernate.tool.internal.reveng.DatabaseReader;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -104,7 +104,7 @@ public class TestCase {
 		MetaDataDialect realMetaData = MetaDataDialectFactory.createMetaDataDialect( 
 				serviceRegistry.getService(JdbcServices.class).getDialect(), 
 				properties);
-		JDBCReader reader = JDBCReader.create( 
+		DatabaseReader reader = DatabaseReader.create( 
 				properties, new DefaultReverseEngineeringStrategy(), 
 				realMetaData, serviceRegistry );
 		DatabaseCollector dc = new DefaultDatabaseCollector(reader.getMetaDataDialect());

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
@@ -20,7 +20,7 @@ import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.dialect.JDBCMetaDataDialect;
 import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.JDBCReader;
+import org.hibernate.tool.internal.reveng.DatabaseReader;
 import org.hibernate.tool.internal.reveng.TableSelectorStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -71,7 +71,7 @@ public class TestCase {
 		ServiceRegistry serviceRegistry = builder.build();
 		TableSelectorStrategy tss = new TableSelectorStrategy(new DefaultReverseEngineeringStrategy());
 		MockedMetaDataDialect mockedMetaDataDialect = new MockedMetaDataDialect();
-		JDBCReader reader = JDBCReader.create( properties, tss, mockedMetaDataDialect, serviceRegistry);
+		DatabaseReader reader = DatabaseReader.create( properties, tss, mockedMetaDataDialect, serviceRegistry);
 		
 		tss.addSchemaSelection( new SchemaSelection(null,null, "CHILD") );
 		

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -31,7 +31,7 @@ import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.JDBCReader;
+import org.hibernate.tool.internal.reveng.DatabaseReader;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -110,7 +110,7 @@ public class TestCase {
 		MetaDataDialect realMetaData = MetaDataDialectFactory.createMetaDataDialect( 
 				serviceRegistry.getService(JdbcServices.class).getDialect(), 
 				properties);
-		JDBCReader reader = JDBCReader.create( 
+		DatabaseReader reader = DatabaseReader.create( 
 				properties, new DefaultReverseEngineeringStrategy(), 
 				realMetaData, serviceRegistry );
 		DatabaseCollector dc = new DefaultDatabaseCollector(reader.getMetaDataDialect());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>