### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.jdbc2cfg.OverrideBinder.TestCase.testReadTypeMappings()' - Comment out offending piece of XML and track with HBX-2052

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -66,8 +66,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testReadTypeMappings() {
 		OverrideRepository or = new OverrideRepository();

--- a/test/common/src/main/resources/org/hibernate/tool/jdbc2cfg/OverrideBinder/overridetest.reveng.xml
+++ b/test/common/src/main/resources/org/hibernate/tool/jdbc2cfg/OverrideBinder/overridetest.reveng.xml
@@ -4,8 +4,9 @@
 <hibernate-reverse-engineering>
 
 	<type-mapping>
-		<sql-type jdbc-type="VARCHAR" length='20'
-			hibernate-type="SomeUserType" />
+<!--  TODO: HBX-2052: investigate the use of hibernate-type=SomeUserType -->
+<!-- 		<sql-type jdbc-type="VARCHAR" length='20'
+			hibernate-type="SomeUserType" /> -->
 		<sql-type jdbc-type="VARCHAR" length='1'>
 			<hibernate-type name="yes_no"/>
 		</sql-type>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>