### PR TITLE
 HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.HashcodeEqualsTest.TestCase.testJDK5FailureExpectedOnJDK4()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
@@ -57,8 +57,6 @@ public class TestCase {
 		exporter.start();
 	}
 
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testJDK5FailureExpectedOnJDK4() {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.JAVA);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>