### PR TITLE
HBX-2159: Remove the dependency on dom4j - Remove dependency from module 'hibernate-tools-tests-nodb'

### DIFF
--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -38,10 +38,6 @@
 
     <dependencies>
 		<dependency>
-			<groupId>dom4j</groupId>
-			<artifactId>dom4j</artifactId>
-		</dependency>
-		<dependency>
 		    <groupId>javax</groupId>
 		    <artifactId>javaee-api</artifactId>
 		</dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>