### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase.testGenerateJava()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -66,8 +66,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testGenerateJava() throws SQLException, ClassNotFoundException {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.JAVA);		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>