### PR TITLE
HBX-2035: Investigate en reenable failing tests for 6.0.0.x - Track failing test 'org.hibernate.tool.ide.completion.HqlAnalyzer.TestCase.testShouldShowTables()' in HBX-2064

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/ide/completion/HqlAnalyzer/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/ide/completion/HqlAnalyzer/TestCase.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  */
 public class TestCase {
 	
-	// TODO HBX-2035: Investigate and reenable
+	// TODO HBX-2064: Investigate and reenable
 	@Ignore
     @Test
     public void testShouldShowTables() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>