### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.DocExporterTest.TestCase.testGenericsRenderedCorrectly()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
@@ -108,8 +108,6 @@ public class TestCase {
 		Assert.assertNotNull(FileUtil.findFirstString("A unique customer comment!", tableFile));
     }
     
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
     @Test
     public void testGenericsRenderedCorrectly() {
     		// A unique customer comment!


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>