### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.jdbc2cfg.OverrideBinder.TestCase.testRevEngExclude()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -286,8 +286,6 @@ public class TestCase {
 		
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testRevEngExclude() {
 		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>