### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.jdbc2cfg.OverrideBinder.TestCase.testIdGenerator()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -205,8 +205,6 @@ public class TestCase {
 		//TODO: test sequence of meta
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testIdGenerator() {
 		OverrideRepository or = new OverrideRepository();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>