### PR TITLE
HBX-2148: Update dependency on ORM to version 6.0.0.Alpha7 - Reenable and fix tests in 'org.hibernate.tool.hbm2x.DocExporterTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
@@ -44,7 +44,6 @@ import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.xml.sax.EntityResolver;
@@ -57,8 +56,6 @@ import org.xml.sax.XMLReader;
 /**
  * @author koen
  */
-//TODO HBX-2148: Reenable these tests
-@Disabled
 public class TestCase {
 
 	private static final String[] HBM_XML_FILES = new String[] {

--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/DocExporterTest/Customer.hbm.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/DocExporterTest/Customer.hbm.xml
@@ -21,7 +21,7 @@
 			<generator class="assigned"/>
 			</id>-->
 
-		<composite-id name="customerId">
+		<composite-id>
 			<key-property name="id" type="long" />
 		</composite-id>
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>