### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.DocExporterTest.TestCase.testCommentIncluded()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
@@ -100,8 +100,6 @@ public class TestCase {
 		checkHtml(outputDir);
 	}
     
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
     public void testCommentIncluded() {
     		// A unique customer comment!


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>