### PR TITLE
HBX-1981: Remove <jboss-logging.version> from pom.xml as JBoss Logging is not used anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
         <javaee-api.version>7.0</javaee-api.version>
 	    <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <jaxen.version>1.2.0</jaxen.version>
-        <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <junit.version>4.12</junit.version>
         <mysql.version>6.0.6</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>