### PR TITLE
HBX-1992: HBX-1992: Reorganize the reverse engineering strategy hierarchy - Rename 'org.hibernate.tool.api.reveng.ReverseEngineeringStrategy' to 'org.hibernate.tool.api.reveng.RevengStrategy'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -15,7 +15,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.RevengSettings;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
 import org.hibernate.tool.util.ReflectionUtil;
 
@@ -41,7 +41,7 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 	}
 	protected MetadataDescriptor createMetadataDescriptor() {
 		Properties properties = loadPropertiesFile();
-		ReverseEngineeringStrategy res = createReverseEngineeringStrategy();
+		RevengStrategy res = createReverseEngineeringStrategy();
 		properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
 		return MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(
@@ -49,7 +49,7 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 						properties);
 	}
 	
-	private ReverseEngineeringStrategy createReverseEngineeringStrategy() {
+	private RevengStrategy createReverseEngineeringStrategy() {
 		File[] revengFileList = null;
 		if (revengFiles != null ) {
 			String[] fileNames = revengFiles.list();
@@ -59,7 +59,7 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 			}
 		}
 
-		ReverseEngineeringStrategy strategy = 
+		RevengStrategy strategy = 
 				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
 						null, revengFileList);
 		
@@ -107,18 +107,18 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 		detectOptimisticLock = b;
 	}
 	
