### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Track failing setup of 'org.hibernate.tool.hbm2x.hbm2hbmxml.TypeParamsTest.Order.TestCase' in HBX-2062

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/TypeParamsTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/TypeParamsTest/TestCase.java
@@ -74,7 +74,7 @@ public class TestCase {
 		hbmexporter.start();
 	}
 
-	// TODO HBX-2035: Investigate and reenable
+	// TODO HBX-2062: Investigate and reenable
 	@Ignore
 	@Test
 	public void testAllFilesExistence() {
@@ -84,7 +84,7 @@ public class TestCase {
 						"org/hibernate/tool/hbm2x/hbm2hbmxml/TypeParamsTest/Order.hbm.xml"));
 	}
 
-	// TODO HBX-2035: Investigate and reenable
+	// TODO HBX-2062: Investigate and reenable
 	@Ignore
 	@Test
 	public void testReadable() {
@@ -100,7 +100,7 @@ public class TestCase {
         Assert.assertNotNull(metadataDescriptor.createMetadata());
     }
 
-	// TODO HBX-2035: Investigate and reenable
+	// TODO HBX-2062: Investigate and reenable
 	@Ignore
 	@Test
 	public void testTypeParamsElements() throws DocumentException {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>