### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.Hbm2DaoTest.TestCase.testNamedQueries()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
@@ -101,8 +101,6 @@ public class TestCase {
         						"org/hibernate/tool/hbm2x/AuthorHome.java")));
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testNamedQueries() {		
 		Assert.assertTrue(FileUtil


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>