### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.JDBCMetaDataConfiguration.TestCase.testGetTable()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/cfg/JDBCMetaDataConfiguration/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/cfg/JDBCMetaDataConfiguration/TestCase.java
@@ -7,7 +7,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -37,8 +36,6 @@ public class TestCase {
 		Assert.assertNotNull("WithVersion", metadata.getEntityBinding("WithVersion"));
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testGetTable() throws Exception {
 		Assert.assertNotNull(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>