### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.DocExporterTest.TestCase.testInheritedProperties()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
@@ -121,8 +121,6 @@ public class TestCase {
 				FileUtil.findFirstString("List&lt;", tableFile));
     }
     
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
     @Test
 	public void testInheritedProperties() {
 		File entityFile = new File(outputDir, "entities/org/hibernate/tool/hbm2x/UUser.html");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>