### PR TITLE
HBX-1992: HBX-1992: Reorganize the reverse engineering strategy hierarchy - Rename 'org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory' to 'org.hibernate.tool.api.reveng.RevengStrategyFactory'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -16,7 +16,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
+import org.hibernate.tool.api.reveng.RevengStrategyFactory;
 import org.hibernate.tool.util.ReflectionUtil;
 
 
@@ -60,7 +60,7 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 		}
 
 		RevengStrategy strategy = 
-				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
+				RevengStrategyFactory.createReverseEngineeringStrategy(
 						null, revengFileList);
 		
 		if(reverseEngineeringStrategyClass!=null) {

--- a/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
@@ -14,7 +14,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
+import org.hibernate.tool.api.reveng.RevengStrategyFactory;
 
 public abstract class AbstractGenerationMojo extends AbstractMojo {
 
@@ -79,7 +79,7 @@ public abstract class AbstractGenerationMojo extends AbstractMojo {
     		revengFiles = new File[] { revengFile };
     	}
         RevengStrategy strategy = 
-        		ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
+        		RevengStrategyFactory.createReverseEngineeringStrategy(
         				revengStrategy, 
         				revengFiles);
         RevengSettings settings =

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/RevengStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/RevengStrategyFactory.java
@@ -5,7 +5,7 @@ import java.io.File;
 import org.hibernate.tool.internal.reveng.OverrideRepository;
 import org.hibernate.tool.util.ReflectionUtil;
 
-public class ReverseEngineeringStrategyFactory {
+public class RevengStrategyFactory {
 	
 	private static final String DEFAULT_REVERSE_ENGINEERING_STRATEGY_CLASS_NAME = 
 			DefaultRevengStrategy.class.getName();

--- a/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/metadata/RevengMetadataDescriptor.java
@@ -7,7 +7,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.api.reveng.ReverseEngineeringStrategyFactory;
+import org.hibernate.tool.api.reveng.RevengStrategyFactory;
 import org.hibernate.tool.internal.reveng.RevengMetadataBuilder;
 
 public class RevengMetadataDescriptor implements MetadataDescriptor {
@@ -25,7 +25,7 @@ public class RevengMetadataDescriptor implements MetadataDescriptor {
 		if (reverseEngineeringStrategy != null) {
 			this.reverseEngineeringStrategy = reverseEngineeringStrategy;
 		} else {
-			this.reverseEngineeringStrategy = ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy();
+			this.reverseEngineeringStrategy = RevengStrategyFactory.createReverseEngineeringStrategy();
 		}
 		if (this.properties.get(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS) == null) {
 			this.properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, true);

--- a/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
@@ -9,20 +9,20 @@ public class ReverseEngineeringStrategyFactoryTest {
 	@Test
 	public void testCreateReverseEngineeringStrategy() {
 		RevengStrategy reverseEngineeringStrategy = 
-				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy();
+				RevengStrategyFactory.createReverseEngineeringStrategy();
 		Assert.assertNotNull(reverseEngineeringStrategy);
 		Assert.assertEquals(
 				DefaultRevengStrategy.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());
 		reverseEngineeringStrategy = 
-				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(
+				RevengStrategyFactory.createReverseEngineeringStrategy(
 						TestReverseEngineeringStrategyFactory.class.getName());
 		Assert.assertNotNull(reverseEngineeringStrategy);
 		Assert.assertEquals(
 				TestReverseEngineeringStrategyFactory.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());
 		reverseEngineeringStrategy = 
-				ReverseEngineeringStrategyFactory.createReverseEngineeringStrategy(null);
+				RevengStrategyFactory.createReverseEngineeringStrategy(null);
 		Assert.assertEquals(
 				DefaultRevengStrategy.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>