### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Use the JUnit Jupiter test suite in the 'mssql' module

### DIFF
--- a/test/mssql/pom.xml
+++ b/test/mssql/pom.xml
@@ -17,10 +17,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
@@ -33,8 +29,8 @@
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
 		<dependency>
-		    <groupId>org.junit.vintage</groupId>
-		    <artifactId>junit-vintage-engine</artifactId>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
     </dependencies>
     

--- a/test/mssql/src/test/java/org/hibernate/tool/test/db/sqlserver/TestSuite.java
+++ b/test/mssql/src/test/java/org/hibernate/tool/test/db/sqlserver/TestSuite.java
@@ -1,11 +1,11 @@
 package org.hibernate.tool.test.db.sqlserver;
 
-import org.hibernate.tools.test.util.DbSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite.SuiteClasses;
+import org.hibernate.tool.test.db.JupiterCommonTestSuite;
+import org.junit.jupiter.api.Nested;
 
-@RunWith(DbSuite.class)
-@SuiteClasses({ 
-	org.hibernate.tool.test.db.CommonTestSuite.class 
-})
-public class TestSuite {}
+public class TestSuite {
+	
+	@Nested
+	public class H2TestSuite extends JupiterCommonTestSuite {}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>