### PR TITLE
HBX-1989: Move class 'PrimaryKeyProcessor' from 'org.hibernate.tool.internal.reveng' to 'org.hibernate.tool.internal.reveng.reader'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/PrimaryKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/PrimaryKeyProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.reader;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -14,6 +14,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.sql.Alias;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.util.RevengUtils;
 import org.jboss.logging.Logger;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
@@ -13,7 +13,6 @@ import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.IndexProcessor;
-import org.hibernate.tool.internal.reveng.PrimaryKeyProcessor;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.jboss.logging.Logger;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>