### PR TITLE
HBX-1963: Remove field 'MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS' and replace uses of it by 'ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -13,6 +13,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Path;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.ReverseEngineeringConstants;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
@@ -41,7 +42,7 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 	protected MetadataDescriptor createMetadataDescriptor() {
 		Properties properties = loadPropertiesFile();
 		ReverseEngineeringStrategy res = createReverseEngineeringStrategy();
-		properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
+		properties.put(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
 		return MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(
 						res, 

--- a/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
@@ -11,6 +11,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.ReverseEngineeringConstants;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
@@ -110,7 +111,7 @@ public abstract class AbstractGenerationMojo extends AbstractMojo {
     }
 
     private MetadataDescriptor createJdbcDescriptor(ReverseEngineeringStrategy strategy, Properties properties) {
-    	properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
+    	properties.put(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
         return MetadataDescriptorFactory
                 .createReverseEngineeringDescriptor(
                         strategy,

--- a/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptor.java
@@ -6,8 +6,6 @@ import org.hibernate.boot.Metadata;
 
 public interface MetadataDescriptor {
 	
-	public String PREFER_BASIC_COMPOSITE_IDS = "org.hibernate.tool.api.metadata.MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS";
-
 	Metadata createMetadata();
 	
 	Properties getProperties();

--- a/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
@@ -5,6 +5,7 @@ import java.util.Properties;
 import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.Environment;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.hibernate.tool.api.reveng.ReverseEngineeringConstants;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.RevengMetadataBuilder;
@@ -24,8 +25,8 @@ public class RevengMetadataDescriptor implements MetadataDescriptor {
 		if (reverseEngineeringStrategy != null) {
 			this.reverseEngineeringStrategy = reverseEngineeringStrategy;
 		}
-		if (this.properties.get(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS) == null) {
-			this.properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, true);
+		if (this.properties.get(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS) == null) {
+			this.properties.put(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS, true);
 		}
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
@@ -3,7 +3,7 @@ package org.hibernate.tool.internal.reveng.binder;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.hibernate.tool.api.reveng.ReverseEngineeringConstants;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 
 abstract class AbstractBinder {
@@ -35,7 +35,7 @@ abstract class AbstractBinder {
 	}
 	
 	Boolean preferBasicCompositeIds() {
-		return (Boolean)binderContext.properties.get(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS);
+		return (Boolean)binderContext.properties.get(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS);
 	}
 	
 }

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -23,6 +23,7 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.ReverseEngineeringConstants;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
@@ -54,7 +55,7 @@ public class TestCase {
 		JdbcUtil.createDatabase(this);
 		reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
 		Properties properties = new Properties();
-		properties.put(MetadataDescriptor.PREFER_BASIC_COMPOSITE_IDS, false);
+		properties.put(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS, false);
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(reverseEngineeringStrategy, properties);
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>