### PR TITLE
HBX-1978: Remove use of MetaDataDialect from RevengMetadataCollector - Remove metaDataDialect argument from constructor RevengMetadataCollector(InFlightMetadataCollector,MetaDataDialect)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
@@ -100,7 +100,7 @@ public class RevengMetadataBuilder {
 						serviceRegistry.getService(JdbcServices.class).getDialect(), 
 						properties );
 	    DatabaseReader reader = DatabaseReader.create(properties,revengStrategy,mdd, serviceRegistry);
-	    RevengMetadataCollector revengMetadataCollector = new RevengMetadataCollector(metadataCollector, mdd);
+	    RevengMetadataCollector revengMetadataCollector = new RevengMetadataCollector(metadataCollector);
         reader.readDatabaseSchema(revengMetadataCollector);
         return revengMetadataCollector;
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataCollector.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 
@@ -20,7 +19,7 @@ public class RevengMetadataCollector {
 	private Map<String, List<ForeignKey>> oneToManyCandidates;
 	private final Map<TableIdentifier, String> suggestedIdentifierStrategies;
 
-	public RevengMetadataCollector(InFlightMetadataCollector metadataCollector, MetaDataDialect metaDataDialect) {
+	public RevengMetadataCollector(InFlightMetadataCollector metadataCollector) {
 		this();
 		this.metadataCollector = metadataCollector;
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>