### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix and reenable 'org.hibernate.tool.hbm2x.HibernateMappingExporterTest.TestCase.testStart()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
@@ -10,7 +10,6 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -20,7 +19,7 @@ public class TestCase {
 	private static final String FOO_HBM_XML = 
 			"<hibernate-mapping>              "+
 			"	<class name='Foo' table='FOO'>"+
-			"		<id type='String'>        "+
+			"		<id type='string'>        "+
 			"			<column name='BAR'/>  "+
 			"		</id>                     "+
 			"	</class>                      "+
@@ -29,8 +28,6 @@ public class TestCase {
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testStart() throws Exception {
 		File resources = new File(temporaryFolder.getRoot(), "resources");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>