### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.DefaultDatabaseCollector.TestCase.testReadOnlySpecificSchema()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -23,8 +23,8 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tool.api.reveng.RevengDialectFactory;
 import org.hibernate.tool.api.reveng.RevengDialect;
+import org.hibernate.tool.api.reveng.RevengDialectFactory;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.api.reveng.RevengStrategy.SchemaSelection;
 import org.hibernate.tool.api.reveng.TableIdentifier;
@@ -36,7 +36,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -55,8 +54,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultSchemaCatalog/TestCase.java
@@ -24,7 +24,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>