### PR TITLE
 HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.PersistentClasses.TestCase.testCreateManyToOne()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -64,8 +64,6 @@ public class TestCase {
 		Assert.assertNotNull(identifier);		
 	}
 		
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testCreateManyToOne() {
 		PersistentClass classMapping = metadata.getEntityBinding(PACKAGE_NAME + ".Item");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>