### PR TITLE
HBX-1992: HBX-1992: Reorganize the reverse engineering strategy hierarchy - Rename 'org.hibernate.tool.api.reveng.ReverseEngineeringSettings' to 'org.hibernate.tool.api.reveng.RevengSettings'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -14,7 +14,7 @@ import org.apache.tools.ant.types.Path;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.metadata.MetadataConstants;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
 import org.hibernate.tool.util.ReflectionUtil;
@@ -67,8 +67,8 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 			strategy = loadreverseEngineeringStrategy(reverseEngineeringStrategyClass, strategy);			
 		}
 		
-		ReverseEngineeringSettings qqsettings = 
-			new ReverseEngineeringSettings(strategy).setDefaultPackageName(packageName)
+		RevengSettings qqsettings = 
+			new RevengSettings(strategy).setDefaultPackageName(packageName)
 			.setDetectManyToMany( detectManyToMany )
 			.setDetectOneToOne( detectOneToOne )
 			.setDetectOptimisticLock( detectOptimisticLock );

--- a/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
@@ -12,7 +12,7 @@ import org.apache.tools.ant.BuildException;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.metadata.MetadataConstants;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
 
@@ -82,8 +82,8 @@ public abstract class AbstractGenerationMojo extends AbstractMojo {
         		ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
         				revengStrategy, 
         				revengFiles);
-        ReverseEngineeringSettings settings =
-                new ReverseEngineeringSettings(strategy)
+        RevengSettings settings =
+                new RevengSettings(strategy)
                         .setDefaultPackageName(packageName)
                         .setDetectManyToMany(detectManyToMany)
                         .setDetectOneToOne(detectOneToOne)

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/RevengSettings.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/RevengSettings.java
@@ -1,6 +1,6 @@
 package org.hibernate.tool.api.reveng;
 
