### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.OneToOne.TestCase.testAddressWithForeignKeyGeneration()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
@@ -92,8 +92,6 @@ public class TestCase {
 		Assert.assertEquals("addressId", addressPerson.getIdentifierProperty().getName());			
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testAddressWithForeignKeyGeneration() {
 		PersistentClass address = metadata.getEntityBinding("AddressPerson");	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>