### PR TITLE
HBX-2044: Update Hibernate ORM dependency to 5.5.0-SNAPSHOT - Fix test failure of HibernateUtilTest#testGetForeignKey()'

### DIFF
--- a/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
@@ -26,7 +26,7 @@ public class HibernateUtilTest {
 		Table table = new Table();
 		Assert.assertNull(HibernateUtil.getForeignKey(table, "foo"));
 		Assert.assertNull(HibernateUtil.getForeignKey(table, "bar"));
-		table.createForeignKey("foo", Collections.emptyList(), null, null);
+		table.createForeignKey("foo", Collections.emptyList(), "fooClass", null);
 		Assert.assertNotNull(HibernateUtil.getForeignKey(table, "foo"));
 		Assert.assertNull(HibernateUtil.getForeignKey(table, "bar"));
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>