### PR TITLE
 HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.ForeignKeys.TestCase.testMultiRefs()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
@@ -49,8 +49,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);;
 	}	
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testMultiRefs() {		
 		Table table = HibernateUtil.getTable(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>