### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.hbm2x.HibernateMappingExporterTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
@@ -20,6 +20,9 @@
 
 package org.hibernate.tool.hbm2x.HibernateMappingExporterTest;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.util.Properties;
@@ -29,10 +32,8 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestCase {
 	
@@ -45,12 +46,12 @@ public class TestCase {
 			"	</class>                      "+
 			"</hibernate-mapping>             ";
 
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
+	@TempDir
+	public File outputFolder = new File("output");
+	
 	@Test
 	public void testStart() throws Exception {
-		File resources = new File(temporaryFolder.getRoot(), "resources");
+		File resources = new File(outputFolder, "resources");
 		resources.mkdir();
 		File fooHbmXmlOrigin = new File(resources, "origin.hbm.xml");
 		FileWriter writer = new FileWriter(fooHbmXmlOrigin);
@@ -60,16 +61,16 @@ public class TestCase {
 		properties.setProperty("hibernate.dialect", HibernateUtil.Dialect.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, new File[] { fooHbmXmlOrigin }, properties); 		
-		final File outputDir = new File(temporaryFolder.getRoot(), "output");
-		outputDir.mkdir();
+		final File srcDir = new File(outputFolder, "output");
+		srcDir.mkdir();
 		HbmExporter exporter = new HbmExporter();
 		exporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
-		final File fooHbmXml = new File(outputDir, "Foo.hbm.xml");
-		Assert.assertFalse(fooHbmXml.exists());
+		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, srcDir);
+		final File fooHbmXml = new File(srcDir, "Foo.hbm.xml");
+		assertFalse( fooHbmXml.exists());
 		exporter.start();
-		Assert.assertTrue(fooHbmXml.exists());
-		Assert.assertTrue(fooHbmXml.delete());
+		assertTrue(fooHbmXml.exists());
+		assertTrue(fooHbmXml.delete());
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>