### PR TITLE
HBX-2148: Update dependency on ORM to version 6.0.0.Alpha7 - Reenable 'org.hibernate.tool.hbm2x.DefaultDatabaseCollector.TestCase#testQuotedNamesAndDefaultDatabaseCollector()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/DefaultDatabaseCollector/TestCase.java
@@ -49,7 +49,6 @@ import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -109,8 +108,6 @@ public class TestCase {
 	 * Because of this there are 2 opposite methods(and they are both failed as addTable uses quoted names
 	 * but getTable uses non-quoted names )
 	 */
-	//TODO HBX-2148: Reenable the test
-	@Disabled
 	@Test
 	public void testQuotedNamesAndDefaultDatabaseCollector() {
 		Properties properties = Environment.getProperties();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>