### PR TITLE
Fix for BVAL-748: Output for template generation set to UTF-8

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateProducer.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateProducer.java
@@ -1,10 +1,6 @@
 package org.hibernate.tool.internal.export.common;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.StringWriter;
+import java.io.*;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -32,19 +28,31 @@ public class TemplateProducer {
 			log.warn("Generated output is empty. Skipped creation for file " + destination);
 			return;
 		}
-		FileWriter fileWriter = null;
+		FileOutputStream destinationStream = null;
+		OutputStreamWriter fileWriter = null;
 		try {
 			
 			th.ensureExistence( destination );    
 	     
 			ac.addFile(destination, fileType);
 			log.debug("Writing " + identifier + " to " + destination.getAbsolutePath() );
-			fileWriter = new FileWriter(destination);
+			destinationStream = new FileOutputStream(destination);
+			// Output encoding set to UTF-8, in order to support international character sets. 
+			fileWriter = new OutputStreamWriter(destinationStream, "UTF-8");;
             fileWriter.write(tempResult);			
 		} 
 		catch (Exception e) {
 		    throw new RuntimeException("Error while writing result to file", e);	
 		} finally {
+			if(destinationStream != null){
+				try {
+					destinationStream.flush();
+					destinationStream.close();
+				}
+				catch (IOException e) {
+					log.warn("Exception while flushing/closing " + destinationStream,e);
+				}
+			}
 			if(fileWriter!=null) {
 				try {
 					fileWriter.flush();


### PR DESCRIPTION
Fix for issue BVAL-748. 
Followed instructions given at the forum (see https://discourse.hibernate.org/t/hbm2java-uses-default-plattform-encoding-for-source-generation/3649). 