### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.BasicMultiSchema.TestCase.testScalePrecisionLength()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/BasicMultiSchema/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/BasicMultiSchema/TestCase.java
@@ -62,11 +62,6 @@ public class TestCase {
 		Assert.assertEquals( 
 				JdbcUtil.toIdentifier(this, "A"), 
 				JdbcUtil.toIdentifier(this, basicColumn.getName() ));
-		
-		// TODO: we cannot call getSqlType(dialect,cfg) without a
-		// MappingassertEquals("INTEGER", basicColumn.getSqlType() ); // at
-		// least on hsqldb
-		// assertEquals(22, basicColumn.getLength() ); // at least on oracle
 
 		PrimaryKey key = table.getPrimaryKey();
 		Assert.assertNotNull( "There should be a primary key!", key );
@@ -79,8 +74,6 @@ public class TestCase {
 
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testScalePrecisionLength() {
 		Table table = HibernateUtil.getTable(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>