### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.Basic.TestCase.testScalePrecisionLength()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Basic/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Basic/TestCase.java
@@ -66,8 +66,6 @@ public class TestCase {
 		Assert.assertSame(basicColumn, column);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testScalePrecisionLength() {
 		Table table = HibernateUtil.getTable(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>