### PR TITLE
HBX-2123: Use 'org.hibernate.dialect.SQLServerDialect' instead of deprecated 'org.hibernate.dialect.SQLServer2012Dialect' for the SQL Server test suite

### DIFF
--- a/test/mssql/src/test/resources/hibernate.properties
+++ b/test/mssql/src/test/resources/hibernate.properties
@@ -1,4 +1,4 @@
-hibernate.dialect org.hibernate.dialect.SQLServer2012Dialect
+hibernate.dialect org.hibernate.dialect.SQLServerDialect
 hibernate.connection.driver_class com.microsoft.sqlserver.jdbc.SQLServerDriver
 hibernate.connection.username sa
 hibernate.connection.password P@55w0rd


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>