### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.ant.Cfg2HbmWithPackageNameAndReverseNamingStrategy.TestCase.testCfg2HbmWithPackageNameAndReverseNamingStrategy()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithPackageNameAndReverseNamingStrategy/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithPackageNameAndReverseNamingStrategy/TestCase.java
@@ -8,7 +8,6 @@ import org.hibernate.tools.test.util.ResourceUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -35,8 +34,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testCfg2HbmWithPackageNameAndReverseNamingStrategy() {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>