### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.CompositeId.TestCase.testGeneration()' to HBX-2042

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -165,7 +165,7 @@ public class TestCase {
         Assert.assertFalse(extraId.getValue() instanceof ManyToOne);
     }
      
-	// TODO HBX-2035: Investigate and reenable
+	// TODO HBX-2042: Reenable when implemented in ORM 6.0
 	@Ignore
     @Test
     public void testGeneration() throws Exception {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>