### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Reenable 'org.hibernate.tool.hbm2x.OtherCfg2HbmTest.TestCase.testNoVelocityLeftOvers()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
@@ -92,8 +92,6 @@ public class TestCase {
         Assert.assertNotNull(metadata);      
     }
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testNoVelocityLeftOvers() {
 		Assert.assertEquals(null, FileUtil.findFirstString("$",new File(outputDir, "org/hibernate/tool/hbm2x/Customer.hbm.xml") ) );


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>