### PR TITLE
HBX-1972: Collapse DatabaseCollector hierarchy into one class - Remove unused method 'configure(DatabaseCollector)' and instance variable 'databaseCollector' from class DefaultReverseEngineeringStrategy

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DefaultReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DefaultReverseEngineeringStrategy.java
@@ -34,8 +34,6 @@ public class DefaultReverseEngineeringStrategy implements ReverseEngineeringStra
 
 	private ReverseEngineeringSettings settings = new ReverseEngineeringSettings(this);
 
-	private DatabaseCollector databaseCollector = null;
-	
 	static {
 		AUTO_OPTIMISTICLOCK_COLUMNS = new HashSet<String>();
 		AUTO_OPTIMISTICLOCK_COLUMNS.add("version");
@@ -174,10 +172,6 @@ public class DefaultReverseEngineeringStrategy implements ReverseEngineeringStra
 
 	public String classNameToCompositeIdName(String className) {
 		return className + "Id"; 
-	}
-
-	public void configure(DatabaseCollector databaseCollector) {
-		this.databaseCollector = databaseCollector;		
 	}
 
 	public void close() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>