-    private ReverseEngineeringStrategy loadreverseEngineeringStrategy(final String className, ReverseEngineeringStrategy delegate) 
+    private RevengStrategy loadreverseEngineeringStrategy(final String className, RevengStrategy delegate) 
     throws BuildException {
         try {
             Class<?> clazz = ReflectionUtil.classForName(className);			
-			Constructor<?> constructor = clazz.getConstructor(new Class[] { ReverseEngineeringStrategy.class });
-            return (ReverseEngineeringStrategy) constructor.newInstance(new Object[] { delegate }); 
+			Constructor<?> constructor = clazz.getConstructor(new Class[] { RevengStrategy.class });
+            return (RevengStrategy) constructor.newInstance(new Object[] { delegate }); 
         } 
         catch (NoSuchMethodException e) {
 			try {
 				getProject().log("Could not find public " + className + "(ReverseEngineeringStrategy delegate) constructor on ReverseEngineeringStrategy. Trying no-arg version.",Project.MSG_VERBOSE);			
 				Class<?> clazz = ReflectionUtil.classForName(className);						
-				ReverseEngineeringStrategy rev = (ReverseEngineeringStrategy) clazz.newInstance();
+				RevengStrategy rev = (RevengStrategy) clazz.newInstance();
 				getProject().log("Using non-delegating strategy, thus packagename and revengfile will be ignored.", Project.MSG_INFO);
 				return rev;
 			} 

--- a/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
@@ -13,7 +13,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.RevengSettings;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
 
 public abstract class AbstractGenerationMojo extends AbstractMojo {
@@ -66,19 +66,19 @@ public abstract class AbstractGenerationMojo extends AbstractMojo {
 
     public void execute() {
         getLog().info("Starting " + this.getClass().getSimpleName() + "...");
-        ReverseEngineeringStrategy strategy = setupReverseEngineeringStrategy();
+        RevengStrategy strategy = setupReverseEngineeringStrategy();
         Properties properties = loadPropertiesFile();
         MetadataDescriptor jdbcDescriptor = createJdbcDescriptor(strategy, properties);
         executeExporter(jdbcDescriptor);
         getLog().info("Finished " + this.getClass().getSimpleName() + "!");
     }
 
-    private ReverseEngineeringStrategy setupReverseEngineeringStrategy() {
+    private RevengStrategy setupReverseEngineeringStrategy() {
     	File[] revengFiles = null;
     	if (revengFile != null) {
     		revengFiles = new File[] { revengFile };
     	}
-        ReverseEngineeringStrategy strategy = 
+        RevengStrategy strategy = 
         		ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
         				revengStrategy, 
         				revengFiles);
@@ -110,7 +110,7 @@ public abstract class AbstractGenerationMojo extends AbstractMojo {
         }
     }
 
-    private MetadataDescriptor createJdbcDescriptor(ReverseEngineeringStrategy strategy, Properties properties) {
+    private MetadataDescriptor createJdbcDescriptor(RevengStrategy strategy, Properties properties) {
     	properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, preferBasicCompositeIds);
         return MetadataDescriptorFactory
                 .createReverseEngineeringDescriptor(

--- a/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptorFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/metadata/MetadataDescriptorFactory.java
@@ -3,7 +3,7 @@ package org.hibernate.tool.api.metadata;
 import java.io.File;
 import java.util.Properties;
 
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.metadata.RevengMetadataDescriptor;
 import org.hibernate.tool.internal.metadata.JpaMetadataDescriptor;
 import org.hibernate.tool.internal.metadata.NativeMetadataDescriptor;
@@ -11,7 +11,7 @@ import org.hibernate.tool.internal.metadata.NativeMetadataDescriptor;
 public class MetadataDescriptorFactory {
 	
 	public static MetadataDescriptor createReverseEngineeringDescriptor(
-			ReverseEngineeringStrategy reverseEngineeringStrategy, 
+			RevengStrategy reverseEngineeringStrategy, 
 			Properties properties) {
 		return new RevengMetadataDescriptor(
 				reverseEngineeringStrategy, 

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/DefaultRevengStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/DefaultRevengStrategy.java
@@ -2,6 +2,6 @@ package org.hibernate.tool.api.reveng;
 
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 
-public class DefaultRevengStrategy extends AbstractRevengStrategy implements ReverseEngineeringStrategy {
+public class DefaultRevengStrategy extends AbstractRevengStrategy implements RevengStrategy {
 
 }

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/RevengSettings.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/RevengSettings.java
@@ -3,7 +3,7 @@ package org.hibernate.tool.api.reveng;
 public class RevengSettings {
 
 	
-	final ReverseEngineeringStrategy rootStrategy;
+	final RevengStrategy rootStrategy;
 	
 	private String defaultPackageName = "";
 	private boolean detectOptimisticLock = true;
@@ -13,7 +13,7 @@ public class RevengSettings {
 	private boolean detectOneToOne = true;
 
 	
-	public RevengSettings(ReverseEngineeringStrategy rootStrategy) {
+	public RevengSettings(RevengStrategy rootStrategy) {
 		this.rootStrategy = rootStrategy;
 	}
 	
@@ -84,7 +84,7 @@ public class RevengSettings {
 	}
 	
 	/** return the top/root strategy. Allows a lower strategy to ask another question. Be aware of possible recursive loops; e.g. do not call the root.tableToClassName in tableToClassName of a custom reversengineeringstrategy. */
-	public ReverseEngineeringStrategy getRootStrategy() {
+	public RevengStrategy getRootStrategy() {
 		return rootStrategy;
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/RevengStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/RevengStrategy.java
@@ -9,7 +9,7 @@ import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 
-public interface ReverseEngineeringStrategy {
+public interface RevengStrategy {
 
 	/**
 	 * Generic method used to initialize the reverse engineering strategy.

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactory.java
@@ -10,26 +10,26 @@ public class ReverseEngineeringStrategyFactory {
 	private static final String DEFAULT_REVERSE_ENGINEERING_STRATEGY_CLASS_NAME = 
 			DefaultRevengStrategy.class.getName();
 	
-	public static ReverseEngineeringStrategy createReverseEngineeringStrategy(
+	public static RevengStrategy createReverseEngineeringStrategy(
 			String reverseEngineeringClassName) {
-		ReverseEngineeringStrategy result = null;
+		RevengStrategy result = null;
 		try {
 			Class<?> reverseEngineeringClass = 
 					ReflectionUtil.classForName(
 							reverseEngineeringClassName == null ? 
 									DEFAULT_REVERSE_ENGINEERING_STRATEGY_CLASS_NAME : 
 									reverseEngineeringClassName);
-			result = (ReverseEngineeringStrategy)reverseEngineeringClass.newInstance();
+			result = (RevengStrategy)reverseEngineeringClass.newInstance();
 		} catch (ClassNotFoundException | IllegalAccessException | InstantiationException exception) {
 			throw new RuntimeException("An exporter of class '" + reverseEngineeringClassName + "' could not be created", exception);
 		}
 		return result;
 	}
 	
-	public static ReverseEngineeringStrategy createReverseEngineeringStrategy(
+	public static RevengStrategy createReverseEngineeringStrategy(
 			String reverseEngineeringClassName,
 			File[] revengFiles) {
-		ReverseEngineeringStrategy result = 
+		RevengStrategy result = 
 				createReverseEngineeringStrategy(reverseEngineeringClassName);
 		if (revengFiles != null && revengFiles.length > 0) {
 			OverrideRepository overrideRepository = new OverrideRepository();
@@ -41,7 +41,7 @@ public class ReverseEngineeringStrategyFactory {
 		return result;
 	}
 	
-	public static ReverseEngineeringStrategy createReverseEngineeringStrategy() {
+	public static RevengStrategy createReverseEngineeringStrategy() {
 		return createReverseEngineeringStrategy(null);
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
@@ -6,17 +6,17 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.Environment;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataConstants;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
 import org.hibernate.tool.internal.reveng.RevengMetadataBuilder;
 
 public class RevengMetadataDescriptor implements MetadataDescriptor {
 	
-	private ReverseEngineeringStrategy reverseEngineeringStrategy = null;
+	private RevengStrategy reverseEngineeringStrategy = null;
     private Properties properties = new Properties();
 
 	public RevengMetadataDescriptor(
-			ReverseEngineeringStrategy reverseEngineeringStrategy, 
+			RevengStrategy reverseEngineeringStrategy, 
 			Properties properties) {
 		this.properties.putAll(Environment.getProperties());
 		if (properties != null) {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/DelegatingReverseEngineeringStrategy.java
@@ -9,19 +9,19 @@ import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.AssociationInfo;
 import org.hibernate.tool.api.reveng.RevengSettings;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 
-public class DelegatingReverseEngineeringStrategy implements ReverseEngineeringStrategy {
+public class DelegatingReverseEngineeringStrategy implements RevengStrategy {
 
-	ReverseEngineeringStrategy delegate;
+	RevengStrategy delegate;
 
 	public List<ForeignKey> getForeignKeys(TableIdentifier referencedTable) {
 		return delegate==null?null:delegate.getForeignKeys(referencedTable);
 	}
 
-	public DelegatingReverseEngineeringStrategy(ReverseEngineeringStrategy delegate) {
+	public DelegatingReverseEngineeringStrategy(RevengStrategy delegate) {
 		this.delegate = delegate;
 	}
 
@@ -114,7 +114,7 @@ public class DelegatingReverseEngineeringStrategy implements ReverseEngineeringS
 	 * 
 	 * If subclasses need to use the Settings then it should keep its own reference, but still remember to initialize the delegates settings by calling super.setSettings(settings).
 	 * 
-	 * @see ReverseEngineeringStrategy.setSettings
+	 * @see RevengStrategy.setSettings
 	 */
 	public void setSettings(RevengSettings settings) {
 		if(delegate!=null) delegate.setSettings(settings);

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/OverrideRepository.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/OverrideRepository.java
@@ -26,7 +26,7 @@ import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.MetaAttribute;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.AssociationInfo;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.MetaAttributeHelper.SimpleMetaAttribute;
@@ -282,7 +282,7 @@ public class OverrideRepository  {
 		tableFilters.add(filter);
 	}
 
-	public ReverseEngineeringStrategy getReverseEngineeringStrategy(ReverseEngineeringStrategy delegate) {
+	public RevengStrategy getReverseEngineeringStrategy(RevengStrategy delegate) {
 		return new DelegatingReverseEngineeringStrategy(delegate) {
 
 			public boolean excludeTable(TableIdentifier ti) {
@@ -569,7 +569,7 @@ public class OverrideRepository  {
 		return result;
  	}
 
-	public ReverseEngineeringStrategy getReverseEngineeringStrategy() {
+	public RevengStrategy getReverseEngineeringStrategy() {
 		return getReverseEngineeringStrategy(null);
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/RevengMetadataBuilder.java
@@ -20,7 +20,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.binder.BinderContext;
 import org.hibernate.tool.internal.reveng.binder.RootClassBinder;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
@@ -36,7 +36,7 @@ public class RevengMetadataBuilder {
 	
 	public static RevengMetadataBuilder create(
 			Properties properties, 
-			ReverseEngineeringStrategy reverseEngineeringStrategy) {
+			RevengStrategy reverseEngineeringStrategy) {
 		return new RevengMetadataBuilder(properties, reverseEngineeringStrategy);
 	}
 	
@@ -45,14 +45,14 @@ public class RevengMetadataBuilder {
 	private final Properties properties;
 	private final MetadataBuildingContext metadataBuildingContext;	
 	private final InFlightMetadataCollectorImpl metadataCollector;	
-	private final ReverseEngineeringStrategy revengStrategy;
+	private final RevengStrategy revengStrategy;
 	private final BinderContext binderContext;
 	
 	private final StandardServiceRegistry serviceRegistry;
 	
 	private RevengMetadataBuilder(
 			Properties properties,
-			ReverseEngineeringStrategy reverseEngineeringStrategy) {
+			RevengStrategy reverseEngineeringStrategy) {
 		this.properties = properties;
 		this.revengStrategy = reverseEngineeringStrategy;
 		this.serviceRegistry = new StandardServiceRegistryBuilder()

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/TableSelectorStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/TableSelectorStrategy.java
@@ -6,14 +6,14 @@ package org.hibernate.tool.internal.reveng;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 
 public class TableSelectorStrategy extends DelegatingReverseEngineeringStrategy {
 	
 	List<SchemaSelection> selections = new ArrayList<SchemaSelection>();
 	
-	public TableSelectorStrategy(ReverseEngineeringStrategy res) {
+	public TableSelectorStrategy(RevengStrategy res) {
 		super(res);
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/AbstractBinder.java
@@ -4,7 +4,7 @@ import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.metadata.MetadataConstants;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 
 abstract class AbstractBinder {
 	
@@ -22,7 +22,7 @@ abstract class AbstractBinder {
 		return binderContext.metadataCollector;
 	}
 	
-	ReverseEngineeringStrategy getRevengStrategy() {
+	RevengStrategy getRevengStrategy() {
 		return binderContext.revengStrategy;
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderContext.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderContext.java
@@ -4,14 +4,14 @@ import java.util.Properties;
 
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 
 public class BinderContext {
 	
 	public static BinderContext create(
 			MetadataBuildingContext metadataBuildingContext,
 			InFlightMetadataCollector metadataCollector,
-			ReverseEngineeringStrategy revengStrategy,
+			RevengStrategy revengStrategy,
 			Properties properties) {
 		return new BinderContext(
 				metadataBuildingContext, 
@@ -22,13 +22,13 @@ public class BinderContext {
 	
 	public final MetadataBuildingContext metadataBuildingContext;
 	public final InFlightMetadataCollector metadataCollector;
-	public final ReverseEngineeringStrategy revengStrategy;
+	public final RevengStrategy revengStrategy;
 	public final Properties properties;
 	
 	private BinderContext(
 			MetadataBuildingContext metadataBuildingContext,
 			InFlightMetadataCollector metadataCollector,
-			ReverseEngineeringStrategy revengStrategy,
+			RevengStrategy revengStrategy,
 			Properties properties) {
 		this.metadataBuildingContext = metadataBuildingContext;
 		this.metadataCollector = metadataCollector;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
@@ -17,7 +17,7 @@ import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.tool.api.reveng.AssociationInfo;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 
 public class BinderUtils {
 	
@@ -81,7 +81,7 @@ public class BinderUtils {
 
 
     static AssociationInfo getAssociationInfo(
-    		ReverseEngineeringStrategy revengStrategy,
+    		RevengStrategy revengStrategy,
     		ForeignKey foreignKey, 
     		boolean inverseProperty) {
     	if (inverseProperty) {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/TypeUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/TypeUtils.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
@@ -18,7 +18,7 @@ public class TypeUtils {
 
 	public static String determinePreferredType(
 			InFlightMetadataCollector metadataCollector,
-			ReverseEngineeringStrategy revengStrategy,
+			RevengStrategy revengStrategy,
 			Table table, 
 			Column column, 
 			boolean generatedIdentifier) {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/BasicColumnProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/BasicColumnProcessor.java
@@ -8,7 +8,7 @@ import org.hibernate.JDBCException;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.util.RevengUtils;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
@@ -21,7 +21,7 @@ public class BasicColumnProcessor {
 
 	public static void processBasicColumns(
 			MetaDataDialect metaDataDialect, 
-			ReverseEngineeringStrategy revengStrategy, 
+			RevengStrategy revengStrategy, 
 			String defaultSchema, String defaultCatalog, 
 			Table table) {
 		

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/DatabaseReader.java
@@ -14,7 +14,7 @@ import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 
@@ -22,14 +22,14 @@ public class DatabaseReader {
 
 	public static DatabaseReader create(
 			Properties properties, 
-			ReverseEngineeringStrategy revengStrategy,
+			RevengStrategy revengStrategy,
 			MetaDataDialect mdd, 
 			ServiceRegistry serviceRegistry) {
 		ConnectionProvider connectionProvider = serviceRegistry.getService(ConnectionProvider.class);
 		return new DatabaseReader(properties, mdd, connectionProvider, revengStrategy);
 	}
 
-	private final ReverseEngineeringStrategy revengStrategy;
+	private final RevengStrategy revengStrategy;
 
 	private MetaDataDialect metadataDialect;
 
@@ -41,7 +41,7 @@ public class DatabaseReader {
 			Properties properties, 
 			MetaDataDialect dialect, 
 			ConnectionProvider provider, 
-			ReverseEngineeringStrategy reveng) {
+			RevengStrategy reveng) {
 		this.metadataDialect = dialect;
 		this.provider = provider;
 		this.revengStrategy = reveng;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeyProcessor.java
@@ -12,7 +12,7 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.util.RevengUtils;
@@ -25,7 +25,7 @@ public class ForeignKeyProcessor {
 	
 	public static ForeignKeyProcessor create(
 			MetaDataDialect metaDataDialect,
-			ReverseEngineeringStrategy revengStrategy,
+			RevengStrategy revengStrategy,
 			String defaultCatalog,
 			String defaultSchema,
 			RevengMetadataCollector revengMetadataCollector) {
@@ -38,14 +38,14 @@ public class ForeignKeyProcessor {
 	}
 	
 	private final MetaDataDialect metaDataDialect;
-	private final ReverseEngineeringStrategy revengStrategy;
+	private final RevengStrategy revengStrategy;
 	private final String defaultSchema;
 	private final String defaultCatalog;
 	private final RevengMetadataCollector revengMetadataCollector;
 	
 	private ForeignKeyProcessor(
 			MetaDataDialect metaDataDialect,
-			ReverseEngineeringStrategy revengStrategy,
+			RevengStrategy revengStrategy,
 			String defaultCatalog,
 			String defaultSchema,
 			RevengMetadataCollector revengMetadataCollector) {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeysInfo.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/ForeignKeysInfo.java
@@ -10,7 +10,7 @@ import java.util.Map.Entry;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 
 public class ForeignKeysInfo {
@@ -31,7 +31,7 @@ public class ForeignKeysInfo {
 		this.referencedColumns = refColumns;
 	}
 	
-	public Map<String, List<ForeignKey>> process(ReverseEngineeringStrategy revengStrategy) {
+	public Map<String, List<ForeignKey>> process(RevengStrategy revengStrategy) {
 		Map<String, List<ForeignKey>> oneToManyCandidates = new HashMap<String, List<ForeignKey>>();
         Iterator<Entry<String, Table>> iterator = dependentTables.entrySet().iterator();
 		while (iterator.hasNext() ) {

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/PrimaryKeyProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/PrimaryKeyProcessor.java
@@ -13,7 +13,7 @@ import org.hibernate.mapping.PrimaryKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.sql.Alias;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.util.RevengUtils;
 import org.jboss.logging.Logger;
@@ -24,7 +24,7 @@ public class PrimaryKeyProcessor {
 
 	public static void processPrimaryKey(
 			MetaDataDialect metaDataDialect, 
-			ReverseEngineeringStrategy revengStrategy, 
+			RevengStrategy revengStrategy, 
 			String defaultSchema, 
 			String defaultCatalog, 
 			RevengMetadataCollector revengMetadataCollector, 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/TableCollector.java
@@ -9,7 +9,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
@@ -21,7 +21,7 @@ public class TableCollector {
 	
 	public static TableCollector create(
 			MetaDataDialect metaDataDialect, 
-			ReverseEngineeringStrategy revengStrategy, 
+			RevengStrategy revengStrategy, 
 			RevengMetadataCollector revengMetadataCollector, 
 			Properties properties) {
 		return new TableCollector(
@@ -32,13 +32,13 @@ public class TableCollector {
 	}
 	
 	private MetaDataDialect metaDataDialect;
-	private ReverseEngineeringStrategy revengStrategy;
+	private RevengStrategy revengStrategy;
 	private RevengMetadataCollector revengMetadataCollector;
 	private Properties properties;
 	
 	private TableCollector(
 			MetaDataDialect metaDataDialect, 
-			ReverseEngineeringStrategy revengStrategy, 
+			RevengStrategy revengStrategy, 
 			RevengMetadataCollector revengMetadataCollector, 
 			Properties properties) {
 		this.metaDataDialect = metaDataDialect;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractRevengStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractRevengStrategy.java
@@ -18,7 +18,7 @@ import org.hibernate.mapping.PrimaryKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.AssociationInfo;
 import org.hibernate.tool.api.reveng.RevengSettings;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
@@ -26,7 +26,7 @@ import org.hibernate.tool.internal.util.NameConverter;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.jboss.logging.Logger;
 
-public abstract class AbstractRevengStrategy implements ReverseEngineeringStrategy {
+public abstract class AbstractRevengStrategy implements RevengStrategy {
 
 	static final private Logger log = Logger.getLogger(AbstractRevengStrategy.class);
 	
@@ -315,7 +315,7 @@ public abstract class AbstractRevengStrategy implements ReverseEngineeringStrate
 		}
 	}
 
-	protected ReverseEngineeringStrategy getRoot() {
+	protected RevengStrategy getRoot() {
 		return settings.getRootStrategy();
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/util/RevengUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/util/RevengUtils.java
@@ -3,13 +3,13 @@ package org.hibernate.tool.internal.reveng.util;
 import java.util.List;
 
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 
 public class RevengUtils {
 
 	public static List<String> getPrimaryKeyInfoInRevengStrategy(
-			ReverseEngineeringStrategy revengStrat, 
+			RevengStrategy revengStrat, 
 			Table table, 
 			String defaultCatalog, 
 			String defaultSchema) {
@@ -26,7 +26,7 @@ public class RevengUtils {
 	}
 	
 	public static String getTableIdentifierStrategyNameInRevengStrategy(
-			ReverseEngineeringStrategy revengStrat, 
+			RevengStrategy revengStrat, 
 			TableIdentifier tableIdentifier, 
 			String defaultCatalog, 
 			String defaultSchema) {

--- a/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
@@ -8,7 +8,7 @@ public class ReverseEngineeringStrategyFactoryTest {
 	
 	@Test
 	public void testCreateReverseEngineeringStrategy() {
-		ReverseEngineeringStrategy reverseEngineeringStrategy = 
+		RevengStrategy reverseEngineeringStrategy = 
 				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy();
 		Assert.assertNotNull(reverseEngineeringStrategy);
 		Assert.assertEquals(

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -26,7 +26,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
@@ -58,7 +58,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "cat.cat"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		List<Table> tables = getTables(MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata());

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -16,7 +16,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
@@ -48,7 +48,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		List<Table> tables = getTables(MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata());
@@ -71,7 +71,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "MASTER"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "CHILD"));
-		ReverseEngineeringStrategy res = 
+		RevengStrategy res = 
 				or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
@@ -16,7 +16,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
 import org.hibernate.tools.test.util.JavaUtil;
@@ -93,7 +93,7 @@ public class TestCase {
 		OverrideRepository overrideRepository = new OverrideRepository();
 		InputStream inputStream = new ByteArrayInputStream(REVENG_XML.getBytes());
 		overrideRepository.addInputStream(inputStream);
-		ReverseEngineeringStrategy res = overrideRepository
+		RevengStrategy res = overrideRepository
 				.getReverseEngineeringStrategy(configurableNamingStrategy);
 		return MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null);

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -27,7 +27,7 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
@@ -47,7 +47,7 @@ import org.junit.rules.TemporaryFolder;
 public class TestCase {
 
 	private MetadataDescriptor metadataDescriptor = null;
-	private ReverseEngineeringStrategy reverseEngineeringStrategy = null;
+	private RevengStrategy reverseEngineeringStrategy = null;
 	
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
@@ -13,7 +13,7 @@ import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class TestCase {
 
 	private Metadata metadata = null;
-	private ReverseEngineeringStrategy reverseEngineeringStrategy = null;
+	private RevengStrategy reverseEngineeringStrategy = null;
 
 	@Before
 	public void setUp() {

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -25,7 +25,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
@@ -48,7 +48,7 @@ public class TestCase {
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	private MetadataDescriptor metadataDescriptor = null;
-	private ReverseEngineeringStrategy reverseEngineeringStrategy = null;
+	private RevengStrategy reverseEngineeringStrategy = null;
 
 	@Before
 	public void setUp() {

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -22,7 +22,7 @@ import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
@@ -53,7 +53,7 @@ public class TestCase {
 		JdbcUtil.createDatabase(this);
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(OVERRIDETEST_REVENG_XML);
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(
+		RevengStrategy res = or.getReverseEngineeringStrategy(
 				new DefaultRevengStrategy() );
 		metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
@@ -70,7 +70,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 				
 		or.addResource(TEST_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(null);
+		RevengStrategy repository = or.getReverseEngineeringStrategy(null);
 
 		Assert.assertEquals("int", repository.columnToHibernateTypeName(null, null, Types.INTEGER, 5, SQLTypeMapping.UNKNOWN_PRECISION, SQLTypeMapping.UNKNOWN_SCALE, false, false) );
 		Assert.assertEquals("long", repository.columnToHibernateTypeName(null, null, Types.INTEGER, SQLTypeMapping.UNKNOWN_LENGTH, SQLTypeMapping.UNKNOWN_PRECISION, SQLTypeMapping.UNKNOWN_SCALE, false, false) );
@@ -98,7 +98,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(DOC_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 
 		Assert.assertEquals("int", repository.columnToHibernateTypeName(null, "ID", Types.INTEGER, SQLTypeMapping.UNKNOWN_LENGTH, 10, SQLTypeMapping.UNKNOWN_SCALE, false, false) );
 		Assert.assertEquals("your.package.TrimStringUserType", repository.columnToHibernateTypeName(null, "NAME", Types.VARCHAR, 30, SQLTypeMapping.UNKNOWN_PRECISION, SQLTypeMapping.UNKNOWN_SCALE, true, false) );
@@ -114,7 +114,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(SCHEMA_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 
 		List<?> schemaSelectors = repository.getSchemaSelections();
 		
@@ -144,7 +144,7 @@ public class TestCase {
 		
 		OverrideRepository ox = new OverrideRepository();
 		ox.addSchemaSelection(new SchemaSelection(null, null, "DUMMY.*"));
-		ReverseEngineeringStrategy strategy = ox.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy strategy = ox.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata md = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(strategy, null)
 				.createMetadata();
@@ -160,7 +160,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(OVERRIDETEST_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(null);
+		RevengStrategy repository = or.getReverseEngineeringStrategy(null);
 
 		Assert.assertNull(repository.columnToHibernateTypeName(TableIdentifier.create(null, null, "blah"), "bogus",0,0,0,0, false, false));
 		Assert.assertNull(repository.columnToHibernateTypeName(TableIdentifier.create(null, null, "ORDERS"), "CUSTID",0,0,0,0, false, false));
@@ -187,7 +187,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(OVERRIDETEST_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(null);
+		RevengStrategy repository = or.getReverseEngineeringStrategy(null);
 
 		Assert.assertNull(repository.columnToPropertyName(TableIdentifier.create(null, null, "blah"), "bogus"));
 		Assert.assertNull(repository.columnToPropertyName(TableIdentifier.create(null, null, "ORDERS"), "cust_id"));
@@ -209,7 +209,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(OVERRIDETEST_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(null);
+		RevengStrategy repository = or.getReverseEngineeringStrategy(null);
 
 		TableIdentifier miscTable = TableIdentifier.create(null,null, "MISC_TYPES");
 		Assert.assertEquals("sequence",repository.getTableIdentifierStrategyName(miscTable));
@@ -260,7 +260,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(OVERRIDETEST_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(null);
+		RevengStrategy repository = or.getReverseEngineeringStrategy(null);
 		
 		Assert.assertTrue(repository.excludeTable(TableIdentifier.create(null,null, "DoNotWantIt") ) );
 		Assert.assertFalse(repository.excludeTable(TableIdentifier.create(null,null, "NotListedThere") ) );
@@ -275,7 +275,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(OVERRIDETEST_REVENG_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		
 		Assert.assertEquals("org.werd.Q", repository.tableToClassName(TableIdentifier.create("q","Werd", "Q") ) );
 		Assert.assertEquals("Notknown", repository.tableToClassName(TableIdentifier.create(null,null, "notknown") ) );
@@ -350,7 +350,7 @@ public class TestCase {
 		sqltype.setHibernateType("yes_no");
 		or.addTypeMapping(sqltype);
 		
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(null);
+		RevengStrategy res = or.getReverseEngineeringStrategy(null);
 		Assert.assertEquals("boolean",res.columnToHibernateTypeName(null,null, Types.BINARY, 1, SQLTypeMapping.UNKNOWN_PRECISION, SQLTypeMapping.UNKNOWN_SCALE, false, false) );
 		Assert.assertEquals(null,res.columnToHibernateTypeName(null,null, Types.LONGVARCHAR, 1, SQLTypeMapping.UNKNOWN_PRECISION, SQLTypeMapping.UNKNOWN_SCALE, false, false) );
 		Assert.assertEquals("yes_no",res.columnToHibernateTypeName(null,null, Types.BIT, SQLTypeMapping.UNKNOWN_LENGTH, SQLTypeMapping.UNKNOWN_PRECISION, SQLTypeMapping.UNKNOWN_SCALE, false, false) );
@@ -381,7 +381,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(OVERRIDETEST_REVENG_XML);
 		
-		ReverseEngineeringStrategy reverseEngineeringStrategy = or.getReverseEngineeringStrategy();
+		RevengStrategy reverseEngineeringStrategy = or.getReverseEngineeringStrategy();
 		
 		Assert.assertFalse(reverseEngineeringStrategy.excludeColumn(TableIdentifier.create(null, null, "EXCOLUMNS"), "blah"));
 		Assert.assertFalse(reverseEngineeringStrategy.excludeColumn(TableIdentifier.create(null, null, "EXCOLUMNS"), "NAME"));
@@ -449,7 +449,7 @@ public class TestCase {
 	@Test
 	public void testTableToClass() {
 		
-		ReverseEngineeringStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		
 		TableIdentifier tableIdentifier = TableIdentifier.create(null, null, "TblTest");
 		Assert.assertEquals("org.test.Test", res.tableToClassName(tableIdentifier));		
@@ -470,7 +470,7 @@ public class TestCase {
 	@Test
 	public void testMetaAttributes() {
 		
-		ReverseEngineeringStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		
 		TableIdentifier tableIdentifier = TableIdentifier.create(null, null, "TblTest");
 		Map<String,MetaAttribute> attributes = res.tableToMetaAttributes(tableIdentifier);

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
@@ -13,7 +13,7 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -68,7 +68,7 @@ public class TestCase {
 	public void testSetAndManyToOne() {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();			
@@ -100,7 +100,7 @@ public class TestCase {
 	public void testOneToOne() throws MalformedURLException, ClassNotFoundException {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();
@@ -125,7 +125,7 @@ public class TestCase {
 		try {
 			OverrideRepository or = new OverrideRepository();
 			or.addResource(BAD_FOREIGNKEY_XML);
-			ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+			RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 			MetadataDescriptorFactory
 					.createReverseEngineeringDescriptor(repository, null)
 					.createMetadata();
@@ -152,7 +152,7 @@ public class TestCase {
 	public void testManyToOneAttributeOverrides() {
 		OverrideRepository or = new OverrideRepository();	
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		ReverseEngineeringStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -26,7 +26,7 @@ import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
@@ -61,7 +61,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "cat.cat"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -16,7 +16,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
@@ -51,7 +51,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {		
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();
@@ -76,7 +76,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "MASTER"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "CHILD"));
-		ReverseEngineeringStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();

--- a/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.hibernate.mapping.Column;
 import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy;
 import org.junit.Assert;
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class TestCase {
 	
-	ReverseEngineeringStrategy rns = new DefaultRevengStrategy();
+	RevengStrategy rns = new DefaultRevengStrategy();
 	
 	@Test
 	public void testColumnKeepCase() {
@@ -97,7 +97,7 @@ public class TestCase {
 	@Test
     public void testCustomClassNameStrategyWithCollectionName() {
     	
-    	ReverseEngineeringStrategy custom = new DelegatingReverseEngineeringStrategy(new DefaultRevengStrategy()) {
+    	RevengStrategy custom = new DelegatingReverseEngineeringStrategy(new DefaultRevengStrategy()) {
     		public String tableToClassName(TableIdentifier tableIdentifier) {
     			return super.tableToClassName( tableIdentifier ) + "Impl";
     		}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>