### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.ManyToMany.TestCase.testAutoCreation()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -78,8 +78,6 @@ public class TestCase {
 		Assert.assertEquals("id", worksOn.getIdentifierProperty().getName());		
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testAutoCreation() {
 		Metadata metadata = MetadataDescriptorFactory


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>