### PR TITLE
HBX-1991: Move class 'ForeignKeysInfo' from 'org.hibernate.tool.internal.reveng' to 'org.hibernate.tool.internal.reveng.reader'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
@@ -16,7 +16,6 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
-import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 
 public class DatabaseReader {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeyProcessor.java
@@ -14,7 +14,6 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.ForeignKeysInfo;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.util.RevengUtils;
 import org.hibernate.tool.internal.util.TableNameQualifier;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeysInfo.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeysInfo.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.reader;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>