### PR TITLE
HBX-2159: Remove the dependency on dom4j - Remove dependency from module 'hibernate-tools-tests-common'

### DIFF
--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -17,10 +17,6 @@
 
     <dependencies>
 		<dependency>
-			<groupId>dom4j</groupId>
-			<artifactId>dom4j</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
 		</dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>