### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix 'org.hibernate.tool.jdbc2cfg.KeyPropertyCompositeId.TestCase.testKeyProperty()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -123,8 +123,6 @@ public class TestCase {
 		Assert.assertFalse(extraId.getValue() instanceof ManyToOne);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testKeyProperty() {
 		PersistentClass product = metadataDescriptor.createMetadata().getEntityBinding(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>