### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Add JUnit Jupiter dependency to the 'hibernate-tools-parent' and 'hibernate-tools-tests-nodb' modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <jaxen.version>1.2.0</jaxen.version>
         <junit.version>4.13.2</junit.version>
+        <junit-jupiter.version>5.7.1</junit-jupiter.version>
         <mysql.version>6.0.6</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
         <sqlserver.version>9.2.1.jre8</sqlserver.version>
@@ -156,6 +157,18 @@
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
                 <version>${hsqldb.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -37,6 +37,14 @@
 		    <groupId>javax</groupId>
 		    <artifactId>javaee-api</artifactId>
 		</dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
