### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.hbm2x.GenerateFromJDBCWithJavaKeyword'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBCWithJavaKeyword/TestCase.java
@@ -1,4 +1,26 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.hbm2x.GenerateFromJDBCWithJavaKeyword;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -21,13 +43,10 @@ import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author koen@hibernate.org
@@ -49,18 +68,15 @@ public class TestCase {
 	        "   </table>                                                                        \n"+
 			"</hibernate-reverse-engineering>                                                     ";
 
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public File outputDir = new File("output");
 	
-	private File outputDir = null;
-	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		outputDir = temporaryFolder.getRoot();
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
@@ -72,19 +88,19 @@ public class TestCase {
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
  		exporter.start();
 		File myReturn = new File(outputDir, "org/reveng/MyReturn.java");
-		Assert.assertTrue(myReturn.exists());
+		assertTrue(myReturn.exists());
 		File myReturnHistory = new File(outputDir, "org/reveng/MyReturnHistory.java");
-		Assert.assertTrue(myReturnHistory.exists());
+		assertTrue(myReturnHistory.exists());
 		JavaUtil.compile(outputDir);
 		URLClassLoader loader = new URLClassLoader(new URL[] { outputDir.toURI().toURL() } );
 		Class<?> returnClass = loader.loadClass("org.reveng.MyReturn");
-		Assert.assertNotNull(returnClass);
+		assertNotNull(returnClass);
 		Class<?> returnHistoryClass = loader.loadClass("org.reveng.MyReturnHistory");
-		Assert.assertNotNull(returnHistoryClass);
+		assertNotNull(returnHistoryClass);
 		Field returnField = returnHistoryClass.getDeclaredField("return_");
-		Assert.assertNotNull(returnField);
+		assertNotNull(returnField);
 		Method returnSetter = returnHistoryClass.getMethod("setReturn", new Class[] { returnClass });
-		Assert.assertNotNull(returnSetter);
+		assertNotNull(returnSetter);
 		loader.close();
 	}
 	

--- a/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
@@ -6,7 +6,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-	org.hibernate.tool.hbm2x.GenerateFromJDBCWithJavaKeyword.TestCase.class,
 	org.hibernate.tool.hbm2x.JdbcHbm2JavaEjb3.TestCase.class,
 	org.hibernate.tool.hbm2x.IncrementalSchemaReading.TestCase.class,
 	org.hibernate.tool.hbm2x.query.QueryExporterTest.TestCase.class,

--- a/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
@@ -30,5 +30,6 @@ public class JupiterCommonTestSuite {
 	@Nested public class DefaultDatabaseCollector extends org.hibernate.tool.hbm2x.DefaultDatabaseCollector.TestCase {}
 	@Nested public class DefaultSchemaCatalog extends org.hibernate.tool.hbm2x.DefaultSchemaCatalog.TestCase {}
 	@Nested public class GenerateFromJDBC extends org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase {}
+	@Nested public class GenerateFromJDBCWithJavaKeyword extends org.hibernate.tool.hbm2x.GenerateFromJDBCWithJavaKeyword.TestCase {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>