### PR TITLE
HBX-1964: Improve implementation of class 'org.hibernate.tool.internal.reveng.reader.DatabaseReader' - Move processing of basic columns from DatabaseReader into TableProcessor

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
@@ -72,8 +72,6 @@ public class DatabaseReader {
 
 		
 			for (Table table : foundTables.keySet()) {
-				BasicColumnProcessor.processBasicColumns(metadataDialect, revengStrategy, getDefaultSchema(),
-						getDefaultCatalog(), table);
 				PrimaryKeyProcessor.processPrimaryKey(metadataDialect, revengStrategy, getDefaultSchema(),
 						getDefaultCatalog(), revengMetadataCollector, table);
 				if (foundTables.get(table)) {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
@@ -93,6 +94,12 @@ public class TableCollector {
     		log.debug("Adding table " + tableIdentifier + " of type " + tableType);
     		Table table = revengMetadataCollector.addTable(tableIdentifier);
     		table.setComment(comment);
+			BasicColumnProcessor.processBasicColumns(
+					metaDataDialect, 
+					revengStrategy, 
+					properties.getProperty(AvailableSettings.DEFAULT_SCHEMA),
+					properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
+					table);
     		processedTables.put(table, tableType.equalsIgnoreCase("TABLE"));
     	}
     	else {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>