### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Add 'org.hibernate.tool.hbm2x.query.QueryExporterTest.TestCase.testQueryExporter()' to HBX-2042

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
@@ -62,7 +62,7 @@ public class TestCase {
 		factory.close();		
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
+	// TODO HBX-2042: Reenable when implemented in ORM 6.0
 	@Ignore
 	@Test
 	public void testQueryExporter() throws Exception {		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>