### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.RevEngForeignKey.TestCase.testManyToOneAttributeDefaults()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
@@ -136,8 +136,6 @@ public class TestCase {
 		}		
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testManyToOneAttributeDefaults() {	
 		Metadata metadata = MetadataDescriptorFactory


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>