### PR TITLE
 HBX-1992: Reorganize the reverse engineering strategy hierarchy - Rename 'org.hibernate.tool.api.reveng.DefaultRevengStrategy' to 'org.hibernate.tool.internal.reveng.strategy.DefaultStrategy'

### DIFF
--- a/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/AbstractGenerationMojo.java
@@ -30,7 +30,7 @@ public abstract class AbstractGenerationMojo extends AbstractMojo {
     /** The class name of the reverse engineering strategy to use.
      * Extend the DefaultReverseEngineeringStrategy and override the corresponding methods, e.g.
      * to adapt the generate class names or to provide custom type mappings. */
-    @Parameter(defaultValue = "org.hibernate.tool.api.reveng.DefaultRevengStrategy")
+    @Parameter
     private String revengStrategy;
 
     /** If true, tables which are pure many-to-many link tables will be mapped as such.

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/DefaultRevengStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/DefaultRevengStrategy.java
@@ -1,7 +1,0 @@
-package org.hibernate.tool.api.reveng;
-
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
-
-public class DefaultRevengStrategy extends AbstractRevengStrategy implements RevengStrategy {
-
-}

--- a/orm/src/main/java/org/hibernate/tool/api/reveng/RevengStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/RevengStrategyFactory.java
@@ -2,13 +2,14 @@ package org.hibernate.tool.api.reveng;
 
 import java.io.File;
 
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.util.ReflectionUtil;
 
 public class RevengStrategyFactory {
 	
 	private static final String DEFAULT_REVERSE_ENGINEERING_STRATEGY_CLASS_NAME = 
-			DefaultRevengStrategy.class.getName();
+			DefaultStrategy.class.getName();
 	
 	public static RevengStrategy createReverseEngineeringStrategy(
 			String reverseEngineeringClassName) {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
@@ -28,10 +28,10 @@ import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.TableSelectorStrategy;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
@@ -68,7 +68,7 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 		dialect = serviceRegistry.getService(JdbcServices.class).getDialect();
 
 		tableSelector = new TableSelectorStrategy(
-				new DefaultRevengStrategy() );
+				new DefaultStrategy() );
 		metadataDialect = MetaDataDialectFactory
 				.createMetaDataDialect(
 						dialect, 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/DefaultStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/DefaultStrategy.java
@@ -1,0 +1,7 @@
+package org.hibernate.tool.internal.reveng.strategy;
+
+import org.hibernate.tool.api.reveng.RevengStrategy;
+
+public class DefaultStrategy extends AbstractRevengStrategy implements RevengStrategy {
+
+}

--- a/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
@@ -1,5 +1,6 @@
 package org.hibernate.tool.api.reveng;
 
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,7 +13,7 @@ public class ReverseEngineeringStrategyFactoryTest {
 				RevengStrategyFactory.createReverseEngineeringStrategy();
 		Assert.assertNotNull(reverseEngineeringStrategy);
 		Assert.assertEquals(
-				DefaultRevengStrategy.class.getName(), 
+				DefaultStrategy.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());
 		reverseEngineeringStrategy = 
 				RevengStrategyFactory.createReverseEngineeringStrategy(
@@ -24,10 +25,10 @@ public class ReverseEngineeringStrategyFactoryTest {
 		reverseEngineeringStrategy = 
 				RevengStrategyFactory.createReverseEngineeringStrategy(null);
 		Assert.assertEquals(
-				DefaultRevengStrategy.class.getName(), 
+				DefaultStrategy.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());		
 	}
 	
-	public static class TestReverseEngineeringStrategyFactory extends DefaultRevengStrategy {}
+	public static class TestReverseEngineeringStrategyFactory extends DefaultStrategy {}
 
 }

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
@@ -16,10 +16,10 @@ import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.internal.dialect.CachedMetaDataDialect;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -140,7 +140,7 @@ public class TestCase {
 		CachedMetaDataDialect dialect = new CachedMetaDataDialect(mock);
 		DatabaseReader reader = DatabaseReader.create( 
 				properties, 
-				new DefaultRevengStrategy(), 
+				new DefaultStrategy(), 
 				dialect, 
 				serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector();
@@ -149,7 +149,7 @@ public class TestCase {
 		mock.setFailOnDelegateAccess(true);	
 		reader = DatabaseReader.create( 
 				properties, 
-				new DefaultRevengStrategy(), 
+				new DefaultStrategy(), 
 				dialect, 
 				serviceRegistry );
 		dc = new RevengMetadataCollector();

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -25,12 +25,12 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -58,7 +58,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "cat.cat"));
-		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		List<Table> tables = getTables(MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata());
@@ -105,7 +105,7 @@ public class TestCase {
 				serviceRegistry.getService(JdbcServices.class).getDialect(), 
 				properties);
 		DatabaseReader reader = DatabaseReader.create( 
-				properties, new DefaultRevengStrategy(), 
+				properties, new DefaultStrategy(), 
 				realMetaData, serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -15,10 +15,10 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -48,7 +48,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
-		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		List<Table> tables = getTables(MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata());
@@ -72,7 +72,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, null, "MASTER"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "CHILD"));
 		RevengStrategy res = 
-				or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+				or.getReverseEngineeringStrategy(new DefaultStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -24,11 +24,11 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.export.doc.DocExporter;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -54,7 +54,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		outputDir = temporaryFolder.getRoot();
-		AbstractRevengStrategy configurableNamingStrategy = new DefaultRevengStrategy();
+		AbstractRevengStrategy configurableNamingStrategy = new DefaultStrategy();
 		configurableNamingStrategy.setSettings(new RevengSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(configurableNamingStrategy, null);

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
@@ -14,10 +14,10 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -88,7 +88,7 @@ public class TestCase {
 	}
 	
 	private MetadataDescriptor createMetadataDescriptor() {
-		AbstractRevengStrategy configurableNamingStrategy = new DefaultRevengStrategy();
+		AbstractRevengStrategy configurableNamingStrategy = new DefaultStrategy();
 		configurableNamingStrategy.setSettings(new RevengSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		OverrideRepository overrideRepository = new OverrideRepository();
 		InputStream inputStream = new ByteArrayInputStream(REVENG_XML.getBytes());

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/IncrementalSchemaReading/TestCase.java
@@ -16,12 +16,12 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.dialect.JDBCMetaDataDialect;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.TableSelectorStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -70,7 +70,7 @@ public class TestCase {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(properties);
 		ServiceRegistry serviceRegistry = builder.build();
-		TableSelectorStrategy tss = new TableSelectorStrategy(new DefaultRevengStrategy());
+		TableSelectorStrategy tss = new TableSelectorStrategy(new DefaultStrategy());
 		MockedMetaDataDialect mockedMetaDataDialect = new MockedMetaDataDialect();
 		DatabaseReader reader = DatabaseReader.create( properties, tss, mockedMetaDataDialect, serviceRegistry);
 		

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -26,10 +26,10 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -55,7 +55,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		reverseEngineeringStrategy = new DefaultRevengStrategy();
+		reverseEngineeringStrategy = new DefaultStrategy();
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(reverseEngineeringStrategy, null);
 	}

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
@@ -12,10 +12,10 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
@@ -37,7 +37,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		reverseEngineeringStrategy = new DefaultRevengStrategy();
+		reverseEngineeringStrategy = new DefaultStrategy();
 		metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(reverseEngineeringStrategy, null)
 				.createMetadata();

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -24,10 +24,10 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.metadata.MetadataConstants;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -53,7 +53,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		reverseEngineeringStrategy = new DefaultRevengStrategy();
+		reverseEngineeringStrategy = new DefaultStrategy();
 		Properties properties = new Properties();
 		properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, false);
 		metadataDescriptor = MetadataDescriptorFactory

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -13,10 +13,10 @@ import org.hibernate.mapping.Property;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -47,7 +47,7 @@ public class TestCase {
 	@Test
 	public void testNoManyToManyBiDirectional() {
         
-        AbstractRevengStrategy c = new DefaultRevengStrategy();
+        AbstractRevengStrategy c = new DefaultStrategy();
         c.setSettings(new RevengSettings(c).setDetectManyToMany(false)); 
         Metadata metadata =  MetadataDescriptorFactory
         		.createReverseEngineeringDescriptor(c, null)

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -21,10 +21,10 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.SQLTypeMapping;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
@@ -54,7 +54,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(OVERRIDETEST_REVENG_XML);
 		RevengStrategy res = or.getReverseEngineeringStrategy(
-				new DefaultRevengStrategy() );
+				new DefaultStrategy() );
 		metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();
@@ -98,7 +98,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(DOC_REVENG_XML);
-		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultStrategy());
 
 		Assert.assertEquals("int", repository.columnToHibernateTypeName(null, "ID", Types.INTEGER, SQLTypeMapping.UNKNOWN_LENGTH, 10, SQLTypeMapping.UNKNOWN_SCALE, false, false) );
 		Assert.assertEquals("your.package.TrimStringUserType", repository.columnToHibernateTypeName(null, "NAME", Types.VARCHAR, 30, SQLTypeMapping.UNKNOWN_PRECISION, SQLTypeMapping.UNKNOWN_SCALE, true, false) );
@@ -114,7 +114,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(SCHEMA_REVENG_XML);
-		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultStrategy());
 
 		List<?> schemaSelectors = repository.getSchemaSelections();
 		
@@ -144,7 +144,7 @@ public class TestCase {
 		
 		OverrideRepository ox = new OverrideRepository();
 		ox.addSchemaSelection(new SchemaSelection(null, null, "DUMMY.*"));
-		RevengStrategy strategy = ox.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy strategy = ox.getReverseEngineeringStrategy(new DefaultStrategy());
 		Metadata md = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(strategy, null)
 				.createMetadata();
@@ -275,7 +275,7 @@ public class TestCase {
 		OverrideRepository or = new OverrideRepository();
 		
 		or.addResource(OVERRIDETEST_REVENG_XML);
-		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		
 		Assert.assertEquals("org.werd.Q", repository.tableToClassName(TableIdentifier.create("q","Werd", "Q") ) );
 		Assert.assertEquals("Notknown", repository.tableToClassName(TableIdentifier.create(null,null, "notknown") ) );
@@ -449,7 +449,7 @@ public class TestCase {
 	@Test
 	public void testTableToClass() {
 		
-		RevengStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultStrategy());
 		
 		TableIdentifier tableIdentifier = TableIdentifier.create(null, null, "TblTest");
 		Assert.assertEquals("org.test.Test", res.tableToClassName(tableIdentifier));		
@@ -470,7 +470,7 @@ public class TestCase {
 	@Test
 	public void testMetaAttributes() {
 		
-		RevengStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = new OverrideRepository().addResource(OVERRIDETEST_REVENG_XML).getReverseEngineeringStrategy(new DefaultStrategy());
 		
 		TableIdentifier tableIdentifier = TableIdentifier.create(null, null, "TblTest");
 		Map<String,MetaAttribute> attributes = res.tableToMetaAttributes(tableIdentifier);

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -21,9 +21,9 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Set;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -43,7 +43,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-        AbstractRevengStrategy c = new DefaultRevengStrategy();
+        AbstractRevengStrategy c = new DefaultStrategy();
         c.setSettings(new RevengSettings(c).setDefaultPackageName(PACKAGE_NAME));
         metadata = MetadataDescriptorFactory
         		.createReverseEngineeringDescriptor(c, null)

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
@@ -12,8 +12,8 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -68,7 +68,7 @@ public class TestCase {
 	public void testSetAndManyToOne() {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();			
@@ -100,7 +100,7 @@ public class TestCase {
 	public void testOneToOne() throws MalformedURLException, ClassNotFoundException {
 		OverrideRepository or = new OverrideRepository();
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();
@@ -125,7 +125,7 @@ public class TestCase {
 		try {
 			OverrideRepository or = new OverrideRepository();
 			or.addResource(BAD_FOREIGNKEY_XML);
-			RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+			RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultStrategy());
 			MetadataDescriptorFactory
 					.createReverseEngineeringDescriptor(repository, null)
 					.createMetadata();
@@ -152,7 +152,7 @@ public class TestCase {
 	public void testManyToOneAttributeOverrides() {
 		OverrideRepository or = new OverrideRepository();	
 		or.addResource(FOREIGN_KEY_TEST_XML);
-		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy repository = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(repository, null)
 				.createMetadata();

--- a/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
+++ b/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
@@ -14,9 +14,9 @@ import org.hibernate.tool.api.export.ExporterFactory;
 import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -40,7 +40,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		outputDir = temporaryFolder.getRoot();
-        AbstractRevengStrategy c = new DefaultRevengStrategy();
+        AbstractRevengStrategy c = new DefaultStrategy();
         c.setSettings(new RevengSettings(c).setDetectManyToMany(true)); 
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(c, null);

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -25,12 +25,12 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.dialect.MetaDataDialect;
 import org.hibernate.tool.api.dialect.MetaDataDialectFactory;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -61,7 +61,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "cat.cat"));
-		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();
@@ -111,7 +111,7 @@ public class TestCase {
 				serviceRegistry.getService(JdbcServices.class).getDialect(), 
 				properties);
 		DatabaseReader reader = DatabaseReader.create( 
-				properties, new DefaultRevengStrategy(), 
+				properties, new DefaultStrategy(), 
 				realMetaData, serviceRegistry );
 		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -15,10 +15,10 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.Environment;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -51,7 +51,7 @@ public class TestCase {
 	public void testReadOnlySpecificSchema() {		
 		OverrideRepository or = new OverrideRepository();
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
-		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();
@@ -76,7 +76,7 @@ public class TestCase {
 		or.addSchemaSelection(new SchemaSelection(null, "OVRTEST"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "MASTER"));
 		or.addSchemaSelection(new SchemaSelection(null, null, "CHILD"));
-		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultRevengStrategy());
+		RevengStrategy res = or.getReverseEngineeringStrategy(new DefaultStrategy());
 		Metadata metadata = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();

--- a/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/jdbc2cfg/DefaultReverseEngineeringStrategy/TestCase.java
@@ -9,10 +9,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.mapping.Column;
-import org.hibernate.tool.api.reveng.DefaultRevengStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.TableIdentifier;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.junit.Assert;
 import org.junit.Test;
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class TestCase {
 	
-	RevengStrategy rns = new DefaultRevengStrategy();
+	RevengStrategy rns = new DefaultStrategy();
 	
 	@Test
 	public void testColumnKeepCase() {
@@ -97,7 +97,7 @@ public class TestCase {
 	@Test
     public void testCustomClassNameStrategyWithCollectionName() {
     	
-    	RevengStrategy custom = new DelegatingStrategy(new DefaultRevengStrategy()) {
+    	RevengStrategy custom = new DelegatingStrategy(new DefaultStrategy()) {
     		public String tableToClassName(TableIdentifier tableIdentifier) {
     			return super.tableToClassName( tableIdentifier ) + "Impl";
     		}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>