### PR TITLE
HBX-2124: Replace JUnit4 tests with JUnit Jupiter tests - Remove the JUnit dependency from module 'parent'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
         <javaee-api.version>8.0.1</javaee-api.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <jaxen.version>1.2.0</jaxen.version>
-        <junit.version>4.13.1</junit.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
         <mysql.version>8.0.23</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
@@ -138,11 +137,6 @@
                 <version>${jaxen.version}</version>
                 <scope>runtime</scope>
 			</dependency> 
-             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-            </dependency>
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>