### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.jdbc2cfg.OverrideBinder.TestCase.testColumnExclude()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -376,8 +376,6 @@ public class TestCase {
 		Assert.assertTrue(tf.exclude(TableIdentifier.create(null, null, "heremaxsub") ).booleanValue() );
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testColumnExclude() {
 		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>