### PR TITLE
HBX-2001: Add copyright and license header where appropriate - Handle package 'org.hibernate.tool.hbm2x.hbm2hbmxml.JoinTest' in project 'test/nodb'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Child.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Child.java
@@ -1,4 +1,23 @@
-//$Id$
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.hibernate.tool.hbm2x.hbm2hbmxml.JoinTest;
 
 /**

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Parent.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Parent.java
@@ -1,4 +1,23 @@
-//$Id$
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.hibernate.tool.hbm2x.hbm2hbmxml.JoinTest;
 
 import java.util.Collection;

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/TestCase.java
@@ -1,19 +1,23 @@
 /*
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2020 Red Hat, Inc.
  *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.hibernate.tool.hbm2x.hbm2hbmxml.JoinTest;
 
 import java.io.File;

--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Parent.hbm.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Parent.hbm.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0"?>
+<!--
+  ~ Hibernate Tools, Tooling for your Hibernate Projects
+  ~
+  ~ Copyright 2017-2020 Red Hat, Inc.
+  ~
+  ~ Licensed under the GNU Lesser General Public License (LGPL), 
+  ~ version 2.1 or later (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ You may read the licence in the 'lgpl.txt' file in the root folder of 
+  ~ project or obtain a copy at
+  ~
+  ~     http://www.gnu.org/licenses/lgpl-2.1.html
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <!DOCTYPE hibernate-mapping PUBLIC 
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 	"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>