### PR TITLE
HBX-2148: Update dependency on ORM to version 6.0.0.Alpha7 - Reenable and fix 'org.hibernate.tools.test.util.HibernateUtilTest#testGetForeignKey()'

### DIFF
--- a/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
@@ -35,25 +35,20 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
-import net.bytebuddy.implementation.bind.annotation.IgnoreForBinding;
 
 public class HibernateUtilTest {
 	
 	@TempDir
 	public File outputFolder = new File("output");
 	
-	// TODO HBX-2148: Reenable the test
-	@Disabled
 	@Test
 	public void testGetForeignKey() {
 		Table table = new Table();
 		assertNull(HibernateUtil.getForeignKey(table, "foo"));
 		assertNull(HibernateUtil.getForeignKey(table, "bar"));
-		table.createForeignKey("foo", Collections.emptyList(), null, null);
+		table.createForeignKey("foo", Collections.emptyList(), "Bar", null);
 		assertNotNull(HibernateUtil.getForeignKey(table, "foo"));
 		assertNull(HibernateUtil.getForeignKey(table, "bar"));
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>