### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase.testPackageNames()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -160,8 +160,6 @@ public class TestCase {
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "index.html"));
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testPackageNames() {
 		Iterator<PersistentClass> iter = metadataDescriptor


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>