### PR TITLE
HBX-2124: Replace JUnit4 dependencies with JUnit Jupiter in 'org.hibernate.tools.test.util.JUnitUtil' and 'org.hibernate.tools.test.util.JUnitUtilTest'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,15 +212,8 @@
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
             </dependency>
          </dependencies>
     </dependencyManagement>

--- a/test/utils/src/main/java/org/hibernate/tools/test/util/JUnitUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/JUnitUtil.java
@@ -19,11 +19,12 @@
  */
 package org.hibernate.tools.test.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.util.Iterator;
 
-import org.junit.Assert;
-import org.junit.ComparisonFailure;
+import org.opentest4j.AssertionFailedError;
 
 public class JUnitUtil {
 	
@@ -38,7 +39,7 @@ public class JUnitUtil {
 			iterator.next();
 		}
 		if (actualAmountOfElements != expectedAmountOfElements) {
-			throw new ComparisonFailure(
+			throw new AssertionFailedError(
 					reason, 
 					Integer.toString(expectedAmountOfElements),
 					Integer.toString(actualAmountOfElements));
@@ -46,9 +47,9 @@ public class JUnitUtil {
 	}
 	
 	public static void assertIsNonEmptyFile(File file) {
-		Assert.assertTrue(file + " does not exist", file.exists() );
-		Assert.assertTrue(file + " not a file", file.isFile() );		
-		Assert.assertTrue(file + " does not have any contents", file.length()>0);
+		assertTrue(file.exists(), file + " does not exist");
+		assertTrue(file.isFile(), file + " not a file");		
+		assertTrue(file.length()>0, file + " does not have any contents");
 	}
 
 }

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/JUnitUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/JUnitUtilTest.java
@@ -19,12 +19,14 @@
  */
 package org.hibernate.tools.test.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.util.ArrayList;
 
-import org.junit.Assert;
-import org.junit.ComparisonFailure;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 public class JUnitUtilTest {
 	
@@ -35,21 +37,21 @@ public class JUnitUtilTest {
 		list.add("bar");
 		try {
 			JUnitUtil.assertIteratorContainsExactly("less", list.iterator(), 1);
-			Assert.fail();
-		} catch (ComparisonFailure e) {
-			Assert.assertTrue(e.getMessage().contains("less"));
+			fail();
+		} catch (AssertionFailedError e) {
+			assertTrue(e.getMessage().contains("less"));
 		}
 		try {
 			JUnitUtil.assertIteratorContainsExactly("more", list.iterator(), 3);
-			Assert.fail();		
-		} catch (ComparisonFailure e) {
-			Assert.assertTrue(e.getMessage().contains("more"));
+			fail();		
+		} catch (AssertionFailedError e) {
+			assertTrue(e.getMessage().contains("more"));
 		}
 		try {
 			JUnitUtil.assertIteratorContainsExactly("exact", list.iterator(), 2);
-			Assert.assertTrue(true);		
-		} catch (ComparisonFailure e) {
-			Assert.fail();
+			assertTrue(true);		
+		} catch (AssertionFailedError e) {
+			fail();
 		}
 	}
 	
@@ -60,14 +62,14 @@ public class JUnitUtilTest {
 		try {
 			JUnitUtil.assertIsNonEmptyFile(exists);
 		} catch (Exception e) {
-			Assert.fail();
+			fail();
 		}
 		File doesNotExist = new File(exists.getAbsolutePath() + '_');
 		try {
 			JUnitUtil.assertIsNonEmptyFile(doesNotExist);
-			Assert.fail();
+			fail();
 		} catch (AssertionError e) {
-			Assert.assertTrue(e.getMessage().contains("does not exist"));
+			assertTrue(e.getMessage().contains("does not exist"));
 		}		
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>