### PR TITLE
HBX-1966: Change ReverseEngineeringStrategy#isForeignKeyCollectionInverse(...) to use Table arguments instead of TableIdentifier

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategy.java
@@ -141,9 +141,6 @@ public interface ReverseEngineeringStrategy {
 	/** Should this foreignkey be excluded as a many-to-one */
 	public boolean excludeForeignKeyAsManytoOne(String keyname, TableIdentifier fromTable, List<?> fromColumns, TableIdentifier referencedTable, List<?> referencedColumns);
 	
-	/** is the collection inverse or not ? */
-	public boolean isForeignKeyCollectionInverse(String name, TableIdentifier foreignKeyTable, List<?> columns, TableIdentifier foreignKeyReferencedTable, List<?> referencedColumns);
-	
 	/** is the collection lazy or not ? */
 	public boolean isForeignKeyCollectionLazy(String name, TableIdentifier foreignKeyTable, List<?> columns, TableIdentifier foreignKeyReferencedTable, List<?> referencedColumns);
 	
@@ -192,6 +189,9 @@ public interface ReverseEngineeringStrategy {
     public String foreignKeyToManyToManyName(ForeignKey fromKey, TableIdentifier middleTable, ForeignKey toKey, boolean uniqueReference);
 
 	public boolean isOneToOne(ForeignKey foreignKey);
+
+	public boolean isForeignKeyCollectionInverse(String name, Table foreignKeyTable, List<?> columns, Table foreignKeyReferencedTable, List<?> referencedColumns);
+	
 
 	public AssociationInfo foreignKeyToAssociationInfo(ForeignKey foreignKey);
 	public AssociationInfo foreignKeyToInverseAssociationInfo(ForeignKey foreignKey);

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DefaultReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DefaultReverseEngineeringStrategy.java
@@ -220,18 +220,13 @@ public class DefaultReverseEngineeringStrategy implements ReverseEngineeringStra
 		return !settings.createManyToOneForForeignKey();
 	}
 
-	public boolean isForeignKeyCollectionInverse(String name, TableIdentifier foreignKeyTable, List<?> columns, TableIdentifier foreignKeyReferencedTable, List<?> referencedColumns) {
-		Table fkTable = databaseCollector.getTable(
-				foreignKeyTable.getSchema(),
-				foreignKeyTable.getCatalog(),
-				foreignKeyTable.getName());
-		if(fkTable==null) {
+	public boolean isForeignKeyCollectionInverse(String name, Table foreignKeyTable, List<?> columns, Table foreignKeyReferencedTable, List<?> referencedColumns) {
+		if(foreignKeyTable==null) {
 			return true; // we don't know better
-		}
-		
-		if(isManyToManyTable(fkTable)) {
+		}		
+		if(isManyToManyTable(foreignKeyTable)) {
 		       // if the reference column is the first one then we are inverse.
-			   Column column = fkTable.getColumn(0);
+			   Column column = foreignKeyTable.getColumn(0);
 			   Column fkColumn = (Column) referencedColumns.get(0);
 			   if(fkColumn.equals(column)) {
 				   return true;   

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
@@ -106,7 +106,7 @@ public class DelegatingReverseEngineeringStrategy implements ReverseEngineeringS
 		return delegate==null?false:delegate.excludeForeignKeyAsManytoOne(keyname, fromTable, fromColumns, referencedTable, referencedColumns);
 	}
 
-	public boolean isForeignKeyCollectionInverse(String name, TableIdentifier foreignKeyTable, List<?> columns, TableIdentifier foreignKeyReferencedTable, List<?> referencedColumns) {
+	public boolean isForeignKeyCollectionInverse(String name, Table foreignKeyTable, List<?> columns, Table foreignKeyReferencedTable, List<?> referencedColumns) {
 		return delegate==null?true:delegate.isForeignKeyCollectionInverse(name, foreignKeyTable, columns, foreignKeyReferencedTable, referencedColumns);
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
@@ -159,9 +159,9 @@ class OneToManyBinder extends AbstractBinder {
 	private boolean isCollectionInverse(ForeignKey foreignKey) {
 		return getRevengStrategy().isForeignKeyCollectionInverse(
 				foreignKey.getName(),
-				TableIdentifier.create( foreignKey.getTable()),
+				foreignKey.getTable(),
 				foreignKey.getColumns(),
-				TableIdentifier.create( foreignKey.getReferencedTable()),
+				foreignKey.getReferencedTable(),
 				foreignKey.getReferencedColumns());
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>