### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests in 'org.hibernate.tool.jdbc2cfg.Views' for module 'oracle'

### DIFF
--- a/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Views/TestCase.java
+++ b/test/oracle/src/main/java/org/hibernate/tool/jdbc2cfg/Views/TestCase.java
@@ -1,7 +1,7 @@
 /*
  * Hibernate Tools, Tooling for your Hibernate Projects
  * 
- * Copyright 2017-2020 Red Hat, Inc.
+ * Copyright 2017-2021 Red Hat, Inc.
  *
  * Licensed under the GNU Lesser General Public License (LGPL), 
  * version 2.1 or later (the "License").
@@ -19,6 +19,11 @@
  */
 package org.hibernate.tool.jdbc2cfg.Views;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.sql.SQLException;
 
 import org.hibernate.boot.Metadata;
@@ -27,12 +32,9 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author max
@@ -42,7 +44,7 @@ public class TestCase {
 	
 	private Metadata metadata;
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		metadata = MetadataDescriptorFactory
@@ -50,7 +52,7 @@ public class TestCase {
 				.createMetadata();
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
@@ -59,19 +61,19 @@ public class TestCase {
 	public void testViewAndSynonyms() throws SQLException {
 		
 		PersistentClass classMapping = metadata.getEntityBinding("Basicview");
-		Assert.assertNotNull(classMapping);
+		assertNotNull(classMapping);
 	
 		classMapping = metadata.getEntityBinding("Weirdname");
-		Assert.assertTrue("If this is not-null synonyms apparently work!",classMapping==null);
+		assertTrue(classMapping==null, "If this is not-null synonyms apparently work!");
 
 		// get comments
 		Table table = HibernateUtil.getTable(metadata, "BASIC");
-		Assert.assertEquals("a basic comment", table.getComment());
-		Assert.assertEquals("a solid key", table.getPrimaryKey().getColumn(0).getComment());
+		assertEquals(table.getComment(), "a basic comment");
+		assertEquals(table.getPrimaryKey().getColumn(0).getComment(), "a solid key");
 		
 		table = HibernateUtil.getTable(metadata, "MULTIKEYED");
-		Assert.assertNull(table.getComment());
-		Assert.assertNull(table.getColumn(0).getComment());
+		assertNull(table.getComment());
+		assertNull(table.getColumn(0).getComment());
 		
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>