### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.stat.Statistics'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/stat/Statistics/Group.java
+++ b/test/common/src/main/java/org/hibernate/tool/stat/Statistics/Group.java
@@ -1,4 +1,22 @@
-//$Id: Group.java 5686 2005-02-12 07:27:32Z steveebersole $
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.stat.Statistics;
 
 import java.util.HashSet;

--- a/test/common/src/main/java/org/hibernate/tool/stat/Statistics/SessionAttribute.java
+++ b/test/common/src/main/java/org/hibernate/tool/stat/Statistics/SessionAttribute.java
@@ -1,4 +1,22 @@
-//$Id: SessionAttribute.java 5686 2005-02-12 07:27:32Z steveebersole $
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.stat.Statistics;
 
 

--- a/test/common/src/main/java/org/hibernate/tool/stat/Statistics/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/stat/Statistics/TestCase.java
@@ -1,3 +1,22 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.stat.Statistics;
 
 import org.hibernate.Session;
@@ -7,26 +26,26 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.tool.api.stat.StatisticsBrowser;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestCase {
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
 
 	// HBX-1554: Ignore the test for now
 	// TODO: re-enable the test
-	@Ignore
+	@Disabled
 	@Test
 	public void testBrowser() throws Exception {
 		MetadataSources mds = new MetadataSources();

--- a/test/common/src/main/java/org/hibernate/tool/stat/Statistics/User.java
+++ b/test/common/src/main/java/org/hibernate/tool/stat/Statistics/User.java
@@ -1,4 +1,22 @@
-//$Id: User.java 5686 2005-02-12 07:27:32Z steveebersole $
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.stat.Statistics;
 
 import java.util.HashSet;

--- a/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/CommonTestSuite.java
@@ -26,6 +26,5 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
 	org.hibernate.tool.jdbc2cfg.Identity.TestCase.class,
-	org.hibernate.tool.stat.Statistics.TestCase.class
 })
 public class CommonTestSuite {}

--- a/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/JupiterCommonTestSuite.java
@@ -74,5 +74,6 @@ public class JupiterCommonTestSuite {
 	@Nested public class SearchEscapeString extends org.hibernate.tool.jdbc2cfg.SearchEscapeString.TestCase {}
 	@Nested public class TernarySchema extends org.hibernate.tool.jdbc2cfg.TernarySchema.TestCase {}
 	@Nested public class Versioning extends org.hibernate.tool.jdbc2cfg.Versioning.TestCase {}
+	@Nested public class Statistics extends org.hibernate.tool.stat.Statistics.TestCase {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>