### PR TITLE
HBX-1976: Use TableIdentifier in RevengMetadataCollector instead of the catalog/schema/name combination - Add method RevengMetadataCollector#getTable(TableIdentifier)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
@@ -55,6 +55,10 @@ public class RevengMetadataCollector {
 		tables.put(tableIdentifier, result);
 		return result;
 	}
+	
+	public Table getTable(TableIdentifier tableIdentifier) {
+		return tables.get(tableIdentifier);
+	}
 
 	public Table getTable(String schema, String catalog, String name) {
 		return tables.get(createIdentifier(catalog, schema, name));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>