### PR TITLE
HBX-2035:  Investigate en reenable failing tests for 6.0.0.x - Track problem in 'org.hibernate.tool.jdbc2cfg.OverrideBinder.TestCase.testTypes()' in HBX-2052

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/OverrideBinder/TestCase.java
@@ -433,7 +433,7 @@ public class TestCase {
 			
 	}
 		
-	// TODO HBX-2035: Investigate and reenable
+	// TODO: HBX-2052: investigate the use of hibernate-type=SomeUserType
 	@Ignore
 	@Test
 	public void testTypes() {		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>