### PR TITLE
HBX-1990: Move class 'IndexProcessor' from 'org.hibernate.tool.internal.reveng' to 'org.hibernate.tool.internal.reveng.reader'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/IndexProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/IndexProcessor.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.reader;
 
 import java.sql.DatabaseMetaData;
 import java.util.ArrayList;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
@@ -12,7 +12,6 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.IndexProcessor;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.jboss.logging.Logger;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>