### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.Hbm2DaoTest.TestCase.testFileExistence()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
@@ -60,8 +60,6 @@ public class TestCase {
 		javaExporter.start();
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testFileExistence() {
 		JUnitUtil.assertIsNonEmptyFile(new File(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>