### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase.testGenerateCfgXml()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -98,8 +98,6 @@ public class TestCase {
 		Assert.assertNotNull(metadata.getEntityBinding("org.reveng.Master") );
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testGenerateCfgXml() throws DocumentException {	
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.CFG);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>