### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tools.test.util.AntUtilTest'

### DIFF
--- a/test/utils/src/test/java/org/hibernate/tools/test/util/AntUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/AntUtilTest.java
@@ -19,16 +19,18 @@
  */
 package org.hibernate.tools.test.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.file.Files;
 
 import org.apache.tools.ant.Target;
 import org.apache.tools.ant.taskdefs.Echo;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class AntUtilTest {
 	
@@ -37,21 +39,21 @@ public class AntUtilTest {
 			"<!DOCTYPE project>                     \n" + 
 			"<project name='AntUtilTest'/>          \n";
 	
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
-	
+	@TempDir
+	public File outputFolder = new File("output");
+		
 	@Test
 	public void testCreateProject() throws Exception {
-		File buildFile = new File(temporaryFolder.getRoot(), "build.xml");
+		File buildFile = new File(outputFolder, "build.xml");
 		Files.copy(new ByteArrayInputStream(BUILD_XML.getBytes()), buildFile.toPath());
 		AntUtil.Project project = AntUtil.createProject(buildFile);
-		Assert.assertEquals("AntUtilTest", project.getName());
+		assertEquals("AntUtilTest", project.getName());
 	}
 	
 	@Test
 	public void testGetLog() {
 		AntUtil.Project project = new AntUtil.Project();
-		Assert.assertNull(project.logBuffer);
+		assertNull(project.logBuffer);
 		Target target = new Target();
 		target.setName("foobar");
 		Echo echo = new Echo();
@@ -60,7 +62,7 @@ public class AntUtilTest {
 		target.addTask(echo);
 		project.addTarget(target);
 		project.executeTarget("foobar");
-		Assert.assertTrue(AntUtil.getLog(project).contains("Executing foobar"));
+		assertTrue(AntUtil.getLog(project).contains("Executing foobar"));
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>