### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tool.ide.completion.HqlAnalyzer.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/ide/completion/HqlAnalyzer/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/ide/completion/HqlAnalyzer/TestCase.java
@@ -1,21 +1,28 @@
 /*
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
  *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.hibernate.tool.ide.completion.HqlAnalyzer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 import java.util.List;
@@ -23,8 +30,7 @@ import java.util.List;
 import org.hibernate.tool.ide.completion.EntityNameReference;
 import org.hibernate.tool.ide.completion.HQLAnalyzer;
 import org.hibernate.tool.ide.completion.SubQuery;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author leon
@@ -119,24 +125,24 @@ public class TestCase {
     public void doTestVisibleSubQueries(String query, int size) {
     	char[] cs = query.replaceAll("\\|", "").toCharArray();
     	List<SubQuery> visible = new HQLAnalyzer().getVisibleSubQueries(cs, query.indexOf("|"));
-        Assert.assertEquals("Invalid visible query size", size, visible.size());
+        assertEquals(size, visible.size(), "Invalid visible query size");
     }
 
     private void doTestSubQueries(String query, int size) {    	
     	List<SubQuery> l = new HQLAnalyzer().getSubQueries(query.toCharArray(), 0).subQueries;
-        Assert.assertEquals("Incorrent subqueries count", size, l.size());
+        assertEquals(size, l.size(), "Incorrent subqueries count");
     }
 
     private void doTestPrefix(String query, String prefix) {
-        Assert.assertEquals(prefix, HQLAnalyzer.getEntityNamePrefix(query.toCharArray(), query.indexOf("|")));
+       assertEquals(prefix, HQLAnalyzer.getEntityNamePrefix(query.toCharArray(), query.indexOf("|")));
     }
 
     private void doTestShouldShowTables(String query, boolean expectedValue) {
         char[] ch = query.replaceAll("\\|", "").toCharArray();
 		if (expectedValue) {
-            Assert.assertTrue(new HQLAnalyzer().shouldShowEntityNames(ch, getCaretPosition(query)));
+           assertTrue(new HQLAnalyzer().shouldShowEntityNames(ch, getCaretPosition(query)));
         } else {
-            Assert.assertFalse(new HQLAnalyzer().shouldShowEntityNames(ch, getCaretPosition(query)));
+            assertFalse(new HQLAnalyzer().shouldShowEntityNames(ch, getCaretPosition(query)));
         }
     }
 
@@ -251,12 +257,12 @@ public class TestCase {
     private void doTestVisibleTables(String query, String[] types, String aliases[]) {
         char[] toCharArray = query.replaceAll("\\|", "").toCharArray();
 		List<EntityNameReference> qts = new HQLAnalyzer().getVisibleEntityNames(toCharArray, getCaretPosition(query));
-        Assert.assertEquals("Incorrect table count", types.length, qts.size());
+        assertEquals(types.length, qts.size(), "Incorrect table count");
         int i = 0;
         for (Iterator<EntityNameReference> iter = qts.iterator(); iter.hasNext();) {
 			EntityNameReference qt = iter.next();
-			Assert.assertEquals("Incorrect query table type [" + i + "]", types[i], qt.getEntityName());
-            Assert.assertEquals("Incorrect query table alias [" + i + "]", aliases[i++], qt.getAlias());
+			assertEquals(types[i], qt.getEntityName(), "Incorrect query table type [" + i + "]");
+            assertEquals(aliases[i++], qt.getAlias(), "Incorrect query table alias [" + i + "]");
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
