### PR TITLE
 HBX-1992: Reorganize the reverse engineering strategy hierarchy - Rename 'org.hibernate.tool.internal.reveng.OverrideBinder' to 'org.hibernate.tool.internal.reveng.strategy.OverrideBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/MetaAttributeHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/MetaAttributeHelper.java
@@ -25,7 +25,7 @@ public class MetaAttributeHelper {
 	}
 
 
-	static MultiValuedMap<String, SimpleMetaAttribute> loadAndMergeMetaMap(
+	public static MultiValuedMap<String, SimpleMetaAttribute> loadAndMergeMetaMap(
 			Element classElement,
 			MultiValuedMap<String, SimpleMetaAttribute> inheritedMeta) {
 		return MetaAttributeHelper.mergeMetaMaps(
@@ -33,7 +33,7 @@ public class MetaAttributeHelper {
 				inheritedMeta);
 	}
 
-	static MultiValuedMap<String, SimpleMetaAttribute> loadMetaMap(Element element) {
+	public static MultiValuedMap<String, SimpleMetaAttribute> loadMetaMap(Element element) {
 		MultiValuedMap<String, SimpleMetaAttribute> result = new HashSetValuedHashMap<String, SimpleMetaAttribute>();
 		List<Element> metaAttributeList = new ArrayList<Element>();
 		ArrayList<Element> metaNodes = getChildElements(element, "meta");

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/OverrideBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/OverrideBinder.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.strategy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,8 +13,11 @@ import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.DefaultAssociationInfo;
+import org.hibernate.tool.internal.reveng.MetaAttributeHelper;
+import org.hibernate.tool.internal.reveng.SQLTypeMapping;
+import org.hibernate.tool.internal.reveng.TableFilter;
 import org.hibernate.tool.internal.reveng.MetaAttributeHelper.SimpleMetaAttribute;
-import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/OverrideRepository.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/OverrideRepository.java
@@ -30,7 +30,6 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.MetaAttributeHelper;
-import org.hibernate.tool.internal.reveng.OverrideBinder;
 import org.hibernate.tool.internal.reveng.SQLTypeMapping;
 import org.hibernate.tool.internal.reveng.TableFilter;
 import org.hibernate.tool.internal.reveng.MetaAttributeHelper.SimpleMetaAttribute;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>