### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Remove JUnit dependency from 'hibernate-tools-tests-nodb'

### DIFF
--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -45,10 +45,6 @@
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
     	<dependency>
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-ant</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>