### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Rename 'orghibernate.tool.test.db.JupiterCommonTestSuite' to 'org.hibernate.tool.test.db.DbTestSuite'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/test/db/DbTestSuite.java
+++ b/test/common/src/main/java/org/hibernate/tool/test/db/DbTestSuite.java
@@ -21,7 +21,7 @@ package org.hibernate.tool.test.db;
 
 import org.junit.jupiter.api.Nested;
 
-public class JupiterCommonTestSuite {
+public class DbTestSuite {
 	
 	@Nested public class AntHibernateToolTests extends org.hibernate.tool.ant.AntHibernateTool.TestCase {}
 	@Nested public class Cfg2HbmNoError extends org.hibernate.tool.ant.Cfg2HbmNoError.TestCase {}

--- a/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
+++ b/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
@@ -19,12 +19,12 @@
  */
 package org.hibernate.tool.test.db.h2;
 
-import org.hibernate.tool.test.db.JupiterCommonTestSuite;
+import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
 public class TestSuite {
 	
 	@Nested
-	public class H2TestSuite extends JupiterCommonTestSuite {}
+	public class H2TestSuite extends DbTestSuite {}
 
 }

--- a/test/hsql/src/test/java/org/hibernate/tool/test/db/hsql/TestSuite.java
+++ b/test/hsql/src/test/java/org/hibernate/tool/test/db/hsql/TestSuite.java
@@ -19,12 +19,12 @@
  */
 package org.hibernate.tool.test.db.hsql;
 
-import org.hibernate.tool.test.db.JupiterCommonTestSuite;
+import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
 public class TestSuite {
 	
 	@Nested
-	public class HSqlTestSuite extends JupiterCommonTestSuite {}
+	public class HSqlTestSuite extends DbTestSuite {}
 
 }

--- a/test/mssql/src/test/java/org/hibernate/tool/test/db/sqlserver/TestSuite.java
+++ b/test/mssql/src/test/java/org/hibernate/tool/test/db/sqlserver/TestSuite.java
@@ -19,12 +19,12 @@
  */
 package org.hibernate.tool.test.db.sqlserver;
 
-import org.hibernate.tool.test.db.JupiterCommonTestSuite;
+import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
 public class TestSuite {
 	
 	@Nested
-	public class MSSqlTestSuite extends JupiterCommonTestSuite {}
+	public class MSSqlTestSuite extends DbTestSuite {}
 
 }

--- a/test/mysql/src/test/java/org/hibernate/tool/test/db/mysql/TestSuite.java
+++ b/test/mysql/src/test/java/org/hibernate/tool/test/db/mysql/TestSuite.java
@@ -1,11 +1,11 @@
 package org.hibernate.tool.test.db.mysql;
 
-import org.hibernate.tool.test.db.JupiterCommonTestSuite;
+import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
 public class TestSuite {
 	
 	@Nested
-	public class MySqlTestSuite extends JupiterCommonTestSuite {}
+	public class MySqlTestSuite extends DbTestSuite {}
 
 }

--- a/test/oracle/src/test/java/org/hibernate/tool/test/db/oracle/TestSuite.java
+++ b/test/oracle/src/test/java/org/hibernate/tool/test/db/oracle/TestSuite.java
@@ -19,12 +19,12 @@
  */
 package org.hibernate.tool.test.db.oracle;
 
-import org.hibernate.tool.test.db.JupiterCommonTestSuite;
+import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
 public class TestSuite {
 	
-	@Nested public class OracleTestSuite extends JupiterCommonTestSuite {}
+	@Nested public class OracleTestSuite extends DbTestSuite {}
 	@Nested public class DialectTestCase extends org.hibernate.cfg.reveng.dialect.TestCase {}
 	@Nested public class CompositeOrderTestCase extends org.hibernate.tool.jdbc2cfg.CompositeIdOrder.TestCase {}
 	@Nested public class ViewsTestCase extends org.hibernate.tool.jdbc2cfg.Views.TestCase {}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>