### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.jdbc2cfg.ForeignKeys'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ForeignKeys/TestCase.java
@@ -1,8 +1,29 @@
 /*
- * Created on 2004-11-24
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
  *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.hibernate.tool.jdbc2cfg.ForeignKeys;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.EnumSet;
 import java.util.Iterator;
@@ -20,10 +41,9 @@ import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author max
@@ -34,7 +54,7 @@ public class TestCase {
 	private Metadata metadata = null;
 	private RevengStrategy reverseEngineeringStrategy = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		reverseEngineeringStrategy = new DefaultStrategy();
@@ -43,7 +63,7 @@ public class TestCase {
 				.createMetadata();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);;
 	}	
@@ -56,28 +76,28 @@ public class TestCase {
 		ForeignKey foreignKey = HibernateUtil.getForeignKey(
 				table, 
 				JdbcUtil.toIdentifier(this, "CON2MASTER") );	
-		Assert.assertNotNull(foreignKey);			
-		Assert.assertEquals(
+		assertNotNull(foreignKey);			
+		assertEquals(
 				reverseEngineeringStrategy.tableToClassName(
 						TableIdentifier.create(null, null, "MASTER")),
 				foreignKey.getReferencedEntityName() );
-        Assert.assertEquals(
+        assertEquals(
         		JdbcUtil.toIdentifier(this, "CONNECTION"), 
         		foreignKey.getTable().getName() );	
-		Assert.assertEquals(
+		assertEquals(
 				HibernateUtil.getTable(
 						metadata, 
 						JdbcUtil.toIdentifier(this, "MASTER") ), 
 				foreignKey.getReferencedTable() );
-		Assert.assertNotNull(
+		assertNotNull(
 				HibernateUtil.getForeignKey(
 						table, 
 						JdbcUtil.toIdentifier(this, "CHILDREF1") ) );
-		Assert.assertNotNull(
+		assertNotNull(
 				HibernateUtil.getForeignKey(
 						table, 
 						JdbcUtil.toIdentifier(this, "CHILDREF2") ) );
-		Assert.assertNull(
+		assertNull(
 				HibernateUtil.getForeignKey(
 						table, 
 						JdbcUtil.toIdentifier(this, "DUMMY") ) );
@@ -86,7 +106,7 @@ public class TestCase {
 	
 	@Test
 	public void testMasterChild() {		
-		Assert.assertNotNull(HibernateUtil.getTable(
+		assertNotNull(HibernateUtil.getTable(
 				metadata, 
 				JdbcUtil.toIdentifier(this, "MASTER")));
 		Table child = HibernateUtil.getTable(
@@ -94,9 +114,9 @@ public class TestCase {
 				JdbcUtil.toIdentifier(this, "CHILD") );	
 		Iterator<?> iterator = child.getForeignKeyIterator();		
 		ForeignKey fk = (ForeignKey) iterator.next();		
-		Assert.assertFalse("should only be one fk", iterator.hasNext() );	
-		Assert.assertEquals(1, fk.getColumnSpan() );
-		Assert.assertSame(
+		assertFalse(iterator.hasNext(), "should only be one fk" );	
+		assertEquals(1, fk.getColumnSpan() );
+		assertSame(
 				fk.getColumn(0), 
 				child.getColumn(
 						new Column(JdbcUtil.toIdentifier(this, "MASTERREF"))));		

--- a/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
@@ -25,7 +25,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-	org.hibernate.tool.jdbc2cfg.ForeignKeys.TestCase.class,
 	org.hibernate.tool.jdbc2cfg.Identity.TestCase.class,
 	org.hibernate.tool.jdbc2cfg.Index.TestCase.class,
 	org.hibernate.tool.jdbc2cfg.KeyPropertyCompositeId.TestCase.class,

--- a/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
@@ -59,5 +59,6 @@ public class JupiterCommonTestSuite {
 	@Nested public class Basic extends org.hibernate.tool.jdbc2cfg.Basic.TestCase {}
 	@Nested public class BasicMultiSchema extends org.hibernate.tool.jdbc2cfg.BasicMultiSchema.TestCase {}
 	@Nested public class CompositeId extends org.hibernate.tool.jdbc2cfg.CompositeId.TestCase {}
+	@Nested public class ForeignKeys extends org.hibernate.tool.jdbc2cfg.ForeignKeys.TestCase {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>