### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.BasicMultiSchema.TestCase.testBasic()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/BasicMultiSchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/BasicMultiSchema/TestCase.java
@@ -41,8 +41,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testBasic() throws SQLException {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>