### PR TITLE
HBX-2148: Update dependency on ORM to version 6.0.0.Alpha7 - Reenable 'org.hibernate.tool.hbm2x.CachedMetaData.TestCase#testCachedDialect()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/CachedMetaData/TestCase.java
@@ -33,8 +33,8 @@ import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.mapping.Table;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.tool.api.reveng.RevengDialectFactory;
 import org.hibernate.tool.api.reveng.RevengDialect;
+import org.hibernate.tool.api.reveng.RevengDialectFactory;
 import org.hibernate.tool.internal.reveng.RevengMetadataCollector;
 import org.hibernate.tool.internal.reveng.dialect.CachedMetaDataDialect;
 import org.hibernate.tool.internal.reveng.reader.DatabaseReader;
@@ -43,7 +43,6 @@ import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 
@@ -146,8 +145,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 	
-	//TODO HBX-2148: Reenable the tests
-	@Disabled
 	@Test
 	public void testCachedDialect() {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>