### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.DocExporterTest.TestCase.testExporter()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
@@ -79,8 +79,6 @@ public class TestCase {
 		exporter.start();
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
     public void testExporter() {
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "index.html") );


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>