### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Remove JUnit dependency from module 'test/common'

### DIFF
--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -20,10 +20,6 @@
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>