### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.ant.AntHibernateTool.TestCase.testHbm2DDLUpdateExecution()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/AntHibernateTool/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/AntHibernateTool/TestCase.java
@@ -85,8 +85,6 @@ public class TestCase {
 
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testHbm2DDLUpdateExecution() {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>