### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Add 'junit-jupiter-engine' and 'junit-vintage-engine' dependencies to module 'hibernate-tools-tests-utils'

### DIFF
--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -34,6 +34,14 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-tools</artifactId>
         </dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
