### PR TITLE
Changing the string null check to improve the performance.

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
@@ -237,7 +237,7 @@ public final class DocHelper {
 		classes.add(pojoClazz);
 		String packageName = pojoClazz.getPackageName();
 
-		if ("".equals(packageName)) {
+		if ( packageName == null || packageName.isEmpty() ) {
 			packageName = DEFAULT_NO_PACKAGE;
 		}
 

--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/BasicPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/BasicPOJOClass.java
@@ -88,7 +88,7 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 	public String getQualifiedDeclarationName() {
 		String generatedName = qualifyInnerClass(getGeneratedClassName());
 		String qualifier = StringHelper.qualifier( getMappedClassName() );
-		if ( "".equals( qualifier ) ) {
+		if ( qualifier == null || qualifier.isEmpty() ) ) {
 			return qualifier + "." + generatedName;
 		}
 		else {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/ComponentPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/ComponentPOJOClass.java
@@ -28,7 +28,7 @@ public class ComponentPOJOClass extends BasicPOJOClass {
 
 		if ( isInterface() ) {
 			if ( clazz.getMetaAttribute( EXTENDS ) != null ) {
-				if ( !"".equals( extendz ) ) {
+				if ( extendz != null && !extendz.isEmpty() ) {
 					extendz += ",";
 				}
 				extendz += getMetaAsString( EXTENDS, "," );
@@ -38,7 +38,7 @@ public class ComponentPOJOClass extends BasicPOJOClass {
 			extendz = getMetaAsString( EXTENDS, "," );
 		}
 
-		return "".equals( extendz ) ? null : extendz;
+		return ( extendz == null || extendz.isEmpty() ) ? null : extendz;
 	}
 	    
 	public String getImplements() {

--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
@@ -63,7 +63,7 @@ public class EntityPOJOClass extends BasicPOJOClass {
 				extendz = clazz.getSuperclass().getClassName();
 			}
 			if ( clazz.getMetaAttribute( EXTENDS ) != null ) {
-				if ( !"".equals( extendz ) ) {
+				if ( extendz != null && !extendz.isEmpty() ) {
 					extendz += ",";
 				}
 				extendz += getMetaAsString( EXTENDS, "," );
@@ -81,7 +81,7 @@ public class EntityPOJOClass extends BasicPOJOClass {
 			extendz = getMetaAsString( EXTENDS, "," );
 		}
 
-		return "".equals( extendz ) ? null : extendz;
+		return ( extendz == null || extendz.isEmpty() ) ? null : extendz;
 	}
 
 

--- a/orm/src/main/java/org/hibernate/tool/internal/util/NameConverter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/util/NameConverter.java
@@ -75,7 +75,7 @@ final public class NameConverter {
 	 * @return The converted database name.
 	 */
 	public static String toUpperCamelCase(String s) {
-		if ( "".equals(s) ) {
+		if ( s == null || s.isEmpty() ) {
 			return s;
 		}
 		StringBuffer result = new StringBuffer();


### PR DESCRIPTION
isEmpty() gives 20-40% more performance than "".equals().

String equals source code,

```
public boolean equals(Object anObject) {
        if (this == anObject) {
            return true;
        }
        if (anObject instanceof String) {
            String aString = (String)anObject;
            if (coder() == aString.coder()) {
                return isLatin1() ? StringLatin1.equals(value, aString.value)
                                  : StringUTF16.equals(value, aString.value);
            }
        }
        return false;
    }
```

Operator instanceOf, class casting, 3 if statements, and all this is just to start the check if the string is actually empty.

Now compare it with `String.isEmpty()`:

```
public boolean isEmpty() {
    return value.length == 0;
}
```

If we increase the performance in the framework, automatically multiple projects get the benefit.

