### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.KeyPropertyCompositeId.TestCase.testMultiColumnForeignKeys()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -66,8 +66,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);;
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testMultiColumnForeignKeys() {
 		Metadata metadata = metadataDescriptor.createMetadata();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>