### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.hbm2x.GenerateFromJDBC'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -1,8 +1,28 @@
 /*
- * Created on 07-Dec-2004
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
  *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.hibernate.tool.hbm2x.GenerateFromJDBC;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.sql.SQLException;
@@ -31,13 +51,10 @@ import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author max
@@ -45,23 +62,21 @@ import org.junit.rules.TemporaryFolder;
  */
 public class TestCase {
 	
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public File outputDir = new File("output");
 	
 	private MetadataDescriptor metadataDescriptor = null;
-	private File outputDir = null;
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		outputDir = temporaryFolder.getRoot();
 		AbstractStrategy configurableNamingStrategy = new DefaultStrategy();
 		configurableNamingStrategy.setSettings(new RevengSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		metadataDescriptor = MetadataDescriptorFactory
 				.createReverseEngineeringDescriptor(configurableNamingStrategy, null);
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
@@ -87,15 +102,15 @@ public class TestCase {
 		exporter.start();	
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "org/reveng/Child.hbm.xml"));
 		File file = new File(outputDir, "GeneralHbmSettings.hbm.xml");
-		Assert.assertTrue(file + " should not exist", !file.exists() );
+		assertTrue(!file.exists(), file + " should not exist" );
 		File[] files = new File[2];
 		files[0] = new File(outputDir, "org/reveng/Child.hbm.xml");
 		files[1] = new File(outputDir, "org/reveng/Master.hbm.xml");
 		Metadata metadata = MetadataDescriptorFactory
 				.createNativeDescriptor(null, files, null)
 				.createMetadata();
-		Assert.assertNotNull(metadata.getEntityBinding("org.reveng.Child") );
-		Assert.assertNotNull(metadata.getEntityBinding("org.reveng.Master") );
+		assertNotNull(metadata.getEntityBinding("org.reveng.Child") );
+		assertNotNull(metadata.getEntityBinding("org.reveng.Master") );
 	}
 	
 	@Test
@@ -115,11 +130,11 @@ public class TestCase {
 		for (int i = 0; i < list.size(); i++) {
 			elements[i] = (Element)list.get(i);
 		}
-		Assert.assertEquals(2,elements.length);	
+		assertEquals(2,elements.length);	
 		for (int i = 0; i < elements.length; i++) {
 			Element element = elements[i];
-			Assert.assertNotNull(element.attributeValue("resource"));
-			Assert.assertNull(element.attributeValue("class"));
+			assertNotNull(element.attributeValue("resource"));
+			assertNull(element.attributeValue("class"));
 		}		
 	}
 	
@@ -141,11 +156,11 @@ public class TestCase {
 		for (int i = 0; i < list.size(); i++) {
 			elements[i] = (Element)list.get(i);
 		}
-		Assert.assertEquals(2, elements.length);
+		assertEquals(2, elements.length);
 		for (int i = 0; i < elements.length; i++) {
 			Element element = elements[i];
-			Assert.assertNull(element.attributeValue("resource"));
-			Assert.assertNotNull(element.attributeValue("class"));
+			assertNull(element.attributeValue("resource"));
+			assertNotNull(element.attributeValue("class"));
 		}		
 	}
 	
@@ -166,7 +181,7 @@ public class TestCase {
 				.iterator();
 		while (iter.hasNext() ) {
 			PersistentClass element = iter.next();
-			Assert.assertEquals("org.reveng", StringHelper.qualifier(element.getClassName() ) );
+			assertEquals("org.reveng", StringHelper.qualifier(element.getClassName() ) );
 		}
 	}
 }

--- a/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
@@ -6,7 +6,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-	org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase.class,
 	org.hibernate.tool.hbm2x.GenerateFromJDBCWithJavaKeyword.TestCase.class,
 	org.hibernate.tool.hbm2x.JdbcHbm2JavaEjb3.TestCase.class,
 	org.hibernate.tool.hbm2x.IncrementalSchemaReading.TestCase.class,

--- a/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
@@ -29,5 +29,6 @@ public class JupiterCommonTestSuite {
 	@Nested public class CachedMetaData extends org.hibernate.tool.hbm2x.CachedMetaData.TestCase {}
 	@Nested public class DefaultDatabaseCollector extends org.hibernate.tool.hbm2x.DefaultDatabaseCollector.TestCase {}
 	@Nested public class DefaultSchemaCatalog extends org.hibernate.tool.hbm2x.DefaultSchemaCatalog.TestCase {}
+	@Nested public class GenerateFromJDBC extends org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>