### PR TITLE
HBX-2159: Remove the dependency on dom4j - Reimplement tests 'org.hibernate.tool.hbm2x.hbm2hbmxml.IdBagTest.TestCase#testIdBagAttributes()' and 'org.hibernate.tool.hbm2x.hbm2hbmxml.IdBagTest.TestCase#testCollectionId()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
@@ -18,15 +18,14 @@ package org.hibernate.tool.hbm2x.hbm2hbmxml.IdBagTest;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
-import org.dom4j.XPath;
-import org.dom4j.io.SAXReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -39,6 +38,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * @author Dmitry Geraskov
@@ -110,47 +112,46 @@ public class TestCase {
     }
 	
 	@Test
-	public void testIdBagAttributes() {
+	public void testIdBagAttributes() throws Exception {
 		File outputXml = new File(
 				outputDir,  
 				"/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/User.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
-		SAXReader xmlReader =  new SAXReader();
-		xmlReader.setValidation(true);
-		Document document;
-		try {
-			document = xmlReader.read(outputXml);
-			XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/idbag");
-			List<?> list = xpath.selectNodes(document);
-			Assert.assertEquals("Expected to get one idbag element", 1, list.size());
-			Element node = (Element) list.get(0);
-			Assert.assertEquals(node.attribute( "table" ).getText(),"`UserGroups`");
-			Assert.assertEquals(node.attribute( "name" ).getText(),"groups");
-			Assert.assertEquals(node.attribute( "lazy" ).getText(),"false");
-			Assert.assertEquals(node.attribute( "access" ).getText(),"field");
-		} catch (DocumentException e) {
-			Assert.fail("Can't parse file " + outputXml.getAbsolutePath());
-		}		
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder  db = dbf.newDocumentBuilder();
+		Document document = db.parse(outputXml);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/idbag")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one idbag element", 1, nodeList.getLength());
+		Element node = (Element) nodeList.item(0);
+		Assert.assertEquals(node.getAttribute( "table" ),"`UserGroups`");
+		Assert.assertEquals(node.getAttribute( "name" ),"groups");
+		Assert.assertEquals(node.getAttribute( "lazy" ),"false");
+		Assert.assertEquals(node.getAttribute( "access" ),"field");
 	}
 	
 	@Test
-	public void testCollectionId() throws DocumentException {
+	public void testCollectionId() throws Exception {
 		File outputXml = new File(
 				outputDir,  
 				"/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/User.hbm.xml");
-		SAXReader xmlReader =  new SAXReader();
-		xmlReader.setValidation(true);
-		Document document = xmlReader.read(outputXml);	
-		XPath xpath = DocumentHelper.createXPath("//hibernate-mapping/class/idbag/collection-id");
-		List<?> list = xpath.selectNodes(document);
-		Assert.assertEquals("Expected to get one collection-id element", 1, list.size());
-		Element node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute( "column" ).getText(),"userGroupId");
-		Assert.assertEquals(node.attribute( "type" ).getText(),"long");
-		list = node.elements("generator");
-		Assert.assertEquals("Expected to get one generator element", 1, list.size());
-		node = (Element) list.get(0);
-		Assert.assertEquals(node.attribute( "class" ).getText(),"increment");
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document document = db.parse(outputXml);
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		NodeList nodeList = (NodeList)xpath
+				.compile("//hibernate-mapping/class/idbag/collection-id")
+				.evaluate(document, XPathConstants.NODESET);
+		Assert.assertEquals("Expected to get one collection-id element", 1, nodeList.getLength());
+		Element node = (Element) nodeList.item(0);
+		Assert.assertEquals(node.getAttribute( "column" ),"userGroupId");
+		Assert.assertEquals(node.getAttribute( "type" ),"long");
+		nodeList = node.getElementsByTagName("generator");
+		Assert.assertEquals("Expected to get one generator element", 1, nodeList.getLength());
+		node = (Element) nodeList.item(0);
+		Assert.assertEquals(node.getAttribute( "class" ),"increment");
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>