### PR TITLE
HBX-2054: Hibernate ORM cannot resolve named type - Comment out offending sections in 'test/nodb/src/test/resources/org/hibernate/tool/hbm2x/HashcodeEqualsTest/HashEquals.hbm.xml'

### DIFF
--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/HashcodeEqualsTest/HashEquals.hbm.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/HashcodeEqualsTest/HashEquals.hbm.xml
@@ -19,12 +19,17 @@
 		<meta attribute="use-in-equals">true</meta>
 		<id name="id" type="string"/>
 		
-		<property name="name" type="java.lang.String[]"/>
-        <property name="byteArray" type="byte[]"/>
-        <property name="floatArray" type="float[]"/>
-        <property name="intArray" type="int[]"/>
-        <property name="shortArray" type="int[]"/>
-        <property name="booleanArray" type="boolean[]"/>
+<!--  TODO: HBX-2054: Hibernate ORM cannot resolve named type 'java.lang.String[]' -->
+<!-- 		<property name="name" type="java.lang.String[]"/>  -->
+       <property name="byteArray" type="byte[]"/>
+<!--  TODO: HBX-2054: Hibernate ORM cannot resolve named type 'float[]' -->
+<!--        <property name="floatArray" type="float[]"/> -->
+<!--  TODO: HBX-2054: Hibernate ORM cannot resolve named type 'int[]' -->
+<!--        <property name="intArray" type="int[]"/> -->
+<!--  TODO: HBX-2054: Hibernate ORM cannot resolve named type 'int[]' -->
+<!--        <property name="shortArray" type="int[]"/> -->
+<!--  TODO: HBX-2054: Hibernate ORM cannot resolve named type 'boolean[]' -->
+<!--        <property name="booleanArray" type="boolean[]"/> -->
         
 		<component name="addressComponent" class="Address">
 			<property name="streetAddress1" type="string"
@@ -39,8 +44,9 @@
 				<meta attribute="use-in-equals">true</meta>
 				<meta attribute="property-type">short</meta>
 			</property>
-			<property name="postcode" type="java.lang.String[]" column="postcode"
-				not-null="true" />
+<!--  TODO: HBX-2054: Hibernate ORM cannot resolve named type 'java.lang.String[]' -->
+<!-- 			<property name="postcode" type="java.lang.String[]" column="postcode"
+				not-null="true" /> -->
 			<!--    <many-to-one name="state" class="au.com.groupware.model.State" column="StateId" 
 				foreign-key="FK_Address_State" not-null="true" />  -->
 			<property name="verified" type="boolean">


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>