### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Use the JUnit Jupiter test suite in the 'mysql' module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <jaxen.version>1.2.0</jaxen.version>
         <junit.version>4.13.1</junit.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <mysql.version>6.0.6</mysql.version>
+        <mysql.version>8.0.23</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
         <sqlserver.version>9.1.1.jre8-preview</sqlserver.version>
     </properties>

--- a/test/mysql/pom.xml
+++ b/test/mysql/pom.xml
@@ -17,20 +17,20 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
+     	<dependency>
+    		<groupId>org.hibernate.tool</groupId>
+    		<artifactId>hibernate-tools-ant</artifactId>
+    	</dependency>
     	<dependency>
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
 		<dependency>
-		    <groupId>org.junit.vintage</groupId>
-		    <artifactId>junit-vintage-engine</artifactId>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
     </dependencies>
     

--- a/test/mysql/readme.txt
+++ b/test/mysql/readme.txt
@@ -17,9 +17,9 @@ username: root
 password: P@55w0rd
 The complete JDBC URL is: jdbc:mysql://localhost:3306
 
-5. Create the 'HTT' schema. You can do this by executing the following SQL: 
+5. Create the 'htt' schema. You can do this by executing the following SQL: 
 
-create schema HTT;
+create schema htt;
 
 5bis. Increase the amount of connections. There are connection leaks in the tests that make the tests fail.
 Execute the following statement as the root user:

--- a/test/mysql/src/test/java/org/hibernate/tool/test/db/mysql/TestSuite.java
+++ b/test/mysql/src/test/java/org/hibernate/tool/test/db/mysql/TestSuite.java
@@ -1,11 +1,11 @@
 package org.hibernate.tool.test.db.mysql;
 
-import org.hibernate.tools.test.util.DbSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite.SuiteClasses;
+import org.hibernate.tool.test.db.JupiterCommonTestSuite;
+import org.junit.jupiter.api.Nested;
 
-@RunWith(DbSuite.class)
-@SuiteClasses({ 
-	org.hibernate.tool.test.db.CommonTestSuite.class 
-})
-public class TestSuite {}
+public class TestSuite {
+	
+	@Nested
+	public class H2TestSuite extends JupiterCommonTestSuite {}
+
+}

--- a/test/mysql/src/test/resources/hibernate.properties
+++ b/test/mysql/src/test/resources/hibernate.properties
@@ -1,7 +1,7 @@
-hibernate.dialect org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect org.hibernate.dialect.MySQLDialect
 hibernate.connection.driver_class com.mysql.cj.jdbc.Driver
 hibernate.connection.username root
 hibernate.connection.password P@55w0rd
-hibernate.connection.url jdbc:mysql://localhost:3306/htt?useSSL=false
+hibernate.connection.url jdbc:mysql://localhost:3306/htt?useSSL=false&allowPublicKeyRetrieval=true
 
 hibernate.default_catalog htt

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -86,6 +86,14 @@
             	<module>mssql</module>
           	</modules> 
        	</profile>
+       	<profile>
+     		<id>mysql</id>
+          	<modules>
+            	<module>utils</module>
+             	<module>common</module>
+            	<module>mysql</module>
+          	</modules> 
+       	</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>