### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.CompositeId.TestCase.testKeyProperty()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -136,8 +136,6 @@ public class TestCase {
          Assert.assertFalse(extraId.getValue() instanceof ManyToOne);
      }
      
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
     public void testKeyProperty() {
         PersistentClass product = metadataDescriptor.createMetadata().getEntityBinding( 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>