### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.HashcodeEqualsTest.TestCase.testCompilable()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HashcodeEqualsTest/TestCase.java
@@ -80,8 +80,6 @@ public class TestCase {
 		Assert.assertEquals(2, artifactCollector.getFileCount("java"));
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testCompilable() {
 		File compiled = new File(temporaryFolder.getRoot(), "compiled");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>