### PR TITLE
HBX-2159: Remove the dependency on dom4j - Reimplement test 'org.hibernate.tool.hbm2x.hbm2hbmxml.OneToOneTest.TestCase#testOneToOne()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/TestCase.java
@@ -8,15 +8,14 @@
 package org.hibernate.tool.hbm2x.hbm2hbmxml.OneToOneTest;
 
 import java.io.File;
-import java.util.List;
 import java.util.Properties;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
-import org.dom4j.XPath;
-import org.dom4j.io.SAXReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -29,6 +28,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 
 
@@ -98,30 +100,33 @@ public class TestCase {
         Assert.assertNotNull(metadataDescriptor.createMetadata());
     }
 	
-	public void testOneToOne() throws DocumentException {
-		SAXReader xmlReader = new SAXReader();
-		xmlReader.setValidation(true);
+	public void testOneToOne() throws Exception {
 		File xmlFile = new File(
         		outputDir, 
         		"org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/Person.hbm.xml");
-		Document document = xmlReader.read(xmlFile);
-		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/one-to-one");
-		List<?> list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one-to-one element", 1, list.size());
-		Element node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute( "name" ).getText(),"address");
-		Assert.assertEquals(node.attribute( "constrained" ).getText(),"false");
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(xmlFile);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/one-to-one")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one-to-one element", 1, nodeList.getLength());
+		Element node = (Element) nodeList.item(0);
+		Assert.assertEquals(node.getAttribute( "name" ),"address");
+		Assert.assertEquals(node.getAttribute( "constrained" ),"false");
 		xmlFile = new File(
         		outputDir, 
         		"org/hibernate/tool/hbm2x/hbm2hbmxml/OneToOneTest/Address.hbm.xml");
-		document = xmlReader.read(xmlFile);
-		xpath = DocumentHelper.createXPath("//hibernate-mapping/class/one-to-one");
-		list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one set element", 1, list.size());
-		node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute( "name" ).getText(),"person");
-		Assert.assertEquals(node.attribute( "constrained" ).getText(),"true");
-		Assert.assertEquals(node.attribute( "access" ).getText(), "field");
+		document = db.parse(xmlFile);
+		nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/one-to-one")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one set element", 1, nodeList.getLength());
+		node = (Element)nodeList.item(0);
+		Assert.assertEquals(node.getAttribute( "name" ),"person");
+		Assert.assertEquals(node.getAttribute( "constrained" ),"true");
+		Assert.assertEquals(node.getAttribute( "access" ), "field");
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>