### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.ant.SchemaExportWarning'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/SchemaExportWarning/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/SchemaExportWarning/TestCase.java
@@ -1,4 +1,26 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.ant.SchemaExportWarning;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -6,31 +28,29 @@ import org.hibernate.tools.test.util.AntUtil;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestCase {
 	
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public File outputFolder = new File("output");
 	
 	private File destinationDir = null;
 	private File resourcesDir = null;
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
-		destinationDir = new File(temporaryFolder.getRoot(), "destination");
+		destinationDir = new File(outputFolder, "destination");
 		destinationDir.mkdir();
-		resourcesDir = new File(temporaryFolder.getRoot(), "resources");
+		resourcesDir = new File(outputFolder, "resources");
 		resourcesDir.mkdir();
 		JdbcUtil.createDatabase(this);
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
@@ -47,17 +67,17 @@ public class TestCase {
 		project.setProperty("resourcesDir", resourcesDir.getAbsolutePath());
 		
 		File schemaExport = new File(destinationDir, "schemaexport.sql");
-		Assert.assertFalse(schemaExport.exists());
+		assertFalse(schemaExport.exists());
 		
 		project.executeTarget("testSchemaExportWarning");
 		
-		Assert.assertTrue(schemaExport.exists());
-		Assert.assertTrue(FileUtil
+		assertTrue(schemaExport.exists());
+		assertTrue(FileUtil
 				.findFirstString("drop", schemaExport)
 				.contains("TopDown"));
 		
 		String log = AntUtil.getLog(project);
-		Assert.assertFalse(log.contains("Exception"));
+		assertFalse(log.contains("Exception"));
 
 	}	
 	

--- a/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
@@ -6,7 +6,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-	org.hibernate.tool.ant.SchemaExportWarning.TestCase.class,
 	org.hibernate.tool.cfg.DriverMetaData.TestCase.class,
 	org.hibernate.tool.cfg.JDBCMetaDataConfiguration.TestCase.class,
 	org.hibernate.tool.hbm2x.CachedMetaData.TestCase.class,

--- a/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
@@ -22,5 +22,6 @@ public class JupiterCommonTestSuite {
 	@Nested public class JPAPUnit extends org.hibernate.tool.ant.JPAPUnit.TestCase {}
 	@Nested public class Properties extends org.hibernate.tool.ant.Properties.TestCase {}
 	@Nested public class Query extends org.hibernate.tool.ant.Query.TestCase {}
+	@Nested public class SchemaExportWarning extends org.hibernate.tool.ant.SchemaExportWarning.TestCase {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>