### PR TITLE
HBX-1972: Collapse DatabaseCollector hierarchy into one class - RevengMetadataCollector does not implement DatabaseCollector anymore

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
@@ -12,7 +12,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 
-public class RevengMetadataCollector implements DatabaseCollector {
+public class RevengMetadataCollector {
 
 	private InFlightMetadataCollector metadataCollector = null;
 	private final Map<TableIdentifier, Table> tables;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>