### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tool.hbm2x.HibernateMappingExporterTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/HibernateMappingExporterTest/TestCase.java
@@ -1,4 +1,27 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.hibernate.tool.hbm2x.HibernateMappingExporterTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -9,10 +32,8 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.hbm2x.HibernateMappingExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestCase {
 	
@@ -25,12 +46,12 @@ public class TestCase {
 			"	</class>                      "+
 			"</hibernate-mapping>             ";
 
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
+	@TempDir
+	public File outputFolder = new File("output");
+	
 	@Test
 	public void testStart() throws Exception {
-		File resources = new File(temporaryFolder.getRoot(), "resources");
+		File resources = new File(outputFolder, "resources");
 		resources.mkdir();
 		File fooHbmXmlOrigin = new File(resources, "origin.hbm.xml");
 		FileWriter writer = new FileWriter(fooHbmXmlOrigin);
@@ -41,16 +62,16 @@ public class TestCase {
 		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, new File[] { fooHbmXmlOrigin }, properties); 		
-		final File outputDir = new File(temporaryFolder.getRoot(), "output");
+		final File outputDir = new File(outputFolder, "output");
 		outputDir.mkdir();
 		HibernateMappingExporter exporter = new HibernateMappingExporter();
 		exporter.setMetadataDescriptor(metadataDescriptor);
 		exporter.setOutputDirectory(outputDir);
 		final File fooHbmXml = new File(outputDir, "Foo.hbm.xml");
-		Assert.assertFalse(fooHbmXml.exists());
+		assertFalse(fooHbmXml.exists());
 		exporter.start();
-		Assert.assertTrue(fooHbmXml.exists());
-		Assert.assertTrue(fooHbmXml.delete());
+		assertTrue(fooHbmXml.exists());
+		assertTrue(fooHbmXml.delete());
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
