### PR TITLE
 HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Replace deprecated OracleXXDialect and MySQL5Dialect in 'RevengDialectFactory' and 'MetaDataDialectFactoryTest'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/reveng/RevengDialectFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/RevengDialectFactory.java
@@ -6,7 +6,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.Oracle8iDialect;
+import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.tool.internal.reveng.dialect.H2MetaDataDialect;
@@ -52,7 +52,7 @@ public class RevengDialectFactory {
 	
 	public static RevengDialect fromDialect(Dialect dialect) {
 		if(dialect!=null) {  
-			if(dialect instanceof Oracle8iDialect) {
+			if(dialect instanceof OracleDialect) {
 				return new OracleMetaDataDialect();
 			} else if (dialect instanceof H2Dialect) {
 				return new H2MetaDataDialect();

--- a/test/nodb/src/test/java/org/hibernate/tool/cfg/MetaDataDialectFactoryTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/cfg/MetaDataDialectFactoryTest/TestCase.java
@@ -5,11 +5,8 @@ import java.util.Properties;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.MySQL5Dialect;
 import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.Oracle10gDialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.Oracle9iDialect;
+import org.hibernate.dialect.OracleDialect;
 import org.hibernate.tool.api.reveng.RevengDialectFactory;
 import org.hibernate.tool.internal.reveng.dialect.H2MetaDataDialect;
 import org.hibernate.tool.internal.reveng.dialect.HSQLMetaDataDialect;
@@ -17,7 +14,6 @@ import org.hibernate.tool.internal.reveng.dialect.JDBCMetaDataDialect;
 import org.hibernate.tool.internal.reveng.dialect.MySQLMetaDataDialect;
 import org.hibernate.tool.internal.reveng.dialect.OracleMetaDataDialect;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestCase {
@@ -40,12 +36,12 @@ public class TestCase {
 		assertSameClass(
 				OracleMetaDataDialect.class, 
 				RevengDialectFactory.createMetaDataDialect(
-						new Oracle9iDialect(), 
+						new OracleDialect(9), 
 						new Properties()));		
 		assertSameClass(
 				MySQLMetaDataDialect.class, 
 				RevengDialectFactory.createMetaDataDialect(
-						new MySQL5Dialect(), 
+						new MySQLDialect(500), 
 						new Properties()));
 		Properties p = new Properties();
 		p.setProperty(
@@ -54,7 +50,7 @@ public class TestCase {
 		assertSameClass(
 				"property should override specific dialect", 
 				H2MetaDataDialect.class, 
-				RevengDialectFactory.createMetaDataDialect(new MySQL5Dialect(), p));			
+				RevengDialectFactory.createMetaDataDialect(new MySQLDialect(500), p));			
 	}
 
 	@Test
@@ -62,7 +58,7 @@ public class TestCase {
 		Properties p = new Properties();
 		p.setProperty("hibernatetool.metadatadialect", "DoesNotExists");
 		try {
-			RevengDialectFactory.createMetaDataDialect(new MySQL5Dialect(), p);
+			RevengDialectFactory.createMetaDataDialect(new MySQLDialect(500), p);
 			Assert.fail();
 		} catch (RuntimeException jbe) {
 			// expected
@@ -71,8 +67,6 @@ public class TestCase {
 		}
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testFromDialect() {
 		assertSameClass(
@@ -81,13 +75,13 @@ public class TestCase {
 				RevengDialectFactory.fromDialect(new NoNameDialect()));	
 		assertSameClass(
 				OracleMetaDataDialect.class, 
-				RevengDialectFactory.fromDialect(new Oracle8iDialect()));
+				RevengDialectFactory.fromDialect(new OracleDialect(8)));
 		assertSameClass(
 				OracleMetaDataDialect.class, 
-				RevengDialectFactory.fromDialect(new Oracle9iDialect()));
+				RevengDialectFactory.fromDialect(new OracleDialect(9)));
 		assertSameClass(
 				OracleMetaDataDialect.class, 
-				RevengDialectFactory.fromDialect(new Oracle10gDialect()));
+				RevengDialectFactory.fromDialect(new OracleDialect(10)));
 		assertSameClass(
 				MySQLMetaDataDialect.class, 
 				RevengDialectFactory.fromDialect(new MySQLDialect()));
@@ -110,10 +104,7 @@ public class TestCase {
 				RevengDialectFactory.fromDialectName("mYorAcleDialect"));
 		assertSameClass(
 				OracleMetaDataDialect.class, 
-				RevengDialectFactory.fromDialectName(Oracle8iDialect.class.getName()));
-		assertSameClass(
-				OracleMetaDataDialect.class, 
-				RevengDialectFactory.fromDialectName(Oracle9iDialect.class.getName()));
+				RevengDialectFactory.fromDialectName(OracleDialect.class.getName()));
 		assertSameClass(
 				MySQLMetaDataDialect.class, 
 				RevengDialectFactory.fromDialectName(MySQLDialect.class.getName()));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>