### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix andreenable 'org.hibernate.tool.hbm2x.Hbm2HibernateDAOTest.TestCase.testNoVelocityLeftOvers()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2HibernateDAOTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2HibernateDAOTest/TestCase.java
@@ -103,8 +103,6 @@ public class TestCase {
 				"comparator/NoopComparator.class") );
 	}
     
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testNoVelocityLeftOvers() {
 		Assert.assertNull(FileUtil.findFirstString(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>