### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.ant.Cfg2HbmNoError.TestCase.testCfg2HbmNoError()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmNoError/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmNoError/TestCase.java
@@ -9,7 +9,6 @@ import org.hibernate.tools.test.util.ResourceUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -36,8 +35,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testCfg2HbmNoError() {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>