### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.JDBCMetaDataConfiguration.TestCase.testReadFromJDBC()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/cfg/JDBCMetaDataConfiguration/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/cfg/JDBCMetaDataConfiguration/TestCase.java
@@ -26,8 +26,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testReadFromJDBC() throws Exception {
 		Metadata metadata = MetadataDescriptorFactory


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>