### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.jdbc2cfg.Versioning.TestCase.testVersion()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
@@ -54,8 +54,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);;
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testVersion() {		
 		PersistentClass cl = metadata.getEntityBinding("WithVersion");		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>