### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.jdbc2cfgIdentity' for module 'mssql'

### DIFF
--- a/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
+++ b/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
@@ -1,3 +1,22 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.test.db.h2;
 
 import org.hibernate.tool.test.db.JupiterCommonTestSuite;

--- a/test/hsql/src/test/java/org/hibernate/tool/test/db/hsql/TestSuite.java
+++ b/test/hsql/src/test/java/org/hibernate/tool/test/db/hsql/TestSuite.java
@@ -1,3 +1,22 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.test.db.hsql;
 
 import org.hibernate.tool.test.db.JupiterCommonTestSuite;
@@ -6,6 +25,6 @@ import org.junit.jupiter.api.Nested;
 public class TestSuite {
 	
 	@Nested
-	public class H2TestSuite extends JupiterCommonTestSuite {}
+	public class HSqlTestSuite extends JupiterCommonTestSuite {}
 
 }

--- a/test/mssql/pom.xml
+++ b/test/mssql/pom.xml
@@ -30,6 +30,11 @@
     	</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-api</artifactId>
+		    <scope>compile</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
     </dependencies>

--- a/test/mssql/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/mssql/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -1,8 +1,26 @@
 /*
- * Created on 2004-11-23
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
  *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.hibernate.tool.jdbc2cfg.Identity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.sql.SQLException;
 
@@ -11,11 +29,10 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author max
@@ -25,7 +42,7 @@ public class TestCase {
 
 	private Metadata metadata = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		MetadataDescriptorFactory
@@ -33,18 +50,18 @@ public class TestCase {
 			.createMetadata();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
 
 	// TODO HBX-1413: Enable the test below
-	@Ignore 
+	@Disabled 
 	@Test
 	public void testIdentity() throws SQLException {
 		PersistentClass classMapping = metadata.getEntityBinding("WithIdentity");
-		Assert.assertNotNull(classMapping);
-		Assert.assertEquals(
+		assertNotNull(classMapping);
+		assertEquals(
 				"identity", 
 				((SimpleValue)classMapping
 						.getIdentifierProperty()
@@ -53,12 +70,12 @@ public class TestCase {
 	}
 	
 	// TODO HBX-1413: Enable the test below
-	@Ignore 
+	@Disabled 
 	@Test
 	public void testGuid() throws SQLException {
 		PersistentClass classMapping = metadata.getEntityBinding("WithGuid");
-		Assert.assertNotNull(classMapping);
-		Assert.assertEquals(
+		assertNotNull(classMapping);
+		assertEquals(
 				"guid", 
 				((SimpleValue)classMapping
 						.getIdentifierProperty()

--- a/test/mssql/src/test/java/org/hibernate/tool/test/db/sqlserver/TestSuite.java
+++ b/test/mssql/src/test/java/org/hibernate/tool/test/db/sqlserver/TestSuite.java
@@ -1,3 +1,22 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.test.db.sqlserver;
 
 import org.hibernate.tool.test.db.JupiterCommonTestSuite;
@@ -6,6 +25,6 @@ import org.junit.jupiter.api.Nested;
 public class TestSuite {
 	
 	@Nested
-	public class H2TestSuite extends JupiterCommonTestSuite {}
+	public class MSSqlTestSuite extends JupiterCommonTestSuite {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>