### PR TITLE
HBX-1996: Move class 'org.hibernate.tool.api.export.ExporterUtil' from 'hibernate-orm' into 'org.hibernate.tool.ant.util.ExceptionUtil' in 'hibernate-ant'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/HibernateToolTask.java
@@ -17,7 +17,7 @@ import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.Environment;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.PropertySet;
-import org.hibernate.tool.api.export.ExporterUtil;
+import org.hibernate.tool.ant.util.ExceptionUtil;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.util.StringUtil;
 
@@ -202,7 +202,7 @@ public class HibernateToolTask extends Task {
 			log(ex, Project.MSG_ERR);
 		}
 
-		String newbieMessage = ExporterUtil.getProblemSolutionOrCause(re);
+		String newbieMessage = ExceptionUtil.getProblemSolutionOrCause(re);
 		if(newbieMessage!=null) {
 			log(newbieMessage);
 		} 		

--- a/ant/src/main/java/org/hibernate/tool/ant/util/ExceptionUtil.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/util/ExceptionUtil.java
@@ -1,9 +1,9 @@
-package org.hibernate.tool.api.export;
+package org.hibernate.tool.ant.util;
 
 import org.hibernate.boot.MappingNotFoundException;
 import org.hibernate.boot.jaxb.Origin;
 
-public class ExporterUtil {
+public class ExceptionUtil {
 
 	public static String getProblemSolutionOrCause(Throwable re) {
 		if(re==null) return null;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>