### PR TITLE
HBX-1964: Improve implementation of class 'org.hibernate.tool.internal.reveng.reader.DatabaseReader' - Only keep RevengMetadataCollector argument in DatabaseReader#readDatabaseSchema(...)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
@@ -131,17 +131,17 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 			if(strings.length==1) {
 				tableSelector.clearSchemaSelections();
 				tableSelector.addSchemaSelection( new SchemaSelection(null,null, strings[0]) );
-				Collection<Table> collection = reader.readDatabaseSchema( revengMetadataCollector, null, null );
+				Collection<Table> collection = reader.readDatabaseSchema(revengMetadataCollector);
 				return !collection.isEmpty();
 			} else if(strings.length==3) {
 				tableSelector.clearSchemaSelections();
 				tableSelector.addSchemaSelection( new SchemaSelection(strings[0],strings[1], strings[2]) );
-				Collection<Table> collection = reader.readDatabaseSchema( revengMetadataCollector, null, null );
+				Collection<Table> collection = reader.readDatabaseSchema( revengMetadataCollector);
 				return !collection.isEmpty();
 			} else if (strings.length==2) {
 				tableSelector.clearSchemaSelections();
 				tableSelector.addSchemaSelection( new SchemaSelection(null,strings[0], strings[1]) );
-				Collection<Table> collection = reader.readDatabaseSchema( revengMetadataCollector, null, null );
+				Collection<Table> collection = reader.readDatabaseSchema( revengMetadataCollector);
 				return !collection.isEmpty();
 			}
 		}
@@ -153,7 +153,7 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 		if ( table.isPhysicalTable() ) {
 			setSchemaSelection( table );
 
-			Collection<Table> collection = reader.readDatabaseSchema( revengMetadataCollector, null, null );
+			Collection<Table> collection = reader.readDatabaseSchema( revengMetadataCollector);
 
 			if ( collection.isEmpty() ) {
 				pc.reportIssue( new Issue( "SCHEMA_TABLE_MISSING",

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
@@ -101,7 +101,7 @@ public class RevengMetadataBuilder {
 						properties );
 	    DatabaseReader reader = DatabaseReader.create(properties,revengStrategy,mdd, serviceRegistry);
 	    RevengMetadataCollector revengMetadataCollector = new RevengMetadataCollector(metadataCollector, mdd);
-        reader.readDatabaseSchema(revengMetadataCollector, defaultCatalog, defaultSchema);
+        reader.readDatabaseSchema(revengMetadataCollector);
         return revengMetadataCollector;
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
@@ -53,14 +53,14 @@ public class DatabaseReader {
 			throw new IllegalStateException("Strategy cannot be null");
 		}
 	}
-
-	public Collection<Table> readDatabaseSchema(RevengMetadataCollector revengMetadataCollector, String catalog, String schema) {
+	
+	public Collection<Table> readDatabaseSchema(RevengMetadataCollector revengMetadataCollector) {
 		try {
 			getMetaDataDialect().configure(provider);
 
 			HashMap<Table, Boolean> foundTables = new HashMap<Table, Boolean>();
 
-			for (Iterator<SchemaSelection> iter = getSchemaSelections(catalog, schema).iterator(); iter.hasNext();) {
+			for (Iterator<SchemaSelection> iter = getSchemaSelections(defaultCatalog, defaultSchema).iterator(); iter.hasNext();) {
 				SchemaSelection selection = iter.next();
 				TableCollector tableCollector = TableCollector.create(
 						getMetaDataDialect(), 

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
@@ -146,10 +145,7 @@ public class TestCase {
 				serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector(
 				reader.getMetaDataDialect());
-		reader.readDatabaseSchema( 
-				dc, 
-				properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
-				properties.getProperty(AvailableSettings.DEFAULT_SCHEMA) );
+		reader.readDatabaseSchema(dc);
 		validate( dc );				
 		mock.setFailOnDelegateAccess(true);	
 		reader = DatabaseReader.create( 
@@ -158,10 +154,7 @@ public class TestCase {
 				dialect, 
 				serviceRegistry );
 		dc = new RevengMetadataCollector(reader.getMetaDataDialect());
-		reader.readDatabaseSchema( 
-				dc, 
-				properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
-				properties.getProperty(AvailableSettings.DEFAULT_SCHEMA) );
+		reader.readDatabaseSchema(dc);
 		validate(dc);
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -98,6 +98,7 @@ public class TestCase {
 	@Test
 	public void testQuotedNamesAndDefaultDatabaseCollector() {
 		Properties properties = Environment.getProperties();
+		properties.put(AvailableSettings.DEFAULT_SCHEMA, "cat.cat");
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		ServiceRegistry serviceRegistry = builder.build();	
 		MetaDataDialect realMetaData = MetaDataDialectFactory.createMetaDataDialect( 
@@ -107,7 +108,7 @@ public class TestCase {
 				properties, new DefaultReverseEngineeringStrategy(), 
 				realMetaData, serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
-		reader.readDatabaseSchema( dc, null, "cat.cat" );
+		reader.readDatabaseSchema(dc);
 		String defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		Assert.assertNotNull("The table should be found", dc.getTable("cat.cat", defaultCatalog, "cat.child"));
 		Assert.assertNotNull("The table should be found", dc.getTable("cat.cat", defaultCatalog, "cat.master"));

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
@@ -75,7 +75,7 @@ public class TestCase {
 		tss.addSchemaSelection( new SchemaSelection(null,null, "CHILD") );
 		
 		RevengMetadataCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
-		reader.readDatabaseSchema( dc, null, null );
+		reader.readDatabaseSchema(dc);
 		
 		Assert.assertEquals(mockedMetaDataDialect.gottenTables.size(),1);
 		Assert.assertEquals(mockedMetaDataDialect.gottenTables.get(0),"CHILD");
@@ -91,7 +91,7 @@ public class TestCase {
 		tss.addSchemaSelection( new SchemaSelection(null, null, "MASTER") );
 		
 		mockedMetaDataDialect.gottenTables.clear();
-		reader.readDatabaseSchema( dc, null, null );
+		reader.readDatabaseSchema(dc);
 		
 		Assert.assertEquals(mockedMetaDataDialect.gottenTables.size(),1);
 		Assert.assertEquals(mockedMetaDataDialect.gottenTables.get(0),"MASTER");
@@ -112,7 +112,7 @@ public class TestCase {
 		
 		
 		tss.clearSchemaSelections();		
-		reader.readDatabaseSchema( dc, null, null );
+		reader.readDatabaseSchema(dc);
 		
 		Table finalMaster = dc.getTable( defaultSchema, defaultCatalog, "MASTER" );
 		

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -104,6 +104,7 @@ public class TestCase {
 	@Test
 	public void testQuotedNamesAndDefaultDatabaseCollector() {
 		Properties properties = Environment.getProperties();
+		properties.put(AvailableSettings.DEFAULT_SCHEMA, "cat.cat");
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		ServiceRegistry serviceRegistry = builder.build();	
 		MetaDataDialect realMetaData = MetaDataDialectFactory.createMetaDataDialect( 
@@ -113,7 +114,7 @@ public class TestCase {
 				properties, new DefaultReverseEngineeringStrategy(), 
 				realMetaData, serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
-		reader.readDatabaseSchema( dc, null, "cat.cat" );
+		reader.readDatabaseSchema(dc);
 		String defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		Assert.assertNotNull("The table should be found", dc.getTable("cat.cat", defaultCatalog, "cat.child"));
 		Assert.assertNotNull("The table should be found", dc.getTable("cat.cat", defaultCatalog, "cat.master"));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>