### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Remove JUnit dependency from module 'test/utils'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/ant/NoConfig/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/ant/NoConfig/TestCase.java
@@ -20,7 +20,7 @@
 
 package org.hibernate.tool.ant.NoConfig;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
@@ -20,8 +20,8 @@
 
 package org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
@@ -20,9 +20,9 @@
 
 package org.hibernate.tool.hbm2x.hbm2hbmxml.InheritanceTest;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;

--- a/test/nodb/src/test/java/org/hibernate/tool/ide/completion/ModelCompletion/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/ide/completion/ModelCompletion/TestCase.java
@@ -20,9 +20,9 @@
 
 package org.hibernate.tool.ide.completion.ModelCompletion;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URL;
@@ -139,11 +139,11 @@ public class TestCase {
         
     		hcc.clear();
         cc.getMatchingImports( " ", hcc );
-        assertTrue("Space prefix should have no classes", hcc.getCompletionProposals().length==0);
+        assertTrue(hcc.getCompletionProposals().length==0, "Space prefix should have no classes");
         
         hcc.clear();
         cc.getMatchingImports( "pro", hcc );
-        assertTrue("Completion should not be case sensitive", hcc.getCompletionProposals().length==2);
+        assertTrue(hcc.getCompletionProposals().length==2, "Completion should not be case sensitive");
         
         hcc.clear();
         cc.getMatchingImports( "StoreC", hcc );
@@ -240,7 +240,7 @@ public class TestCase {
 
     private void doTestFields(HQLCompletionProposal[] proposals, String[] fields) {
         if (fields == null || fields.length==0) {
-        	assertTrue("No fields should have been found", proposals.length==0);
+        	assertTrue(proposals.length==0, "No fields should have been found");
             return;
         }
         

--- a/test/oracle/pom.xml
+++ b/test/oracle/pom.xml
@@ -37,10 +37,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>ojdbc8</artifactId>
         </dependency>

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -38,11 +38,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
@@ -57,14 +52,11 @@
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-api</artifactId>
+		    <scope>compile</scope>
 		</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
-		</dependency>
-		<dependency>
-		    <groupId>org.junit.vintage</groupId>
-		    <artifactId>junit-vintage-engine</artifactId>
 		</dependency>
     </dependencies>
     

--- a/test/utils/src/main/java/org/hibernate/tools/test/util/ConnectionLeakUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/ConnectionLeakUtil.java
@@ -25,7 +25,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.junit.Assert;
+import org.opentest4j.AssertionFailedError;
 
 public class ConnectionLeakUtil {
 	
@@ -45,7 +45,9 @@ public class ConnectionLeakUtil {
 	
 	public void assertNoLeaks() {
 		int leaked = getLeakedConnectionCount();
-		Assert.assertTrue(leaked + " connections are leaked.", leaked == 0); 
+		if (leaked != 0) {
+			throw new AssertionFailedError(leaked + " connections are leaked.");
+		}
 	}
 	
 	private int getLeakedConnectionCount() {

--- a/test/utils/src/main/java/org/hibernate/tools/test/util/JUnitUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/JUnitUtil.java
@@ -19,11 +19,12 @@
  */
 package org.hibernate.tools.test.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.util.Iterator;
 
-import org.junit.Assert;
-import org.junit.ComparisonFailure;
+import org.opentest4j.AssertionFailedError;
 
 public class JUnitUtil {
 	
@@ -37,18 +38,15 @@ public class JUnitUtil {
 			actualAmountOfElements++;
 			iterator.next();
 		}
-		if (actualAmountOfElements != expectedAmountOfElements) {
-			throw new ComparisonFailure(
-					reason, 
-					Integer.toString(expectedAmountOfElements),
-					Integer.toString(actualAmountOfElements));
+		if (expectedAmountOfElements != actualAmountOfElements) {
+			throw new AssertionFailedError(reason, expectedAmountOfElements, actualAmountOfElements);
 		}
 	}
 	
 	public static void assertIsNonEmptyFile(File file) {
-		Assert.assertTrue(file + " does not exist", file.exists() );
-		Assert.assertTrue(file + " not a file", file.isFile() );		
-		Assert.assertTrue(file + " does not have any contents", file.length()>0);
+		assertTrue(file.exists(), file + " does not exist");
+		assertTrue(file.isFile(), file + " not a file");		
+		assertTrue(file.length()>0, file + " does not have any contents");
 	}
 
 }

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/JUnitUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/JUnitUtilTest.java
@@ -19,12 +19,14 @@
  */
 package org.hibernate.tools.test.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.util.ArrayList;
 
-import org.junit.Assert;
-import org.junit.ComparisonFailure;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 public class JUnitUtilTest {
 	
@@ -35,21 +37,21 @@ public class JUnitUtilTest {
 		list.add("bar");
 		try {
 			JUnitUtil.assertIteratorContainsExactly("less", list.iterator(), 1);
-			Assert.fail();
-		} catch (ComparisonFailure e) {
-			Assert.assertTrue(e.getMessage().contains("less"));
+			fail();
+		} catch (AssertionFailedError e) {
+			assertTrue(e.getMessage().contains("less"));
 		}
 		try {
 			JUnitUtil.assertIteratorContainsExactly("more", list.iterator(), 3);
-			Assert.fail();		
-		} catch (ComparisonFailure e) {
-			Assert.assertTrue(e.getMessage().contains("more"));
+			fail();		
+		} catch (AssertionFailedError e) {
+			assertTrue(e.getMessage().contains("more"));
 		}
 		try {
 			JUnitUtil.assertIteratorContainsExactly("exact", list.iterator(), 2);
-			Assert.assertTrue(true);		
-		} catch (ComparisonFailure e) {
-			Assert.fail();
+			assertTrue(true);		
+		} catch (AssertionFailedError e) {
+			fail();
 		}
 	}
 	
@@ -60,14 +62,14 @@ public class JUnitUtilTest {
 		try {
 			JUnitUtil.assertIsNonEmptyFile(exists);
 		} catch (Exception e) {
-			Assert.fail();
+			fail();
 		}
 		File doesNotExist = new File(exists.getAbsolutePath() + '_');
 		try {
 			JUnitUtil.assertIsNonEmptyFile(doesNotExist);
-			Assert.fail();
+			fail();
 		} catch (AssertionError e) {
-			Assert.assertTrue(e.getMessage().contains("does not exist"));
+			assertTrue(e.getMessage().contains("does not exist"));
 		}		
 	}
 

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/ResourceUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/ResourceUtilTest.java
@@ -19,9 +19,9 @@
  */
 package org.hibernate.tools.test.util;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>