### PR TITLE
 HBX-1964: Improve implementation of class 'org.hibernate.tool.internal.reveng.reader.DatabaseReader' - Move processing of index columns from DatabaseReader into TableProcessor

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
@@ -17,7 +17,6 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
-import org.hibernate.tool.internal.reveng.IndexProcessor;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 
 public class DatabaseReader {
@@ -67,13 +66,6 @@ public class DatabaseReader {
 						revengMetadataCollector, 
 						properties);
 				foundTables.putAll(tableCollector.processTables(selection));
-			}
-
-		
-			for (Table table : foundTables.keySet()) {
-				if (foundTables.get(table)) {
-					IndexProcessor.processIndices(metadataDialect, getDefaultSchema(), getDefaultCatalog(), table);
-				}
 			}
 
 			Map<String, List<ForeignKey>> oneToManyCandidates = resolveForeignKeys(revengMetadataCollector);

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
@@ -12,6 +12,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.IndexProcessor;
 import org.hibernate.tool.internal.reveng.PrimaryKeyProcessor;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.jboss.logging.Logger;
@@ -108,6 +109,13 @@ public class TableCollector {
 					properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
 					revengMetadataCollector, 
 					table);
+			if (tableType.equalsIgnoreCase("TABLE")) {
+				IndexProcessor.processIndices(
+						metaDataDialect, 
+						properties.getProperty(AvailableSettings.DEFAULT_SCHEMA),
+						properties.getProperty(AvailableSettings.DEFAULT_CATALOG), 
+						table);
+			}
     		processedTables.put(table, tableType.equalsIgnoreCase("TABLE"));
     	}
     	else {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>