### PR TITLE
HBX-1977: Improve implementation of class ForeignKeyProcessor - Move ForeignKeyProcessor from 'org.hibernate.tool.internal.reveng' to 'org.hibernate.tool.internal.reveng.binder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
@@ -16,7 +16,6 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
-import org.hibernate.tool.internal.reveng.ForeignKeyProcessor;
 import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
 import org.hibernate.tool.internal.reveng.IndexProcessor;
 import org.hibernate.tool.internal.reveng.PrimaryKeyProcessor;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeyProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.reader;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,6 +14,8 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
+import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.util.RevengUtils;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.jboss.logging.Logger;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>