### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.OneToOne.TestCase.testBuildMappings()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
@@ -124,8 +124,6 @@ public class TestCase {
 		Assert.assertTrue(oto.isConstrained());
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testBuildMappings() {	
 		Assert.assertNotNull(metadata);		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>