### PR TITLE
HBX-1978: Remove use of MetaDataDialect from RevengMetadataCollector - Remove metaDataDialect argument from constructor RevengMetadataCollector(MetaDataDialect)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
@@ -284,7 +284,7 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 	}
 	
 	private Collection<Table> readFromDatabase() {
-		RevengMetadataCollector revengMetadataCollector = new RevengMetadataCollector(metadataDialect);
+		RevengMetadataCollector revengMetadataCollector = new RevengMetadataCollector();
 		reader.readDatabaseSchema(revengMetadataCollector);
 		return revengMetadataCollector.getTables();
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
@@ -21,11 +21,11 @@ public class RevengMetadataCollector {
 	private final Map<TableIdentifier, String> suggestedIdentifierStrategies;
 
 	public RevengMetadataCollector(InFlightMetadataCollector metadataCollector, MetaDataDialect metaDataDialect) {
-		this(metaDataDialect);
+		this();
 		this.metadataCollector = metadataCollector;
 	}
 	
-	public RevengMetadataCollector(MetaDataDialect metaDataDialect) {
+	public RevengMetadataCollector() {
 		this.tables = new HashMap<TableIdentifier, Table>();
 		this.suggestedIdentifierStrategies = new HashMap<TableIdentifier, String>();
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
@@ -143,8 +143,7 @@ public class TestCase {
 				new DefaultReverseEngineeringStrategy(), 
 				dialect, 
 				serviceRegistry );
-		RevengMetadataCollector dc = new RevengMetadataCollector(
-				reader.getMetaDataDialect());
+		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);
 		validate( dc );				
 		mock.setFailOnDelegateAccess(true);	
@@ -153,7 +152,7 @@ public class TestCase {
 				new DefaultReverseEngineeringStrategy(), 
 				dialect, 
 				serviceRegistry );
-		dc = new RevengMetadataCollector(reader.getMetaDataDialect());
+		dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);
 		validate(dc);
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -107,7 +107,7 @@ public class TestCase {
 		DatabaseReader reader = DatabaseReader.create( 
 				properties, new DefaultReverseEngineeringStrategy(), 
 				realMetaData, serviceRegistry );
-		RevengMetadataCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
+		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);
 		String defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		Assert.assertNotNull("The table should be found", getTable(dc, realMetaData, defaultCatalog, "cat.cat", "cat.child"));

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
@@ -76,7 +76,7 @@ public class TestCase {
 		
 		tss.addSchemaSelection( new SchemaSelection(null,null, "CHILD") );
 		
-		RevengMetadataCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
+		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);
 		
 		Assert.assertEquals(mockedMetaDataDialect.gottenTables.size(),1);

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -113,7 +113,7 @@ public class TestCase {
 		DatabaseReader reader = DatabaseReader.create( 
 				properties, new DefaultReverseEngineeringStrategy(), 
 				realMetaData, serviceRegistry );
-		RevengMetadataCollector dc = new RevengMetadataCollector(reader.getMetaDataDialect());
+		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);
 		String defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
 		Assert.assertNotNull("The table should be found", getTable(dc, realMetaData, defaultCatalog, "cat.cat", "cat.child"));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>