### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.Identity.TestCase.testIdentity()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
@@ -23,7 +23,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -14,7 +14,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -38,8 +37,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testIdentity() throws SQLException {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>