### PR TITLE
HBX-2159: Remove the dependency on dom4j - Reimplement tests 'org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest.TestCase#testClassProxy()' and ''org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest.TestCase#testDynamicComponentNode()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
@@ -25,15 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
-import org.dom4j.XPath;
-import org.dom4j.io.SAXReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
@@ -45,6 +44,9 @@ import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * @author Dmitry Geraskov
@@ -105,33 +107,39 @@ public class TestCase {
     }
 
 	@Test
-	public void testClassProxy() throws DocumentException {
+	public void testClassProxy() throws Exception {
 		File outputXml = new File(
 				srcDir,  
 				"org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/Glarch.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
-		SAXReader xmlReader = new SAXReader();
-		Document document = xmlReader.read(outputXml);
-		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class");
-		List<?> list = xpath.selectNodes(document);
-		assertEquals(1, list.size(), "Expected to get one class element");
-		Element node = (Element) list.get(0);
-		assertEquals(node.attribute("proxy").getText(),"org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest.GlarchProxy");
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(outputXml);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class")
+				.evaluate(document, XPathConstants.NODESET);
+		assertEquals(1, nodeList.getLength(), "Expected to get one class element");
+		Element element = (Element) nodeList.item(0);
+		assertEquals(element.getAttribute("proxy"),"org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest.GlarchProxy");
 	}
 
 	@Test
-	public void testDynamicComponentNode() throws DocumentException {
+	public void testDynamicComponentNode() throws Exception {
 		File outputXml = new File(
 				srcDir,  
 				"org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/Glarch.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
-		SAXReader xmlReader = new SAXReader();
-		Document document = xmlReader.read(outputXml);
-		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/dynamic-component");
-		List<?> list = xpath.selectNodes(document);
-		assertEquals(1, list.size(), "Expected to get one dynamic-component element");
-		Element node = (Element) list.get(0);
-		assertEquals(node.attribute( "name" ).getText(),"dynaBean");
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(outputXml);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/dynamic-component")
+				.evaluate(document, XPathConstants.NODESET);
+		assertEquals(1, nodeList.getLength(), "Expected to get one dynamic-component element");
+		Element element = (Element) nodeList.item(0);
+		assertEquals(element.getAttribute( "name" ),"dynaBean");
 	}
-
+	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>