### PR TITLE
HBX-1992: Reorganize the reverse engineering strategy hierarchy - Rename 'org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy' into 'org.hibernate.tool.api.reveng.DefaultRevengStrategy' and create abstract org.hibernate.tool.internal.reveng.strategt.AbstractRevengStrategy'

### DIFF
--- a/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
@@ -30,7 +30,7 @@ public abstract class AbstractGenerationMojo extends AbstractMojo {
     /** The class name of the reverse engineering strategy to use.
      * Extend the DefaultReverseEngineeringStrategy and override the corresponding methods, e.g.
      * to adapt the generate class names or to provide custom type mappings. */
-    @Parameter(defaultValue = "org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy")
+    @Parameter(defaultValue = "org.hibernate.tool.api.reveng.DefaultRevengStrategy")
     private String revengStrategy;
 
     /** If true, tables which are pure many-to-many link tables will be mapped as such.

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/DefaultRevengStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/DefaultRevengStrategy.java
@@ -1,0 +1,7 @@
+package org.hibernate.tool.api.reveng;
+
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+
+public class DefaultRevengStrategy extends AbstractRevengStrategy implements ReverseEngineeringStrategy {
+
+}

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactory.java
@@ -2,14 +2,13 @@ package org.hibernate.tool.api.reveng;
 
 import java.io.File;
 
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tool.util.ReflectionUtil;
 
 public class ReverseEngineeringStrategyFactory {
 	
 	private static final String DEFAULT_REVERSE_ENGINEERING_STRATEGY_CLASS_NAME = 
-			DefaultReverseEngineeringStrategy.class.getName();
+			DefaultRevengStrategy.class.getName();
 	
 	public static ReverseEngineeringStrategy createReverseEngineeringStrategy(
 			String reverseEngineeringClassName) {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
@@ -28,8 +28,8 @@ import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.TableSelectorStrategy;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
@@ -68,7 +68,7 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 		dialect = serviceRegistry.getService(JdbcServices.class).getDialect();
 
 		tableSelector = new TableSelectorStrategy(
-				new DefaultReverseEngineeringStrategy() );
+				new DefaultRevengStrategy() );
 		metadataDialect = MetaDataDialectFactory
 				.createMetaDataDialect(
 						dialect, 

--- a/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
@@ -7,12 +7,12 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.reveng.ReverseEngineeringConstants;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
 import org.hibernate.tool.internal.reveng.RevengMetadataBuilder;
 
 public class RevengMetadataDescriptor implements MetadataDescriptor {
 	
-	private ReverseEngineeringStrategy reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
+	private ReverseEngineeringStrategy reverseEngineeringStrategy = null;
     private Properties properties = new Properties();
 
 	public RevengMetadataDescriptor(
@@ -24,6 +24,8 @@ public class RevengMetadataDescriptor implements MetadataDescriptor {
 		}
 		if (reverseEngineeringStrategy != null) {
 			this.reverseEngineeringStrategy = reverseEngineeringStrategy;
+		} else {
+			this.reverseEngineeringStrategy = ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy();
 		}
 		if (this.properties.get(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS) == null) {
 			this.properties.put(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS, true);

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractRevengStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractRevengStrategy.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.strategy;
 
 import java.beans.Introspector;
 import java.util.ArrayList;
@@ -26,9 +26,9 @@ import org.hibernate.tool.internal.util.NameConverter;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.jboss.logging.Logger;
 
-public class DefaultReverseEngineeringStrategy implements ReverseEngineeringStrategy {
+public abstract class AbstractRevengStrategy implements ReverseEngineeringStrategy {
 
-	static final private Logger log = Logger.getLogger(DefaultReverseEngineeringStrategy.class);
+	static final private Logger log = Logger.getLogger(AbstractRevengStrategy.class);
 	
 	private static Set<String> AUTO_OPTIMISTICLOCK_COLUMNS;
 
@@ -41,7 +41,7 @@ public class DefaultReverseEngineeringStrategy implements ReverseEngineeringStra
 	}
 	
 		
-	public DefaultReverseEngineeringStrategy() {
+	public AbstractRevengStrategy() {
 		super();
 	}
 	

--- a/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
@@ -1,6 +1,5 @@
 package org.hibernate.tool.api.reveng;
 
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -13,7 +12,7 @@ public class ReverseEngineeringStrategyFactoryTest {
 				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy();
 		Assert.assertNotNull(reverseEngineeringStrategy);
 		Assert.assertEquals(
-				DefaultReverseEngineeringStrategy.class.getName(), 
+				DefaultRevengStrategy.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());
 		reverseEngineeringStrategy = 
 				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
@@ -25,10 +24,10 @@ public class ReverseEngineeringStrategyFactoryTest {
 		reverseEngineeringStrategy = 
 				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(null);
 		Assert.assertEquals(
-				DefaultReverseEngineeringStrategy.class.getName(), 
+				DefaultRevengStrategy.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());		
 	}
 	
-	public static class TestReverseEngineeringStrategyFactory extends DefaultReverseEngineeringStrategy {}
+	public static class TestReverseEngineeringStrategyFactory extends DefaultRevengStrategy {}
 
 }

--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithCustomReverseNamingStrategy/Strategy.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithCustomReverseNamingStrategy/Strategy.java
@@ -1,9 +1,9 @@
 package org.hibernate.tool.ant.Cfg2HbmWithCustomReverseNamingStrategy;
 
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 
-public class Strategy extends DefaultReverseEngineeringStrategy {
+public class Strategy extends AbstractRevengStrategy {
 
 	public String tableToClassName(TableIdentifier tableIdentifier) {		
 		return "foo.Bar";		

--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithPackageNameAndReverseNamingStrategy/Strategy.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithPackageNameAndReverseNamingStrategy/Strategy.java
@@ -1,9 +1,9 @@
 package org.hibernate.tool.ant.Cfg2HbmWithPackageNameAndReverseNamingStrategy;
 
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 
-public class Strategy extends DefaultReverseEngineeringStrategy {
+public class Strategy extends AbstractRevengStrategy {
 
 	public String tableToClassName(TableIdentifier tableIdentifier) {		
 		return "Bar";		

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
@@ -16,8 +16,8 @@ import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.internal.dialect.CachedMetaDataDialect;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -140,7 +140,7 @@ public class TestCase {
 		CachedMetaDataDialect dialect = new CachedMetaDataDialect(mock);
 		DatabaseReader reader = DatabaseReader.create( 
 				properties, 
-				new DefaultReverseEngineeringStrategy(), 
+				new DefaultRevengStrategy(), 
 				dialect, 
 				serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector();
@@ -149,7 +149,7 @@ public class TestCase {
 		mock.setFailOnDelegateAccess(true);	
 		reader = DatabaseReader.create( 
 				properties, 
-				new DefaultReverseEngineeringStrategy(), 
+				new DefaultRevengStrategy(), 
 				dialect, 
 				serviceRegistry );
 		dc = new RevengMetadataCollector();

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -25,10 +25,10 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
@@ -58,7 +58,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "cat.cat"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		List<Table> tables = getTables(MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata());
@@ -105,7 +105,7 @@ public class TestCase {
 				serviceRegistry.getService(JdbcServices.class).getDialect(), 
 				properties);
 		DatabaseReader reader = DatabaseReader.create( 
-				properties, new DefaultReverseEngineeringStrategy(), 
+				properties, new DefaultRevengStrategy(), 
 				realMetaData, serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -15,10 +15,10 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -48,7 +48,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		List<Table> tables = getTables(MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata());
@@ -72,7 +72,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, null, "MASTER"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "CHILD"));
 		ReverseEngineeringStrategy res = 
-				or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+				or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -24,10 +24,11 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.internal.export.doc.DocExporter;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -53,7 +54,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		outputDir = temporaryFolder.getRoot();
-		DefaultReverseEngineeringStrategy configurableNamingStrategy = new DefaultReverseEngineeringStrategy();
+		AbstractRevengStrategy configurableNamingStrategy = new DefaultRevengStrategy();
 		configurableNamingStrategy.setSettings(new ReverseEngineeringSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(configurableNamingStrategy, null);

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
@@ -14,10 +14,11 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -87,7 +88,7 @@ public class TestCase {
 	}
 	
 	private MetadataDescriptor createMetadataDescriptor() {
-		DefaultReverseEngineeringStrategy configurableNamingStrategy = new DefaultReverseEngineeringStrategy();
+		AbstractRevengStrategy configurableNamingStrategy = new DefaultRevengStrategy();
 		configurableNamingStrategy.setSettings(new ReverseEngineeringSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		OverrideRepository overrideRepository = new OverrideRepository();
 		InputStream inputStream = new ByteArrayInputStream(REVENG_XML.getBytes());

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
@@ -16,10 +16,10 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.dialect.JDBCMetaDataDialect;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.TableSelectorStrategy;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
@@ -70,7 +70,7 @@ public class TestCase {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(properties);
 		ServiceRegistry serviceRegistry = builder.build();
-		TableSelectorStrategy tss = new TableSelectorStrategy(new DefaultReverseEngineeringStrategy());
+		TableSelectorStrategy tss = new TableSelectorStrategy(new DefaultRevengStrategy());
 		MockedMetaDataDialect mockedMetaDataDialect = new MockedMetaDataDialect();
 		DatabaseReader reader = DatabaseReader.create( properties, tss, mockedMetaDataDialect, serviceRegistry);
 		

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -26,10 +26,10 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -55,7 +55,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
+		reverseEngineeringStrategy = new DefaultRevengStrategy();
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(reverseEngineeringStrategy, null);
 	}

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
@@ -12,10 +12,10 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -37,7 +37,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
+		reverseEngineeringStrategy = new DefaultRevengStrategy();
 		metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(reverseEngineeringStrategy, null)
 				.createMetadata();

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -23,11 +23,11 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringConstants;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -53,7 +53,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		reverseEngineeringStrategy = new DefaultReverseEngineeringStrategy();
+		reverseEngineeringStrategy = new DefaultRevengStrategy();
 		Properties properties = new Properties();
 		properties.put(ReverseEngineeringConstants.PREFER_BASIC_COMPOSITE_IDS, false);
 		metadataDescriptor = MetadataDescriptorFactory

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -13,9 +13,10 @@ import org.hibernate.mapping.Property;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -46,7 +47,7 @@ public class TestCase {
 	@Test
 	public void testNoManyToManyBiDirectional() {
         
-        DefaultReverseEngineeringStrategy c = new DefaultReverseEngineeringStrategy();
+        AbstractRevengStrategy c = new DefaultRevengStrategy();
         c.setSettings(new ReverseEngineeringSettings(c).setDetectManyToMany(false)); 
         Metadata metadata =  MetadataDescriptorFactory
         		.createReverseEngineeringDescriptor(c, null)

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -21,10 +21,10 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tool.internal.reveng.SQLTypeMapping;
 import org.hibernate.tool.internal.reveng.TableFilter;
@@ -54,7 +54,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(OVERRIDETEST_REVENG_XML);
 		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(
-				new DefaultReverseEngineeringStrategy() );
+				new DefaultRevengStrategy() );
 		metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();
@@ -98,7 +98,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(DOC_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 
 		Assert.assertEquals("int", repository.columnToHibernateTypeName(null, "ID", Types.INTEGER, SQLTypeMapping.UNKNOWN_LENGTH, 10, SQLTypeMapping.UNKNOWN_SCALE, false, false) );
 		Assert.assertEquals("your.package.TrimStringUserType", repository.columnToHibernateTypeName(null, "NAME", Types.VARCHAR, 30, SQLTypeMapping.UNKNOWN_PRECISION, SQLTypeMapping.UNKNOWN_SCALE, true, false) );
@@ -114,7 +114,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(SCHEMA_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 
 		List<?> schemaSelectors = repository.getSchemaSelections();
 		
@@ -144,7 +144,7 @@ public class TestCase {
 		
 		OverrideRepository ox = new OverrideRepository();
 		ox.addSchemaSelection(new SchemaSelection(null, null, "DUMMY.*"));
-		ReverseEngineeringStrategy strategy = ox.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy strategy = ox.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata md = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(strategy, null)
 				.createMetadata();
@@ -275,7 +275,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(OVERRIDETEST_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		
 		Assert.assertEquals("org.werd.Q", repository.tableToClassName(TableIdentifier.create("q","Werd", "Q") ) );
 		Assert.assertEquals("Notknown", repository.tableToClassName(TableIdentifier.create(null,null, "notknown") ) );
@@ -449,7 +449,7 @@ public class TestCase {
 	@Test
 	public void testTableToClass() {
 		
-		ReverseEngineeringStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		
 		TableIdentifier tableIdentifier = TableIdentifier.create(null, null, "TblTest");
 		Assert.assertEquals("org.test.Test", res.tableToClassName(tableIdentifier));		
@@ -470,7 +470,7 @@ public class TestCase {
 	@Test
 	public void testMetaAttributes() {
 		
-		ReverseEngineeringStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		
 		TableIdentifier tableIdentifier = TableIdentifier.create(null, null, "TblTest");
 		Map<String,MetaAttribute> attributes = res.tableToMetaAttributes(tableIdentifier);

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -21,8 +21,9 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Set;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -42,7 +43,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-        DefaultReverseEngineeringStrategy c = new DefaultReverseEngineeringStrategy();
+        AbstractRevengStrategy c = new DefaultRevengStrategy();
         c.setSettings(new ReverseEngineeringSettings(c).setDefaultPackageName(PACKAGE_NAME));
         metadata = MetadataDescriptorFactory
         		.createReverseEngineeringDescriptor(c, null)

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
@@ -12,8 +12,8 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -68,7 +68,7 @@ public class TestCase {
 	public void testSetAndManyToOne() {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();			
@@ -100,7 +100,7 @@ public class TestCase {
 	public void testOneToOne() throws MalformedURLException, ClassNotFoundException {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();
@@ -125,7 +125,7 @@ public class TestCase {
 		try {
 			OverrideRepository or = new OverrideRepository();
 			or.addResource(BAD_FOREIGNKEY_XML);
-			ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+			ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 			MetadataDescriptorFactory
 					.createReverseEngineeringDescriptor(repository, null)
 					.createMetadata();
@@ -152,7 +152,7 @@ public class TestCase {
 	public void testManyToOneAttributeOverrides() {
 		OverrideRepository or = new OverrideRepository();	
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
@@ -19,7 +19,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.export.common.DefaultValueVisitor;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -44,7 +44,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		DefaultReverseEngineeringStrategy c = new DefaultReverseEngineeringStrategy() {
+		AbstractRevengStrategy c = new AbstractRevengStrategy() {
 			public List<SchemaSelection> getSchemaSelections() {
 				List<SchemaSelection> selections = new ArrayList<SchemaSelection>();
 				selections.add(new SchemaSelection(null, "HTT"));

--- a/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
+++ b/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
@@ -14,8 +14,9 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -39,7 +40,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		outputDir = temporaryFolder.getRoot();
-        DefaultReverseEngineeringStrategy c = new DefaultReverseEngineeringStrategy();
+        AbstractRevengStrategy c = new DefaultRevengStrategy();
         c.setSettings(new ReverseEngineeringSettings(c).setDetectManyToMany(true)); 
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(c, null);

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -25,10 +25,10 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
@@ -61,7 +61,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "cat.cat"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();
@@ -111,7 +111,7 @@ public class TestCase {
 				serviceRegistry.getService(JdbcServices.class).getDialect(), 
 				properties);
 		DatabaseReader reader = DatabaseReader.create( 
-				properties, new DefaultReverseEngineeringStrategy(), 
+				properties, new DefaultRevengStrategy(), 
 				realMetaData, serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -15,10 +15,10 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -51,7 +51,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {		
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();
@@ -76,7 +76,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "MASTER"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "CHILD"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();

--- a/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
@@ -9,10 +9,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.mapping.Column;
+import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy;
 import org.junit.Assert;
 import org.junit.Test;
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class TestCase {
 	
-	ReverseEngineeringStrategy rns = new DefaultReverseEngineeringStrategy();
+	ReverseEngineeringStrategy rns = new DefaultRevengStrategy();
 	
 	@Test
 	public void testColumnKeepCase() {
@@ -97,7 +97,7 @@ public class TestCase {
 	@Test
     public void testCustomClassNameStrategyWithCollectionName() {
     	
-    	ReverseEngineeringStrategy custom = new DelegatingReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy()) {
+    	ReverseEngineeringStrategy custom = new DelegatingReverseEngineeringStrategy(new DefaultRevengStrategy()) {
     		public String tableToClassName(TableIdentifier tableIdentifier) {
     			return super.tableToClassName( tableIdentifier ) + "Impl";
     		}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>