### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.hbm2x.hbm2hbmxml.ListArrayTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/TestCase.java
@@ -20,6 +20,9 @@
 
 package org.hibernate.tool.hbm2x.hbm2hbmxml.ListArrayTest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,11 +42,9 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author Dmitry Geraskov
@@ -55,33 +56,33 @@ public class TestCase {
 			"Glarch.hbm.xml"
 	};
 	
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public File outputFolder = new File("output");
 	
-	private File outputDir = null;
+	private File srcDir = null;
 	private File resourcesDir = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		outputDir = new File(temporaryFolder.getRoot(), "output");
-		outputDir.mkdir();
-		resourcesDir = new File(temporaryFolder.getRoot(), "resources");
+		srcDir = new File(outputFolder, "src");
+		srcDir.mkdir();
+		resourcesDir = new File(outputFolder, "resources");
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		Exporter hbmexporter = new HbmExporter();
 		hbmexporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, metadataDescriptor);
-		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
+		hbmexporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, srcDir);
 		hbmexporter.start();
 	}
 
 	@Test
 	public void testAllFilesExistence() {
 		JUnitUtil.assertIsNonEmptyFile(new File(
-				outputDir,  
+				srcDir,  
 				"org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/Fee.hbm.xml") );
 		JUnitUtil.assertIsNonEmptyFile(new File(
-				outputDir,
+				srcDir,
 				"org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/Glarch.hbm.xml") );
 	}
 
@@ -89,22 +90,22 @@ public class TestCase {
 	public void testReadable() {
         ArrayList<File> files = new ArrayList<File>(4); 
         files.add(new File(
-        		outputDir, 
+        		srcDir, 
         		"org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/Fee.hbm.xml"));
         files.add(new File(
-        		outputDir, 
+        		srcDir, 
         		"org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/Glarch.hbm.xml"));
 		Properties properties = new Properties();
 		properties.setProperty(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, files.toArray(new File[2]), properties);
-        Assert.assertNotNull(metadataDescriptor.createMetadata());
+        assertNotNull(metadataDescriptor.createMetadata());
     }
 
 	@Test
 	public void testListNode() throws DocumentException {
 		File outputXml = new File(
-				outputDir,  
+				srcDir,  
 				"org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/Glarch.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
 		SAXReader xmlReader =  new SAXReader();
@@ -112,36 +113,36 @@ public class TestCase {
 		Document document = xmlReader.read(outputXml);
 		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/list");
 		List<?> list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get two list element", 2, list.size());
+		assertEquals(2, list.size(), "Expected to get two list element");
 		Element node = (Element) list.get(1); //second list
-		Assert.assertEquals("fooComponents", node.attribute( "name" ).getText());
-		Assert.assertEquals("true", node.attribute( "lazy" ).getText());
-		Assert.assertEquals("all", node.attribute( "cascade" ).getText());
+		assertEquals("fooComponents", node.attribute( "name" ).getText());
+		assertEquals("true", node.attribute( "lazy" ).getText());
+		assertEquals("all", node.attribute( "cascade" ).getText());
 		list = node.elements("list-index");
-		Assert.assertEquals("Expected to get one list-index element", 1, list.size());
+		assertEquals(1, list.size(), "Expected to get one list-index element");
 		list = ((Element) list.get(0)).elements("column");
-		Assert.assertEquals("Expected to get one column element", 1, list.size());
+		assertEquals(1, list.size(), "Expected to get one column element");
 		node = (Element) list.get(0);
-		Assert.assertEquals("tha_indecks", node.attribute( "name" ).getText());
+		assertEquals("tha_indecks", node.attribute( "name" ).getText());
 		node = node.getParent().getParent();//list
 		list = node.elements("composite-element");
-		Assert.assertEquals("Expected to get one composite-element element", 1, list.size());
+		assertEquals(1, list.size(), "Expected to get one composite-element element");
 		node = (Element) list.get(0);
-		Assert.assertEquals("Expected to get two property element", 2, node.elements("property").size());
+		assertEquals(2, node.elements("property").size(), "Expected to get two property element");
 		node = node.element("many-to-one");
-		Assert.assertEquals("fee", node.attribute( "name" ).getText());
-		Assert.assertEquals("all", node.attribute( "cascade" ).getText());
+		assertEquals("fee", node.attribute( "name" ).getText());
+		assertEquals("all", node.attribute( "cascade" ).getText());
 		//TODO :assertEquals(node.attribute( "outer-join" ).getText(),"true");
 		node = node.getParent();//composite-element
 		node = node.element("nested-composite-element");
-		Assert.assertEquals("subcomponent", node.attribute( "name" ).getText());
-		Assert.assertEquals("org.hibernate.tool.hbm2x.hbm2hbmxml.ListArrayTest.FooComponent", node.attribute( "class" ).getText());
+		assertEquals("subcomponent", node.attribute( "name" ).getText());
+		assertEquals("org.hibernate.tool.hbm2x.hbm2hbmxml.ListArrayTest.FooComponent", node.attribute( "class" ).getText());
 	}
 
 	@Test
 	public void testArrayNode() throws DocumentException {
 		File outputXml = new File(
-				outputDir,  
+				srcDir,  
 				"org/hibernate/tool/hbm2x/hbm2hbmxml/ListArrayTest/Glarch.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
 		SAXReader xmlReader =  new SAXReader();
@@ -149,19 +150,19 @@ public class TestCase {
 		Document document = xmlReader.read(outputXml);
 		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/array");
 		List<?> list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one array element", 1, list.size());
+		assertEquals(1, list.size(), "Expected to get one array element");
 		Element node = (Element) list.get(0);
-		Assert.assertEquals("proxyArray", node.attribute( "name" ).getText());
-		Assert.assertEquals("org.hibernate.tool.hbm2x.hbm2hbmxml.ListArrayTest.GlarchProxy", node.attribute( "element-class" ).getText());
+		assertEquals("proxyArray", node.attribute( "name" ).getText());
+		assertEquals("org.hibernate.tool.hbm2x.hbm2hbmxml.ListArrayTest.GlarchProxy", node.attribute( "element-class" ).getText());
 		list = node.elements("list-index");		
-		Assert.assertEquals("Expected to get one list-index element", 1, list.size());
+		assertEquals(1, list.size(), "Expected to get one list-index element");
 		list = ((Element) list.get(0)).elements("column");
-		Assert.assertEquals("Expected to get one column element", 1, list.size());
+		assertEquals(1, list.size(), "Expected to get one column element");
 		node = (Element) list.get(0);
-		Assert.assertEquals("array_indecks", node.attribute( "name" ).getText());
+		assertEquals("array_indecks", node.attribute( "name" ).getText());
 		node = node.getParent().getParent();//array
 		list = node.elements("one-to-many");
-		Assert.assertEquals("Expected to get one 'one-to-many' element", 1, list.size());
+		assertEquals(1, list.size(), "Expected to get one 'one-to-many' element");
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>