### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Fix test failure of 'org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase.testGenerateDoc()'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
@@ -112,6 +112,8 @@ public final class DocHelper {
 	 * The Dialect.
 	 */
 	private Dialect dialect;
+	
+	private Metadata metadata;
 
 	/**
 	 * Constructor.
@@ -127,6 +129,8 @@ public final class DocHelper {
 		if (metadata == null) {
 			throw new IllegalArgumentException("Hibernate Configuration cannot be null");
 		}
+		
+		this.metadata = metadata;
 
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(properties);
@@ -405,7 +409,7 @@ public final class DocHelper {
 	public String getSQLTypeName(Column column) {
 
 		try {
-			return column.getSqlType(dialect, null);
+			return column.getSqlType(dialect, metadata);
 		} catch (HibernateException ex) {
 
 			// TODO: Fix this when we find a way to get the type or

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -149,8 +149,6 @@ public class TestCase {
 		}		
 	}
 	
-	// TODO HBX-2035: Investigate and reenable
-	@Ignore
 	@Test
 	public void testGenerateDoc() {	
 		DocExporter exporter = new DocExporter();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>