### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.PersistentClasses.TestCase.testCreatePersistentClasses()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -56,8 +56,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testCreatePersistentClasses() {
 		PersistentClass classMapping = metadata.getEntityBinding(PACKAGE_NAME + ".Orders");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>