### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.jdbc2cfg.Identity' for module 'oracle'

### DIFF
--- a/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -1,7 +1,7 @@
 /*
  * Hibernate Tools, Tooling for your Hibernate Projects
  * 
- * Copyright 2017-2020 Red Hat, Inc.
+ * Copyright 2018-2020 Red Hat, Inc.
  *
  * Licensed under the GNU Lesser General Public License (LGPL), 
  * version 2.1 or later (the "License").
@@ -19,6 +19,9 @@
  */
 package org.hibernate.tool.jdbc2cfg.Identity;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.sql.SQLException;
 
 import org.hibernate.boot.Metadata;
@@ -26,11 +29,10 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author max
@@ -40,7 +42,7 @@ public class TestCase {
 
 	private Metadata metadata = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
@@ -48,19 +50,19 @@ public class TestCase {
 				.createMetadata();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
 
 	// TODO HBX-1412: Enable the test below and make sure it passes.
-	@Ignore
+	@Disabled
 	@Test
 	public void testIdentity() throws SQLException {
 
 		PersistentClass classMapping = metadata.getEntityBinding("Autoinc");
-		Assert.assertNotNull(classMapping);
-		Assert.assertEquals(
+		assertNotNull(classMapping);
+		assertEquals(
 				"identity", 
 				((SimpleValue)classMapping
 						.getIdentifierProperty()
@@ -68,7 +70,7 @@ public class TestCase {
 					.getIdentifierGeneratorStrategy());
 		
 		classMapping = metadata.getEntityBinding("Noautoinc");
-		Assert.assertEquals(
+		assertEquals(
 				"assigned", 
 				((SimpleValue)classMapping
 						.getIdentifierProperty()


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>