### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Remove junit-vintage-engine dependency from 'hibernate-tools-tests-nodb'

### DIFF
--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -65,10 +65,6 @@
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
-		<dependency>
-		    <groupId>org.junit.vintage</groupId>
-		    <artifactId>junit-vintage-engine</artifactId>
-		</dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>