### PR TITLE
HBX-2148: Update dependency on ORM to version 6.0.0.Alpha7 - Reenable and fix 'org.hibernate.tool.hbm2x.hbm2hbmxml.Cfg2HbmToolTest.TestCase#testNeedsTable()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Cfg2HbmToolTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Cfg2HbmToolTest/TestCase.java
@@ -24,6 +24,11 @@ package org.hibernate.tool.hbm2x.hbm2hbmxml.Cfg2HbmToolTest;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.mapping.JoinedSubclass;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
@@ -31,26 +36,38 @@ import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Subclass;
 import org.hibernate.mapping.UnionSubclass;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Dmitry Geraskov
  * @author koen
  */
-//TODO HBX-2148: Reenable the tests
-@Disabled
 public class TestCase {
+	
+	MetadataBuildingContext foo;
 	
 	@Test
 	public void testNeedsTable(){
+		MetadataBuildingContext mdbc = createMetadataBuildingContext();
 		Cfg2HbmTool c2h = new Cfg2HbmTool();
-		PersistentClass pc = new RootClass(null);
+		PersistentClass pc = new RootClass(mdbc);
 		assertTrue(c2h.needsTable(pc));
-		assertTrue(c2h.needsTable(new JoinedSubclass(pc, null)));
-		assertTrue(c2h.needsTable(new UnionSubclass(pc, null)));
-		assertFalse(c2h.needsTable(new SingleTableSubclass(pc, null)));
-		assertFalse(c2h.needsTable(new Subclass(pc, null)));			
+		assertTrue(c2h.needsTable(new JoinedSubclass(pc, mdbc)));
+		assertTrue(c2h.needsTable(new UnionSubclass(pc, mdbc)));
+		assertFalse(c2h.needsTable(new SingleTableSubclass(pc, mdbc)));
+		assertFalse(c2h.needsTable(new Subclass(pc, mdbc)));			
+	}
+	
+	private MetadataBuildingContext createMetadataBuildingContext() {
+		return (MetadataBuildingContext)Proxy.newProxyInstance(
+				getClass().getClassLoader(), 
+				new Class[] { MetadataBuildingContext.class }, 
+				new InvocationHandler() {					
+					@Override
+					public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+						return null;
+					}
+				});
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>