### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.KeyPropertyCompositeId.TestCase.testPossibleKeyManyToOne()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -97,8 +97,6 @@ public class TestCase {
 		Assert.assertEquals(((Column) (columnIterator.next())).getName(), "ORDER_NUMBER");
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testPossibleKeyManyToOne() {
 		PersistentClass product = metadataDescriptor.createMetadata().getEntityBinding(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>