### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.hbm2x.DefaultDatabaseCollector' for module 'mysql'

### DIFF
--- a/test/mysql/pom.xml
+++ b/test/mysql/pom.xml
@@ -30,6 +30,11 @@
     	</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-api</artifactId>
+		    <scope>compile</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
     </dependencies>

--- a/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/mysql/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -1,14 +1,28 @@
-/*******************************************************************************
- * Copyright (c) 2010 Red Hat, Inc.
- * Distributed under license by Red Hat, Inc. All rights reserved.
- * This program is made available under the terms of the
- * Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
  *
- * Contributor:
- *     Red Hat, Inc. - initial API and implementation
- ******************************************************************************/
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.hbm2x.DefaultDatabaseCollector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -33,11 +47,10 @@ import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dmitry Geraskov
@@ -45,18 +58,18 @@ import org.junit.Test;
  */
 public class TestCase {
 		
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
 	
 	// TODO Reenable this test (HBX-1401) 
-	@Ignore
+	@Disabled
 	@Test
 	public void testReadOnlySpecificSchema() {
 		OverrideRepository or = new OverrideRepository();
@@ -66,7 +79,7 @@ public class TestCase {
 				.createReverseEngineeringDescriptor(res, null)
 				.createMetadata();
 		List<Table> tables = getTables(metadata);
-		Assert.assertEquals(2,tables.size());
+		assertEquals(2,tables.size());
 		Table catchild = (Table) tables.get(0);
 		Table catmaster = (Table) tables.get(1);
 		if(catchild.getName().equals("cat.master")) {
@@ -75,8 +88,8 @@ public class TestCase {
 		} 
 		TableIdentifier masterid = TableIdentifier.create(catmaster);
 		TableIdentifier childid = TableIdentifier.create(catchild);
-		Assert.assertEquals(TableIdentifier.create(null, "cat.cat", "cat.child"), childid);
-		Assert.assertEquals(TableIdentifier.create(null, "cat.cat", "cat.master"), masterid);
+		assertEquals(TableIdentifier.create(null, "cat.cat", "cat.child"), childid);
+		assertEquals(TableIdentifier.create(null, "cat.cat", "cat.master"), masterid);
 	}
 	
 	@Test
@@ -86,9 +99,9 @@ public class TestCase {
 		ssrb.applySettings(properties);
 		ServiceRegistry serviceRegistry = ssrb.build();
 		RevengDialect realMetaData = RevengDialectFactory.createMetaDataDialect( serviceRegistry.getService(JdbcServices.class).getDialect(), properties);
-		Assert.assertTrue("The name must be quoted!", realMetaData.needQuote("cat.cat"));
-		Assert.assertTrue("The name must be quoted!", realMetaData.needQuote("cat.child"));
-		Assert.assertTrue("The name must be quoted!", realMetaData.needQuote("cat.master"));
+		assertTrue(realMetaData.needQuote("cat.cat"), "The name must be quoted!");
+		assertTrue(realMetaData.needQuote("cat.child"), "The name must be quoted!");
+		assertTrue(realMetaData.needQuote("cat.master"), "The name must be quoted!");
 	}
 	
 	/**
@@ -100,7 +113,7 @@ public class TestCase {
 	 * but getTable uses non-quoted names )
 	 */
 	// TODO Reenable this test (HBX-1401) 
-	@Ignore
+	@Disabled
 	@Test
 	public void testQuotedNamesAndDefaultDatabaseCollector() {
 		Properties properties = Environment.getProperties();
@@ -116,11 +129,11 @@ public class TestCase {
 		RevengMetadataCollector dc = new RevengMetadataCollector();
 		reader.readDatabaseSchema(dc);
 		String defaultCatalog = properties.getProperty(AvailableSettings.DEFAULT_CATALOG);
-		Assert.assertNotNull("The table should be found", getTable(dc, realMetaData, defaultCatalog, "cat.cat", "cat.child"));
-		Assert.assertNotNull("The table should be found", getTable(dc, realMetaData, defaultCatalog, "cat.cat", "cat.master"));
-		Assert.assertNull("Quoted names should not return the table", getTable(dc, realMetaData, defaultCatalog, doubleQuote("cat.cat"), doubleQuote("cat.child")));
-		Assert.assertNull("Quoted names should not return the table", getTable(dc, realMetaData, defaultCatalog, doubleQuote("cat.cat"), doubleQuote("cat.master")));
-		Assert.assertEquals("Foreign key 'masterref' was filtered!", 1, dc.getOneToManyCandidates().size());
+		assertNotNull(getTable(dc, realMetaData, defaultCatalog, "cat.cat", "cat.child"), "The table should be found");
+		assertNotNull(getTable(dc, realMetaData, defaultCatalog, "cat.cat", "cat.master"), "The table should be found");
+		assertNull(getTable(dc, realMetaData, defaultCatalog, doubleQuote("cat.cat"), doubleQuote("cat.child")), "Quoted names should not return the table");
+		assertNull(getTable(dc, realMetaData, defaultCatalog, doubleQuote("cat.cat"), doubleQuote("cat.master")), "Quoted names should not return the table");
+		assertEquals(1, dc.getOneToManyCandidates().size(), "Foreign key 'masterref' was filtered!");
 	}
 	
 	private Table getTable(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>