### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Add junit-vintage-engine dependencies to DB specific modules so the test are run using JUnit 5

### DIFF
--- a/test/h2/pom.xml
+++ b/test/h2/pom.xml
@@ -32,6 +32,10 @@
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
     </dependencies>
     
 </project>

--- a/test/hsql/pom.xml
+++ b/test/hsql/pom.xml
@@ -29,6 +29,10 @@
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
     </dependencies>
     
 </project>

--- a/test/mssql/pom.xml
+++ b/test/mssql/pom.xml
@@ -32,6 +32,10 @@
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
     </dependencies>
     
 </project>

--- a/test/mysql/pom.xml
+++ b/test/mysql/pom.xml
@@ -28,6 +28,10 @@
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
     </dependencies>
     
 </project>

--- a/test/oracle/pom.xml
+++ b/test/oracle/pom.xml
@@ -48,6 +48,10 @@
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>