### PR TITLE
HBX-1992: HBX-1992: Reorganize the reverse engineering strategy hierarchy - Rename 'org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy' to 'org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/OverrideRepository.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/OverrideRepository.java
@@ -30,6 +30,7 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.MetaAttributeHelper.SimpleMetaAttribute;
+import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.jboss.logging.Logger;
@@ -283,7 +284,7 @@ public class OverrideRepository  {
 	}
 
 	public RevengStrategy getReverseEngineeringStrategy(RevengStrategy delegate) {
-		return new DelegatingReverseEngineeringStrategy(delegate) {
+		return new DelegatingStrategy(delegate) {
 
 			public boolean excludeTable(TableIdentifier ti) {
 				return OverrideRepository.this.excludeTable(ti);

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/TableSelectorStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/TableSelectorStrategy.java
@@ -8,8 +8,9 @@ import java.util.List;
 
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
+import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 
-public class TableSelectorStrategy extends DelegatingReverseEngineeringStrategy {
+public class TableSelectorStrategy extends DelegatingStrategy {
 	
 	List<SchemaSelection> selections = new ArrayList<SchemaSelection>();
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/DelegatingStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/DelegatingStrategy.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.strategy;
 
 import java.util.List;
 import java.util.Map;
@@ -13,7 +13,7 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 
-public class DelegatingReverseEngineeringStrategy implements RevengStrategy {
+public class DelegatingStrategy implements RevengStrategy {
 
 	RevengStrategy delegate;
 
@@ -21,7 +21,7 @@ public class DelegatingReverseEngineeringStrategy implements RevengStrategy {
 		return delegate==null?null:delegate.getForeignKeys(referencedTable);
 	}
 
-	public DelegatingReverseEngineeringStrategy(RevengStrategy delegate) {
+	public DelegatingStrategy(RevengStrategy delegate) {
 		this.delegate = delegate;
 	}
 

--- a/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
@@ -13,7 +13,7 @@ import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.DelegatingReverseEngineeringStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -97,7 +97,7 @@ public class TestCase {
 	@Test
     public void testCustomClassNameStrategyWithCollectionName() {
     	
-    	RevengStrategy custom = new DelegatingReverseEngineeringStrategy(new DefaultRevengStrategy()) {
+    	RevengStrategy custom = new DelegatingStrategy(new DefaultRevengStrategy()) {
     		public String tableToClassName(TableIdentifier tableIdentifier) {
     			return super.tableToClassName( tableIdentifier ) + "Impl";
     		}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>