### PR TITLE
HBX-2001: Add copyright and license header where appropriate - Handle package 'org.hibernate.tool.hbm2x.Hbm2JavaConstructorTest' in project 'test/nodb'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaConstructorTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2JavaConstructorTest/TestCase.java
@@ -1,7 +1,23 @@
 /*
- * Created on 2004-12-01
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2020 Red Hat, Inc.
  *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.hibernate.tool.hbm2x.Hbm2JavaConstructorTest;
 
 import java.io.File;

--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/Hbm2JavaConstructorTest/ConstructorUsage.java_
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/Hbm2JavaConstructorTest/ConstructorUsage.java_
@@ -1,3 +1,23 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2017-2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 public class ConstructorUsage {
 

--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/Hbm2JavaConstructorTest/Constructors.hbm.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/Hbm2JavaConstructorTest/Constructors.hbm.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0"?>
+<!--
+  ~ Hibernate Tools, Tooling for your Hibernate Projects
+  ~
+  ~ Copyright 2017-2020 Red Hat, Inc.
+  ~
+  ~ Licensed under the GNU Lesser General Public License (LGPL), 
+  ~ version 2.1 or later (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ You may read the licence in the 'lgpl.txt' file in the root folder of 
+  ~ project or obtain a copy at
+  ~
+  ~     http://www.gnu.org/licenses/lgpl-2.1.html
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <!DOCTYPE hibernate-mapping PUBLIC 
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>