### PR TITLE
HBX-1976: Use TableIdentifier in RevengMetadataCollector instead of the catalog/schema/name combination - Replace uses of RevengMetadataCollector#getTable(String,String,String) by RevengMetadataCollector#getTable(TableIdentifier)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
@@ -58,17 +58,14 @@ public class TableCollector {
 		        String tableName = (String) tableRs.get("TABLE_NAME");
 				String schemaName = (String) tableRs.get("TABLE_SCHEM");
 		        String catalogName = (String) tableRs.get("TABLE_CAT");
-		        TableIdentifier ti = TableIdentifier.create(quote(catalogName), quote(schemaName), quote(tableName));		        
-				if(revengStrategy.excludeTable(ti) ) {
-					log.debug("Table " + ti + " excluded by strategy");
+		        TableIdentifier tableIdentifier = TableIdentifier.create(quote(catalogName), quote(schemaName), quote(tableName));		        
+				if(revengStrategy.excludeTable(tableIdentifier) ) {
+					log.debug("Table " + tableIdentifier + " excluded by strategy");
 		        	continue;
 		        }								
 				String comment = (String) tableRs.get("REMARKS");
 				String tableType = (String) tableRs.get("TABLE_TYPE");
-				if(revengMetadataCollector.getTable
-						  (schemaName, 
-								  catalogName, 
-								  tableName)!=null) {
+				if(revengMetadataCollector.getTable(tableIdentifier)!=null) {
 					  log.debug("Ignoring " + tableName + " since it has already been processed");
 					  continue;
 				  } else {
@@ -84,10 +81,6 @@ public class TableCollector {
 							  catalogName=null;
 						  }
 						  log.debug("Adding table " + tableName + " of type " + tableType);
-						  TableIdentifier tableIdentifier = TableIdentifier.create(
-								  quote(catalogName), 
-								  quote(schemaName), 
-								  quote(tableName));
 						  Table table = revengMetadataCollector.addTable(tableIdentifier);
 						  table.setComment(comment);
 						  if(tableType.equalsIgnoreCase("TABLE")) {

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -110,14 +110,41 @@ public class TestCase {
 		RevengMetadataCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
 		reader.readDatabaseSchema(dc);
 		String defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
-		Assert.assertNotNull("The table should be found", dc.getTable("cat.cat", defaultCatalog, "cat.child"));
-		Assert.assertNotNull("The table should be found", dc.getTable("cat.cat", defaultCatalog, "cat.master"));
-		Assert.assertNull("Quoted names should not return the table", dc.getTable(quote("cat.cat"), defaultCatalog, quote("cat.child")));
-		Assert.assertNull("Quoted names should not return the table", dc.getTable(quote("cat.cat"), defaultCatalog, quote("cat.master")));
+		Assert.assertNotNull("The table should be found", getTable(dc, realMetaData, defaultCatalog, "cat.cat", "cat.child"));
+		Assert.assertNotNull("The table should be found", getTable(dc, realMetaData, defaultCatalog, "cat.cat", "cat.master"));
+		Assert.assertNull("Quoted names should not return the table", getTable(dc, realMetaData, defaultCatalog, doubleQuote("cat.cat"), doubleQuote("cat.child")));
+		Assert.assertNull("Quoted names should not return the table", getTable(dc, realMetaData, defaultCatalog, doubleQuote("cat.cat"), doubleQuote("cat.master")));
 		Assert.assertEquals("Foreign key 'masterref' was filtered!", 1, dc.getOneToManyCandidates().size());
 	}
 	
-	private static String quote(String name) {
+	private Table getTable(
+			RevengMetadataCollector revengMetadataCollector, 
+			MetaDataDialect metaDataDialect, 
+			String catalog, 
+			String schema, 
+			String name) {
+		return revengMetadataCollector.getTable(
+				TableIdentifier.create(
+						quote(metaDataDialect, catalog), 
+						quote(metaDataDialect, schema), 
+						quote(metaDataDialect, name)));
+	}
+ 	
+	private String quote(MetaDataDialect metaDataDialect, String name) {
+		if (name == null)
+			return name;
+		if (metaDataDialect.needQuote(name)) {
+			if (name.length() > 1 && name.charAt(0) == '`'
+					&& name.charAt(name.length() - 1) == '`') {
+				return name; // avoid double quoting
+			}
+			return "`" + name + "`";
+		} else {
+			return name;
+		}
+	}
+	
+	private static String doubleQuote(String name) {
 		return "\"" + name + "\"";
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>