### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.ForeignKeys.TestCase.testExport()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
@@ -103,8 +103,6 @@ public class TestCase {
 						new Column(JdbcUtil.toIdentifier(this, "MASTERREF"))));		
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testExport() {
 		SchemaExport schemaExport = new SchemaExport();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>