### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.Hbm2DaoTest.TestCase.testNoVelocityLeftOvers()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2DaoTest/TestCase.java
@@ -83,8 +83,6 @@ public class TestCase {
 		Assert.assertTrue(new File(compiled, "comparator/NoopComparator.class").exists());
 	}
     
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testNoVelocityLeftOvers() {	
 		Assert.assertNull(FileUtil


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>