### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.DefaultSchemaCatalog.TestCase.testUseDefault()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -88,8 +88,6 @@ public class TestCase {
 		Assert.assertEquals(4,tables.size());					
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testUseDefault() {
 		Properties properties = new Properties();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>