### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Create 'h2-jupiter' module to be able to run the Jupiter tests for H2

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
@@ -1,0 +1,10 @@
+package org.hibernate.tool.test.db;
+
+import org.junit.jupiter.api.Nested;
+
+public class JupiterCommonTestSuite {
+	
+	@Nested public class AntHibernateToolTests extends org.hibernate.tool.ant.AntHibernateTool.TestCase {}
+	@Nested public class Cfg2HbmNoError extends org.hibernate.tool.ant.Cfg2HbmNoError.TestCase {}
+
+}

--- a/test/h2-jupiter/pom.xml
+++ b/test/h2-jupiter/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hibernate.tool</groupId>
+        <artifactId>hibernate-tools-tests-parent</artifactId>
+        <version>6.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hibernate-tools-tests-h2-jupiter</artifactId>
+
+    <name>Hibernate Tools H2 Jupiter Tests Project</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+     	<dependency>
+    		<groupId>org.hibernate.tool</groupId>
+    		<artifactId>hibernate-tools-ant</artifactId>
+    	</dependency>
+    	<dependency>
+    		<groupId>org.hibernate.tool</groupId>
+    		<artifactId>hibernate-tools-tests-common</artifactId>
+    	</dependency>
+ 		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+ 		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
+    </dependencies>
+    
+</project>

--- a/test/h2-jupiter/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
+++ b/test/h2-jupiter/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
@@ -1,0 +1,11 @@
+package org.hibernate.tool.test.db.h2;
+
+import org.hibernate.tool.test.db.JupiterCommonTestSuite;
+import org.junit.jupiter.api.Nested;
+
+public class TestSuite {
+	
+	@Nested
+	public class H2TestSuite extends JupiterCommonTestSuite {}
+
+}

--- a/test/h2-jupiter/src/test/resources/hibernate.properties
+++ b/test/h2-jupiter/src/test/resources/hibernate.properties
@@ -1,0 +1,8 @@
+hibernate.dialect org.hibernate.dialect.H2Dialect
+hibernate.connection.driver_class org.h2.Driver
+hibernate.connection.username sa
+hibernate.connection.password  
+hibernate.connection.url jdbc:h2:mem:test
+
+hibernate.default_schema PUBLIC
+hibernate.default_catalog TEST

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -67,6 +67,7 @@
             	<module>nodb</module>
             	<module>common</module>
             	<module>h2</module>
+            	<module>h2-jupiter</module>
 				<module>maven</module>
           	</modules> 
        	</profile>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>