### PR TITLE
HBX-2012: Update eclipse-jdt-core dependency to version 3.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.20.0</version>
+            <version>3.21.0</version>
             <scope>compile</scope>
         </dependency>
  		<dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>