### PR TITLE
HBX-2159: Remove the dependency on dom4j - Reimplement tests 'org.hibernate.tool.hbm2x.hbm2hbmxml.SetElementTest.TestCase#testKey()' and 'org.hibernate.tool.hbm2x.hbm2hbmxml.SetElementTest.TestCase#testSetElement()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
@@ -17,15 +17,14 @@
 package org.hibernate.tool.hbm2x.hbm2hbmxml.SetElementTest;
 
 import java.io.File;
-import java.util.List;
 import java.util.Properties;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
-import org.dom4j.XPath;
-import org.dom4j.io.SAXReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -38,6 +37,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * @author Dmitry Geraskov
@@ -92,52 +94,57 @@ public class TestCase {
     }
 
 	@Test
-	public void testKey() throws DocumentException {
+	public void testKey() throws Exception {
 		File outputXml = 
 				new File(
 						outputDir,  
 						"org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/Search.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
-		SAXReader xmlReader =  new SAXReader();
-		xmlReader.setValidation(true);
-		Document document = xmlReader.read(outputXml);
-		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/set/key");
-		List<?> list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one key element", 1, list.size());
-		Element node = (Element) list.get(0);
-		if (node.attribute( "column" ) != null){//implied attribute
-			Assert.assertEquals(node.attribute( "column" ).getText(),"searchString");
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(outputXml);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/set/key")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one key element", 1, nodeList.getLength());
+		Element node = (Element)nodeList.item(0);
+		if (node.getAttribute( "column" ) != null && !"".equals(node.getAttribute("column"))) {//implied attribute
+			Assert.assertEquals(node.getAttribute( "column" ),"searchString");
 		} else {
-			node = node.element("column");
-			Assert.assertEquals(node.attribute( "name" ).getText(),"searchString");
+			node = (Element)node.getElementsByTagName("column").item(0);
+			Assert.assertEquals(node.getAttribute( "name" ),"searchString");
 		}
 	}
 
 	@Test
-	public void testSetElement() throws DocumentException {
+	public void testSetElement() throws Exception {
 		File outputXml = 
 				new File(
 						outputDir,  
 						"org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/Search.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
-		SAXReader xmlReader =  new SAXReader();
-		xmlReader.setValidation(true);
-		Document document = xmlReader.read(outputXml);
-		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/set");
-		List<?> list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one set element", 1, list.size());
-		Element node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute( "name" ).getText(),"searchResults");
-		Assert.assertEquals(node.attribute( "access" ).getText(),"field");
-		xpath = DocumentHelper.createXPath("//hibernate-mapping/class/set/element");
-		list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one element 'element'", 1, list.size());
-		node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute( "type" ).getText(), "string");
-		list = node.selectNodes("column");
-		Assert.assertEquals("Expected to get one element 'column'", 1, list.size());
-		node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute( "name" ).getText(), "text");
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(outputXml);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/set")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one set element", 1, nodeList.getLength());
+		Element node = (Element) nodeList.item(0);
+		Assert.assertEquals(node.getAttribute( "name" ),"searchResults");
+		Assert.assertEquals(node.getAttribute( "access" ),"field");
+		nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/set/element")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one element 'element'", 1, nodeList.getLength());
+		node = (Element) nodeList.item(0);
+		Assert.assertEquals(node.getAttribute( "type" ), "string");
+		nodeList = node.getElementsByTagName("column");
+		Assert.assertEquals("Expected to get one element 'column'", 1, nodeList.getLength());
+		node = (Element) nodeList.item(0);
+		Assert.assertEquals(node.getAttribute( "name" ), "text");
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>