### PR TITLE
HBX-2159: Remove the dependency on dom4j - Reimplement tests 'org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest.TestCase#testClassProxy()' and ''org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest.TestCase#testDynamicComponentNode()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/TestCase.java
@@ -18,15 +18,14 @@ package org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
-import org.dom4j.XPath;
-import org.dom4j.io.SAXReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -39,6 +38,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * @author Dmitry Geraskov
@@ -99,33 +101,39 @@ public class TestCase {
     }
 
 	@Test
-	public void testClassProxy() throws DocumentException {
+	public void testClassProxy() throws Exception {
 		File outputXml = new File(
 				outputDir,  
 				"org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/Glarch.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
-		SAXReader xmlReader = new SAXReader();
-		Document document = xmlReader.read(outputXml);
-		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class");
-		List<?> list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one class element", 1, list.size());
-		Element node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute("proxy").getText(),"org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest.GlarchProxy");
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(outputXml);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one class element", 1, nodeList.getLength());
+		Element element = (Element) nodeList.item(0);
+		Assert.assertEquals(element.getAttribute("proxy"),"org.hibernate.tool.hbm2x.hbm2hbmxml.DynamicComponentTest.GlarchProxy");
 	}
 
 	@Test
-	public void testDynamicComponentNode() throws DocumentException {
+	public void testDynamicComponentNode() throws Exception {
 		File outputXml = new File(
 				outputDir,  
 				"org/hibernate/tool/hbm2x/hbm2hbmxml/DynamicComponentTest/Glarch.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
-		SAXReader xmlReader = new SAXReader();
-		Document document = xmlReader.read(outputXml);
-		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/dynamic-component");
-		List<?> list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one dynamic-component element", 1, list.size());
-		Element node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute( "name" ).getText(),"dynaBean");
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(outputXml);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/dynamic-component")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one dynamic-component element", 1, nodeList.getLength());
+		Element element = (Element) nodeList.item(0);
+		Assert.assertEquals(element.getAttribute( "name" ),"dynaBean");
 	}
-
+	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>