### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.OtherCfg2HbmTest.TestCase.testReadable()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
@@ -75,8 +75,6 @@ public class TestCase {
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "HelloUniverse.hbm.xml") );		
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
     public void testReadable() {
 		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>