### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.RevEngForeignKey.TestCase.testManyToOneAttributeOverrides()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
@@ -149,8 +149,6 @@ public class TestCase {
 		Assert.assertEquals("SELECT", property.getValue().getFetchMode().toString());
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testManyToOneAttributeOverrides() {
 		OverrideRepository or = new OverrideRepository();	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>