### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.jdbc2cfg.OverrideBinder.TestCase.testSimpleUserDefinedForeignKeys()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -396,8 +396,6 @@ public class TestCase {
 		
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testSimpleUserDefinedForeignKeys() {
 		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>