-public class ReverseEngineeringSettings {
+public class RevengSettings {
 
 	
 	final ReverseEngineeringStrategy rootStrategy;
@@ -13,11 +13,11 @@ public class ReverseEngineeringSettings {
 	private boolean detectOneToOne = true;
 
 	
-	public ReverseEngineeringSettings(ReverseEngineeringStrategy rootStrategy) {
+	public RevengSettings(ReverseEngineeringStrategy rootStrategy) {
 		this.rootStrategy = rootStrategy;
 	}
 	
-	public ReverseEngineeringSettings setDefaultPackageName(String defaultPackageName) {
+	public RevengSettings setDefaultPackageName(String defaultPackageName) {
 		if(defaultPackageName==null) {
 			this.defaultPackageName = "";
 		} else {
@@ -36,7 +36,7 @@ public class ReverseEngineeringSettings {
 		return detectOptimisticLock ;
 	}
 	
-	public ReverseEngineeringSettings setDetectOptimisticLock(
+	public RevengSettings setDetectOptimisticLock(
 			boolean optimisticLockSupportEnabled) {
 		this.detectOptimisticLock = optimisticLockSupportEnabled;
 		return this;
@@ -48,7 +48,7 @@ public class ReverseEngineeringSettings {
 	}
 	
 	
-	public ReverseEngineeringSettings setCreateCollectionForForeignKey(
+	public RevengSettings setCreateCollectionForForeignKey(
 			boolean createCollectionForForeignKey) {
 		this.createCollectionForForeignKey = createCollectionForForeignKey;
 		return this;
@@ -59,13 +59,13 @@ public class ReverseEngineeringSettings {
 		return createManyToOneForForeignKey;
 	}
 	
-	public ReverseEngineeringSettings setCreateManyToOneForForeignKey(
+	public RevengSettings setCreateManyToOneForForeignKey(
 			boolean createManyToOneForForeignKey) {
 		this.createManyToOneForForeignKey = createManyToOneForForeignKey;
 		return this;
 	}
 
-	public ReverseEngineeringSettings setDetectManyToMany(boolean b) {
+	public RevengSettings setDetectManyToMany(boolean b) {
 		this.detectManyToMany = b;
 		return this;
 	}
@@ -74,7 +74,7 @@ public class ReverseEngineeringSettings {
 		return detectManyToMany;
 	}
 	
-	public ReverseEngineeringSettings setDetectOneToOne(boolean b) {
+	public RevengSettings setDetectOneToOne(boolean b) {
 		this.detectOneToOne = b;
 		return this;
 	}

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategy.java
@@ -16,7 +16,7 @@ public interface ReverseEngineeringStrategy {
 	 * 
 	 * @param settings used for this
 	 */
-	public void  setSettings(ReverseEngineeringSettings settings);
+	public void  setSettings(RevengSettings settings);
 	
 	/**
 	 * Close any resources this strategy might have used. Called after reverse engineering has been completed.

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
@@ -8,7 +8,7 @@ import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.AssociationInfo;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
@@ -116,7 +116,7 @@ public class DelegatingReverseEngineeringStrategy implements ReverseEngineeringS
 	 * 
 	 * @see ReverseEngineeringStrategy.setSettings
 	 */
-	public void setSettings(ReverseEngineeringSettings settings) {
+	public void setSettings(RevengSettings settings) {
 		if(delegate!=null) delegate.setSettings(settings);
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractRevengStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractRevengStrategy.java
@@ -17,7 +17,7 @@ import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.PrimaryKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.AssociationInfo;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
@@ -32,7 +32,7 @@ public abstract class AbstractRevengStrategy implements ReverseEngineeringStrate
 	
 	private static Set<String> AUTO_OPTIMISTICLOCK_COLUMNS;
 
-	private ReverseEngineeringSettings settings = new ReverseEngineeringSettings(this);
+	private RevengSettings settings = new RevengSettings(this);
 
 	static {
 		AUTO_OPTIMISTICLOCK_COLUMNS = new HashSet<String>();
@@ -234,7 +234,7 @@ public abstract class AbstractRevengStrategy implements ReverseEngineeringStrate
 		return true;
 	}
 
-	public void setSettings(ReverseEngineeringSettings settings) {
+	public void setSettings(RevengSettings settings) {
 		this.settings = settings;		
 	}
 

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -25,7 +25,7 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.export.doc.DocExporter;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
@@ -55,7 +55,7 @@ public class TestCase {
 		JdbcUtil.createDatabase(this);
 		outputDir = temporaryFolder.getRoot();
 		AbstractRevengStrategy configurableNamingStrategy = new DefaultRevengStrategy();
-		configurableNamingStrategy.setSettings(new ReverseEngineeringSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
+		configurableNamingStrategy.setSettings(new RevengSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(configurableNamingStrategy, null);
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
@@ -15,7 +15,7 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
@@ -89,7 +89,7 @@ public class TestCase {
 	
 	private MetadataDescriptor createMetadataDescriptor() {
 		AbstractRevengStrategy configurableNamingStrategy = new DefaultRevengStrategy();
-		configurableNamingStrategy.setSettings(new ReverseEngineeringSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
+		configurableNamingStrategy.setSettings(new RevengSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		OverrideRepository overrideRepository = new OverrideRepository();
 		InputStream inputStream = new ByteArrayInputStream(REVENG_XML.getBytes());
 		overrideRepository.addInputStream(inputStream);

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -14,7 +14,7 @@ import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -48,7 +48,7 @@ public class TestCase {
 	public void testNoManyToManyBiDirectional() {
         
         AbstractRevengStrategy c = new DefaultRevengStrategy();
-        c.setSettings(new ReverseEngineeringSettings(c).setDetectManyToMany(false)); 
+        c.setSettings(new RevengSettings(c).setDetectManyToMany(false)); 
         Metadata metadata =  MetadataDescriptorFactory
         		.createReverseEngineeringDescriptor(c, null)
         		.createMetadata();

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -22,7 +22,7 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Set;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -44,7 +44,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
         AbstractRevengStrategy c = new DefaultRevengStrategy();
-        c.setSettings(new ReverseEngineeringSettings(c).setDefaultPackageName(PACKAGE_NAME));
+        c.setSettings(new RevengSettings(c).setDefaultPackageName(PACKAGE_NAME));
         metadata = MetadataDescriptorFactory
         		.createReverseEngineeringDescriptor(c, null)
         		.createMetadata();

--- a/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
+++ b/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
@@ -15,7 +15,7 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -41,7 +41,7 @@ public class TestCase {
 		JdbcUtil.createDatabase(this);
 		outputDir = temporaryFolder.getRoot();
         AbstractRevengStrategy c = new DefaultRevengStrategy();
-        c.setSettings(new ReverseEngineeringSettings(c).setDetectManyToMany(true)); 
+        c.setSettings(new RevengSettings(c).setDetectManyToMany(true)); 
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(c, null);
 	}

--- a/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.hibernate.mapping.Column;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringSettings;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy;
@@ -103,7 +103,7 @@ public class TestCase {
     		}
     	};
 
-    	custom.setSettings( new ReverseEngineeringSettings(custom) );
+    	custom.setSettings( new RevengSettings(custom) );
     	
     	TableIdentifier productTable = TableIdentifier.create(null, null, "product");
 		Assert.assertEquals("ProductImpl", custom.tableToClassName( productTable ));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>