### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.OneToOne.TestCase.testOneToOneMultiColumnBiDirectional()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
@@ -98,8 +98,6 @@ public class TestCase {
 		Assert.assertEquals("foreign", ((SimpleValue)address.getIdentifier()).getIdentifierGeneratorStrategy());
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testOneToOneMultiColumnBiDirectional() {
 		PersistentClass person = metadata.getEntityBinding("MultiPerson");	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>