### PR TITLE
HBX-1958: Rename class 'org.hibernate.tool.internal.reveng.BasicColumnProcessor' to 'org.hibernate.tool.internal.reveng.reader.BasicColumnProcessor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/BasicColumnProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/BasicColumnProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.reader;
 
 import java.sql.DatabaseMetaData;
 import java.util.Iterator;
@@ -11,6 +11,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.RevEngUtils;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.jboss.logging.Logger;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
@@ -24,7 +24,6 @@ import org.hibernate.tool.api.reveng.DatabaseCollector;
 import org.hibernate.tool.api.reveng.ProgressListener;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
-import org.hibernate.tool.internal.reveng.BasicColumnProcessor;
 import org.hibernate.tool.internal.reveng.ForeignKeyProcessor;
 import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
 import org.hibernate.tool.internal.reveng.IndexProcessor;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>