### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.OneToOne.TestCase.testGenerateMappingAndReadable()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OneToOne/TestCase.java
@@ -129,8 +129,6 @@ public class TestCase {
 		Assert.assertNotNull(metadata);		
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testGenerateMappingAndReadable() throws MalformedURLException {
 		File outputDir = temporaryFolder.getRoot();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>