### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbx1093.TestCase.testGenerateJava()'

### DIFF
--- a/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
+++ b/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
@@ -21,7 +21,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -52,8 +51,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testGenerateJava() throws IOException {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.JAVA);	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>