### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.jdbc2cfg.CompositeIdOrder' for module 'oracle'

### DIFF
--- a/test/oracle/src/main/java/org/hibernate/cfg/reveng/dialect/TestCase.java
+++ b/test/oracle/src/main/java/org/hibernate/cfg/reveng/dialect/TestCase.java
@@ -1,7 +1,7 @@
 /*
  * Hibernate Tools, Tooling for your Hibernate Projects
  * 
- * Copyright 2018-2020 Red Hat, Inc.
+ * Copyright 2018-2021 Red Hat, Inc.
  *
  * Licensed under the GNU Lesser General Public License (LGPL), 
  * version 2.1 or later (the "License").

--- a/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeIdOrder/TestCase.java
+++ b/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeIdOrder/TestCase.java
@@ -1,7 +1,7 @@
 /*
  * Hibernate Tools, Tooling for your Hibernate Projects
  * 
- * Copyright 2017-2020 Red Hat, Inc.
+ * Copyright 2018-2021 Red Hat, Inc.
  *
  * Licensed under the GNU Lesser General Public License (LGPL), 
  * version 2.1 or later (the "License").
@@ -19,6 +19,9 @@
  */
 package org.hibernate.tool.jdbc2cfg.CompositeIdOrder;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.sql.SQLException;
 import java.util.Iterator;
 
@@ -32,12 +35,9 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author max
@@ -47,7 +47,7 @@ public class TestCase {
 	
 	private Metadata metadata = null;
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
@@ -55,7 +55,7 @@ public class TestCase {
 				.createMetadata();
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
@@ -64,32 +64,32 @@ public class TestCase {
 	public void testMultiColumnForeignKeys() throws SQLException {
 
 		Table table = HibernateUtil.getTable(metadata, "COURSE");
-        Assert.assertNotNull(table);
+        assertNotNull(table);
         ForeignKey foreignKey = HibernateUtil.getForeignKey(table, "FK_COURSE__SCHEDULE");     
-        Assert.assertNotNull(foreignKey);
+        assertNotNull(foreignKey);
                 
-        Assert.assertEquals("Schedule", foreignKey.getReferencedEntityName() );
-        Assert.assertEquals("COURSE", foreignKey.getTable().getName() );
+        assertEquals("Schedule", foreignKey.getReferencedEntityName() );
+        assertEquals("COURSE", foreignKey.getTable().getName() );
         
-        Assert.assertEquals(1,foreignKey.getColumnSpan() );
-        Assert.assertEquals(foreignKey.getColumn(0).getName(), "SCHEDULE_KEY");
+        assertEquals(1,foreignKey.getColumnSpan() );
+        assertEquals(foreignKey.getColumn(0).getName(), "SCHEDULE_KEY");
         
-        Assert.assertEquals(table.getPrimaryKey().getColumn(0).getName(), "SCHEDULE_KEY");
-        Assert.assertEquals(table.getPrimaryKey().getColumn(1).getName(), "REQUEST_KEY");
+        assertEquals(table.getPrimaryKey().getColumn(0).getName(), "SCHEDULE_KEY");
+        assertEquals(table.getPrimaryKey().getColumn(1).getName(), "REQUEST_KEY");
         
         PersistentClass course = metadata.getEntityBinding("Course");
         
-        Assert.assertEquals(2,course.getIdentifier().getColumnSpan() );
+        assertEquals(2,course.getIdentifier().getColumnSpan() );
         Iterator<Selectable> columnIterator = course.getIdentifier().getColumnIterator();
-        Assert.assertEquals(((Column)(columnIterator.next())).getName(), "SCHEDULE_KEY");
-        Assert.assertEquals(((Column)(columnIterator.next())).getName(), "REQUEST_KEY");
+        assertEquals(((Column)(columnIterator.next())).getName(), "SCHEDULE_KEY");
+        assertEquals(((Column)(columnIterator.next())).getName(), "REQUEST_KEY");
         
         PersistentClass topic = metadata.getEntityBinding("CourseTopic");
         
         Property property = topic.getProperty("course");
         columnIterator = property.getValue().getColumnIterator();
-        Assert. assertEquals(((Column)(columnIterator.next())).getName(), "SCHEDULE_KEY");
-        Assert.assertEquals(((Column)(columnIterator.next())).getName(), "REQUEST_KEY");
+        assertEquals(((Column)(columnIterator.next())).getName(), "SCHEDULE_KEY");
+        assertEquals(((Column)(columnIterator.next())).getName(), "REQUEST_KEY");
 
 	}
 

--- a/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -1,7 +1,7 @@
 /*
  * Hibernate Tools, Tooling for your Hibernate Projects
  * 
- * Copyright 2018-2020 Red Hat, Inc.
+ * Copyright 2018-2021 Red Hat, Inc.
  *
  * Licensed under the GNU Lesser General Public License (LGPL), 
  * version 2.1 or later (the "License").


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>