### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Remove JUnit dependency from module 'orm'

### DIFF
--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -44,11 +44,6 @@
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
 		</dependency> 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
@@ -76,6 +71,14 @@
 		<dependency>
 			<groupId>org.hibernate.common</groupId>
 			<artifactId>hibernate-commons-annotations</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/orm/src/test/java/org/hibernate/tool/api/export/ExporterFactoryTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/export/ExporterFactoryTest.java
@@ -19,9 +19,13 @@
  */
 package org.hibernate.tool.api.export;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.hibernate.tool.internal.export.common.AbstractExporter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExporterFactoryTest {
 	
@@ -29,17 +33,17 @@ public class ExporterFactoryTest {
 	public void testCreateExporter() {
 		try {
 			ExporterFactory.createExporter("foobar");
-			Assert.fail();
+			fail();
 		} catch(Throwable t) {
-			Assert.assertTrue(t.getMessage().contains("foobar"));
+			assertTrue(t.getMessage().contains("foobar"));
 		}
 		Exporter exporter = ExporterFactory.createExporter(
 				"org.hibernate.tool.api.export.ExporterFactoryTest$TestExporter");
-		Assert.assertNotNull(exporter);
-		Assert.assertTrue(exporter instanceof TestExporter);
+		assertNotNull(exporter);
+		assertTrue(exporter instanceof TestExporter);
 		exporter = ExporterFactory.createExporter(ExporterType.JAVA);
-		Assert.assertNotNull(exporter);
-		Assert.assertEquals(
+		assertNotNull(exporter);
+		assertEquals(
 				ExporterType.JAVA.className(), 
 				exporter.getClass().getName());
 	}

--- a/orm/src/test/java/org/hibernate/tool/api/export/ExporterTypeTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/export/ExporterTypeTest.java
@@ -19,18 +19,18 @@
  */
 package org.hibernate.tool.api.export;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Test;
 
 public class ExporterTypeTest {
 	
 	@Test
 	public void testExporterType() {
-		Assert.assertEquals(
+		assertEquals(
 				"org.hibernate.tool.internal.export.java.JavaExporter",
 				ExporterType.JAVA.className());
-		Assert.assertEquals(
+		assertEquals(
 				"org.hibernate.tool.internal.export.cfg.CfgExporter", 
 				ExporterType.CFG.className());
 	}

--- a/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/reveng/ReverseEngineeringStrategyFactoryTest.java
@@ -19,9 +19,11 @@
  */
 package org.hibernate.tool.api.reveng;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ReverseEngineeringStrategyFactoryTest {
@@ -30,20 +32,20 @@ public class ReverseEngineeringStrategyFactoryTest {
 	public void testCreateReverseEngineeringStrategy() {
 		RevengStrategy reverseEngineeringStrategy = 
 				RevengStrategyFactory.createReverseEngineeringStrategy();
-		Assert.assertNotNull(reverseEngineeringStrategy);
-		Assert.assertEquals(
+		assertNotNull(reverseEngineeringStrategy);
+		assertEquals(
 				DefaultStrategy.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());
 		reverseEngineeringStrategy = 
 				RevengStrategyFactory.createReverseEngineeringStrategy(
 						TestReverseEngineeringStrategyFactory.class.getName());
-		Assert.assertNotNull(reverseEngineeringStrategy);
-		Assert.assertEquals(
+		assertNotNull(reverseEngineeringStrategy);
+		assertEquals(
 				TestReverseEngineeringStrategyFactory.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());
 		reverseEngineeringStrategy = 
 				RevengStrategyFactory.createReverseEngineeringStrategy(null);
-		Assert.assertEquals(
+		assertEquals(
 				DefaultStrategy.class.getName(), 
 				reverseEngineeringStrategy.getClass().getName());		
 	}

--- a/orm/src/test/java/org/hibernate/tool/internal/reveng/strategy/MetaAttributeHelperTest.java
+++ b/orm/src/test/java/org/hibernate/tool/internal/reveng/strategy/MetaAttributeHelperTest.java
@@ -19,6 +19,9 @@
  */
 package org.hibernate.tool.internal.reveng.strategy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.util.Collection;
 import java.util.Optional;
@@ -27,10 +30,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.collections4.MultiValuedMap;
-import org.hibernate.tool.internal.reveng.strategy.MetaAttributeHelper;
 import org.hibernate.tool.internal.reveng.strategy.MetaAttributeHelper.SimpleMetaAttribute;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 public class MetaAttributeHelperTest {
@@ -46,14 +47,14 @@ public class MetaAttributeHelperTest {
 		DocumentBuilder db = dbf.newDocumentBuilder();
 		Document document = db.parse(new ByteArrayInputStream(XML.getBytes()));
 		MultiValuedMap<String, SimpleMetaAttribute> mm = MetaAttributeHelper.loadMetaMap(document.getDocumentElement());
-		Assert.assertEquals(1, mm.size());
+		assertEquals(1, mm.size());
 		Collection<SimpleMetaAttribute> attributeList = mm.get("blah");
-		Assert.assertEquals(1, attributeList.size());
+		assertEquals(1, attributeList.size());
 		Optional<SimpleMetaAttribute> first = attributeList.stream().findFirst();
-		Assert.assertTrue(first.isPresent());
+		assertTrue(first.isPresent());
 		SimpleMetaAttribute attribute = first.get();
-		Assert.assertEquals(true, attribute.inheritable);
-		Assert.assertEquals("foo", attribute.value);
+		assertEquals(true, attribute.inheritable);
+		assertEquals("foo", attribute.value);
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>