### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.hbm2x.query.QueryExporterTest'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/Group.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/Group.java
@@ -1,4 +1,22 @@
-//$Id: Group.java 7085 2005-06-08 17:59:47Z oneovthafew $
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.hbm2x.query.QueryExporterTest;
 
 import java.io.ObjectStreamClass;

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
@@ -1,4 +1,25 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.hbm2x.query.QueryExporterTest;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -22,29 +43,27 @@ import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestCase {
 
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
+	@TempDir
+	public File outputDir = new File("output");
+	
 	private File destinationDir = null;
 	private File resourcesDir = null;
 	private File userGroupHbmXmlFile = null;
 	
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		JdbcUtil.createDatabase(this);
-		destinationDir = new File(temporaryFolder.getRoot(), "destination");
+		destinationDir = new File(outputDir, "destination");
 		destinationDir.mkdir();
-		resourcesDir = new File(temporaryFolder.getRoot(), "resources");
+		resourcesDir = new File(outputDir, "resources");
 		resourcesDir.mkdir();
 		String[] resources = { "UserGroup.hbm.xml" };		
 		ResourceUtil.createResources(this, resources, resourcesDir);
@@ -63,7 +82,7 @@ public class TestCase {
 	}
 	
 	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Ignore
+	@Disabled
 	@Test
 	public void testQueryExporter() throws Exception {		
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.QUERY);
@@ -83,14 +102,14 @@ public class TestCase {
 		JUnitUtil.assertIsNonEmptyFile(new File(destinationDir, "queryresult.txt"));		
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		SchemaExport export = new SchemaExport();
 		final EnumSet<TargetType> targetTypes = EnumSet.noneOf( TargetType.class );
 		targetTypes.add( TargetType.DATABASE );
 		export.drop(targetTypes, createMetadata());		
 		if (export.getExceptions() != null && export.getExceptions().size() > 0){
-			Assert.fail("Schema export failed");
+			fail("Schema export failed");
 		}		
 		JdbcUtil.dropDatabase(this);
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/User.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/User.java
@@ -1,4 +1,22 @@
-//$Id: User.java 7085 2005-06-08 17:59:47Z oneovthafew $
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.hbm2x.query.QueryExporterTest;
 
 import java.io.ObjectStreamClass;

--- a/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
@@ -6,7 +6,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-	org.hibernate.tool.hbm2x.query.QueryExporterTest.TestCase.class,
 	org.hibernate.tool.hbmlint.HbmLintTest.TestCase.class,
 	org.hibernate.tool.hbmlint.SchemaAnalyzer.TestCase.class,
 	org.hibernate.tool.jdbc2cfg.AutoQuote.TestCase.class,

--- a/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
@@ -33,5 +33,6 @@ public class JupiterCommonTestSuite {
 	@Nested public class GenerateFromJDBCWithJavaKeyword extends org.hibernate.tool.hbm2x.GenerateFromJDBCWithJavaKeyword.TestCase {}
 	@Nested public class IncrementalSchemaReading extends org.hibernate.tool.hbm2x.IncrementalSchemaReading.TestCase {}
 	@Nested public class JdbcHbm2JavaEjb3 extends org.hibernate.tool.hbm2x.JdbcHbm2JavaEjb3.TestCase {}
+	@Nested public class QueryExporterTest extends org.hibernate.tool.hbm2x.query.QueryExporterTest.TestCase {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>