### PR TITLE
HBX-1998: Rename class 'org.hibernate.tool.internal.reveng.PrimaryKeyInfo' to 'org.hibernate.tool.internal.reveng.binder.PrimaryKeyInfo'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
@@ -23,7 +23,6 @@ import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.TableIdentifier;
 import org.hibernate.tool.internal.reveng.DefaultAssociationInfo;
-import org.hibernate.tool.internal.reveng.PrimaryKeyInfo;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.binder.ForeignKeyUtils.ForeignKeyForColumns;
 import org.hibernate.tool.internal.reveng.util.RevengUtils;

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyInfo.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyInfo.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.internal.reveng;
+package org.hibernate.tool.internal.reveng.binder;
 
 import java.util.Properties;
 

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
@@ -19,7 +19,6 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.TableIdentifier;
-import org.hibernate.tool.internal.reveng.PrimaryKeyInfo;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.util.RevengUtils;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>