### PR TITLE
HBX-1972: Collapse DatabaseCollector hierarchy into one class - Replace uses of 'org.hibernate.tool.internal.reveng.DefaultDatabaseCollector' by 'org.hibernate.tool.internal.reveng.RevengMetadataCollector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
@@ -31,8 +31,8 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.reveng.DatabaseCollector;
-import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.TableSelectorStrategy;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
@@ -78,7 +78,7 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 				tableSelector, 
 				mdd,
 				serviceRegistry);
-		dbc = new DefaultDatabaseCollector(mdd);
+		dbc = new RevengMetadataCollector(mdd);
 		ConnectionProvider connectionProvider = serviceRegistry.getService(ConnectionProvider.class);
 		sequenceCollector = SequenceCollector.create(connectionProvider);
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
@@ -18,9 +18,8 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.internal.dialect.CachedMetaDataDialect;
-import org.hibernate.tool.internal.reveng.DatabaseCollector;
-import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -145,7 +144,7 @@ public class TestCase {
 				new DefaultReverseEngineeringStrategy(), 
 				dialect, 
 				serviceRegistry );
-		DefaultDatabaseCollector dc = new DefaultDatabaseCollector(
+		RevengMetadataCollector dc = new RevengMetadataCollector(
 				reader.getMetaDataDialect());
 		reader.readDatabaseSchema( 
 				dc, 
@@ -158,7 +157,7 @@ public class TestCase {
 				new DefaultReverseEngineeringStrategy(), 
 				dialect, 
 				serviceRegistry );
-		dc = new DefaultDatabaseCollector(reader.getMetaDataDialect());
+		dc = new RevengMetadataCollector(reader.getMetaDataDialect());
 		reader.readDatabaseSchema( 
 				dc, 
 				properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
@@ -166,7 +165,7 @@ public class TestCase {
 		validate(dc);
 	}
 
-	private void validate(DefaultDatabaseCollector dc) {
+	private void validate(RevengMetadataCollector dc) {
 		Iterator<Table> iterator = dc.iterateTables();
 		Table table = iterator.next();
 		Table master = null, child = null;

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -29,9 +29,9 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.DatabaseCollector;
-import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
+import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -107,7 +107,7 @@ public class TestCase {
 		DatabaseReader reader = DatabaseReader.create( 
 				properties, new DefaultReverseEngineeringStrategy(), 
 				realMetaData, serviceRegistry );
-		DatabaseCollector dc = new DefaultDatabaseCollector(reader.getMetaDataDialect());
+		DatabaseCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
 		reader.readDatabaseSchema( dc, null, "cat.cat" );
 		String defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		Assert.assertNotNull("The table should be found", dc.getTable("cat.cat", defaultCatalog, "cat.child"));

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
@@ -17,8 +17,8 @@ import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.dialect.JDBCMetaDataDialect;
-import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.TableSelectorStrategy;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -74,7 +74,7 @@ public class TestCase {
 		
 		tss.addSchemaSelection( new SchemaSelection(null,null, "CHILD") );
 		
-		DefaultDatabaseCollector dc = new DefaultDatabaseCollector(reader.getMetaDataDialect());
+		RevengMetadataCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
 		reader.readDatabaseSchema( dc, null, null );
 		
 		Assert.assertEquals(mockedMetaDataDialect.gottenTables.size(),1);

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -29,9 +29,9 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.DatabaseCollector;
-import org.hibernate.tool.internal.reveng.DefaultDatabaseCollector;
 import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
+import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -113,7 +113,7 @@ public class TestCase {
 		DatabaseReader reader = DatabaseReader.create( 
 				properties, new DefaultReverseEngineeringStrategy(), 
 				realMetaData, serviceRegistry );
-		DatabaseCollector dc = new DefaultDatabaseCollector(reader.getMetaDataDialect());
+		DatabaseCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
 		reader.readDatabaseSchema( dc, null, "cat.cat" );
 		String defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		Assert.assertNotNull("The table should be found", dc.getTable("cat.cat", defaultCatalog, "cat.child"));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>