### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.DefaultSchemaCatalog.TestCase.testOverlapping()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -66,8 +66,6 @@ public class TestCase {
 		Assert.assertEquals(TableIdentifier.create(null, "OVRTEST", "CATCHILD"), childid);	
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testOverlapping() {	
 		OverrideRepository or = new OverrideRepository();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>