### PR TITLE
HBX-1976: Use TableIdentifier in RevengMetadataCollector instead of the catalog/schema/name combination - Remove unused instance variable RevengMetadataCollector#metaDataDialect

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
@@ -19,15 +19,13 @@ public class RevengMetadataCollector {
 	private final Map<TableIdentifier, Table> tables;
 	private Map<String, List<ForeignKey>> oneToManyCandidates;
 	private final Map<TableIdentifier, String> suggestedIdentifierStrategies;
-	private final  MetaDataDialect metaDataDialect;
-	
+
 	public RevengMetadataCollector(InFlightMetadataCollector metadataCollector, MetaDataDialect metaDataDialect) {
 		this(metaDataDialect);
 		this.metadataCollector = metadataCollector;
 	}
 	
 	public RevengMetadataCollector(MetaDataDialect metaDataDialect) {
-		this.metaDataDialect = metaDataDialect;
 		this.tables = new HashMap<TableIdentifier, Table>();
 		this.suggestedIdentifierStrategies = new HashMap<TableIdentifier, String>();
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>