### PR TITLE
HBX-1976: Use TableIdentifier in RevengMetadataCollector instead of the catalog/schema/name combination - Replace RevengMetadataCollector#addTable(String,String,String) by RevengMetadataCollector#addTable(TableIdentifier)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
@@ -35,21 +35,24 @@ public class RevengMetadataCollector {
 	public Iterator<Table> iterateTables() {
 		return tables.values().iterator();
 	}
-
-	public Table addTable(String schema, String catalog, String name) {
+	
+	// TableIdentifier's catalog, schema and name should be quoted
+	public Table addTable(TableIdentifier tableIdentifier) {
 		Table result = null;
-		TableIdentifier identifier = createIdentifier(catalog, schema, name);
+		String catalog = tableIdentifier.getCatalog();
+		String schema = tableIdentifier.getSchema();
+		String name = tableIdentifier.getName();
 		if (metadataCollector != null) {
-			result = metadataCollector.addTable(quote(schema), quote(catalog), quote(name), null, false);
+			result = metadataCollector.addTable(schema, catalog, name, null, false);
 		} else {
-			result = createTable(quote(catalog), quote(schema), quote(name));			
+			result = createTable(catalog, schema, name);			
 		}
-		if (tables.containsKey(identifier)) {
+		if (tables.containsKey(tableIdentifier)) {
 			throw new RuntimeException(
 					"Attempt to add a double entry for table: " + 
-					TableNameQualifier.qualify(quote(catalog), quote(schema), quote(name)));
+					TableNameQualifier.qualify(catalog, schema, name));
 		}
-		tables.put(identifier, result);
+		tables.put(tableIdentifier, result);
 		return result;
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
@@ -84,7 +84,11 @@ public class TableCollector {
 							  catalogName=null;
 						  }
 						  log.debug("Adding table " + tableName + " of type " + tableType);
-						  Table table = revengMetadataCollector.addTable(schemaName, catalogName, tableName);
+						  TableIdentifier tableIdentifier = TableIdentifier.create(
+								  quote(catalogName), 
+								  quote(schemaName), 
+								  quote(tableName));
+						  Table table = revengMetadataCollector.addTable(tableIdentifier);
 						  table.setComment(comment);
 						  if(tableType.equalsIgnoreCase("TABLE")) {
 							  processedTables.put(table, true);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>