### PR TITLE
HBX-1964: Improve implementation of class 'org.hibernate.tool.internal.reveng.reader.DatabaseReader' - Move processing of primary key columns from DatabaseReader into TableProcessor

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
@@ -18,7 +18,6 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
 import org.hibernate.tool.internal.reveng.IndexProcessor;
-import org.hibernate.tool.internal.reveng.PrimaryKeyProcessor;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 
 public class DatabaseReader {
@@ -72,8 +71,6 @@ public class DatabaseReader {
 
 		
 			for (Table table : foundTables.keySet()) {
-				PrimaryKeyProcessor.processPrimaryKey(metadataDialect, revengStrategy, getDefaultSchema(),
-						getDefaultCatalog(), revengMetadataCollector, table);
 				if (foundTables.get(table)) {
 					IndexProcessor.processIndices(metadataDialect, getDefaultSchema(), getDefaultCatalog(), table);
 				}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
@@ -12,6 +12,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.PrimaryKeyProcessor;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.jboss.logging.Logger;
 
@@ -99,6 +100,13 @@ public class TableCollector {
 					revengStrategy, 
 					properties.getProperty(AvailableSettings.DEFAULT_SCHEMA),
 					properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
+					table);
+			PrimaryKeyProcessor.processPrimaryKey(
+					metaDataDialect, 
+					revengStrategy, 
+					properties.getProperty(AvailableSettings.DEFAULT_SCHEMA),
+					properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
+					revengMetadataCollector, 
 					table);
     		processedTables.put(table, tableType.equalsIgnoreCase("TABLE"));
     	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>