### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase.testGenerateMappings()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -79,8 +79,6 @@ public class TestCase {
 		exporter.start();
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testGenerateMappings() {
 		Exporter exporter = new HbmExporter();	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>