### PR TITLE
 HBX-1992: Reorganize the reverse engineering strategy hierarchy - Rename 'org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy' to 'org.hibernate.tool.internal.reveng.strategy.AbstractStrategy'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
@@ -26,9 +26,9 @@ import org.hibernate.tool.internal.util.NameConverter;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 import org.jboss.logging.Logger;
 
-public abstract class AbstractRevengStrategy implements RevengStrategy {
+public abstract class AbstractStrategy implements RevengStrategy {
 
-	static final private Logger log = Logger.getLogger(AbstractRevengStrategy.class);
+	static final private Logger log = Logger.getLogger(AbstractStrategy.class);
 	
 	private static Set<String> AUTO_OPTIMISTICLOCK_COLUMNS;
 
@@ -41,7 +41,7 @@ public abstract class AbstractRevengStrategy implements RevengStrategy {
 	}
 	
 		
-	public AbstractRevengStrategy() {
+	public AbstractStrategy() {
 		super();
 	}
 	

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/DefaultStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/DefaultStrategy.java
@@ -2,6 +2,6 @@ package org.hibernate.tool.internal.reveng.strategy;
 
 import org.hibernate.tool.api.reveng.RevengStrategy;
 
-public class DefaultStrategy extends AbstractRevengStrategy implements RevengStrategy {
+public class DefaultStrategy extends AbstractStrategy implements RevengStrategy {
 
 }

--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithCustomReverseNamingStrategy/Strategy.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithCustomReverseNamingStrategy/Strategy.java
@@ -1,9 +1,9 @@
 package org.hibernate.tool.ant.Cfg2HbmWithCustomReverseNamingStrategy;
 
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 
-public class Strategy extends AbstractRevengStrategy {
+public class Strategy extends AbstractStrategy {
 
 	public String tableToClassName(TableIdentifier tableIdentifier) {		
 		return "foo.Bar";		

--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithPackageNameAndReverseNamingStrategy/Strategy.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithPackageNameAndReverseNamingStrategy/Strategy.java
@@ -1,9 +1,9 @@
 package org.hibernate.tool.ant.Cfg2HbmWithPackageNameAndReverseNamingStrategy;
 
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 
-public class Strategy extends AbstractRevengStrategy {
+public class Strategy extends AbstractStrategy {
 
 	public String tableToClassName(TableIdentifier tableIdentifier) {		
 		return "Bar";		

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -27,7 +27,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.export.doc.DocExporter;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
@@ -54,7 +54,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		outputDir = temporaryFolder.getRoot();
-		AbstractRevengStrategy configurableNamingStrategy = new DefaultStrategy();
+		AbstractStrategy configurableNamingStrategy = new DefaultStrategy();
 		configurableNamingStrategy.setSettings(new RevengSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(configurableNamingStrategy, null);

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
@@ -16,7 +16,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JavaUtil;
@@ -88,7 +88,7 @@ public class TestCase {
 	}
 	
 	private MetadataDescriptor createMetadataDescriptor() {
-		AbstractRevengStrategy configurableNamingStrategy = new DefaultStrategy();
+		AbstractStrategy configurableNamingStrategy = new DefaultStrategy();
 		configurableNamingStrategy.setSettings(new RevengSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		OverrideRepository overrideRepository = new OverrideRepository();
 		InputStream inputStream = new ByteArrayInputStream(REVENG_XML.getBytes());

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -15,7 +15,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -47,7 +47,7 @@ public class TestCase {
 	@Test
 	public void testNoManyToManyBiDirectional() {
         
-        AbstractRevengStrategy c = new DefaultStrategy();
+        AbstractStrategy c = new DefaultStrategy();
         c.setSettings(new RevengSettings(c).setDetectManyToMany(false)); 
         Metadata metadata =  MetadataDescriptorFactory
         		.createReverseEngineeringDescriptor(c, null)

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -22,7 +22,7 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Set;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.RevengSettings;
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -43,7 +43,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-        AbstractRevengStrategy c = new DefaultStrategy();
+        AbstractStrategy c = new DefaultStrategy();
         c.setSettings(new RevengSettings(c).setDefaultPackageName(PACKAGE_NAME));
         metadata = MetadataDescriptorFactory
         		.createReverseEngineeringDescriptor(c, null)

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/TernarySchema/TestCase.java
@@ -19,7 +19,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.SchemaSelection;
 import org.hibernate.tool.internal.export.common.DefaultValueVisitor;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -44,7 +44,7 @@ public class TestCase {
 	@Before
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		AbstractRevengStrategy c = new AbstractRevengStrategy() {
+		AbstractStrategy c = new AbstractStrategy() {
 			public List<SchemaSelection> getSchemaSelections() {
 				List<SchemaSelection> selections = new ArrayList<SchemaSelection>();
 				selections.add(new SchemaSelection(null, "HTT"));

--- a/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
+++ b/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
@@ -15,7 +15,7 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.RevengSettings;
-import org.hibernate.tool.internal.reveng.strategy.AbstractRevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
@@ -40,7 +40,7 @@ public class TestCase {
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		outputDir = temporaryFolder.getRoot();
-        AbstractRevengStrategy c = new DefaultStrategy();
+        AbstractStrategy c = new DefaultStrategy();
         c.setSettings(new RevengSettings(c).setDetectManyToMany(true)); 
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(c, null);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>