### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor class 'org.hibernate.tools.test.util.ResourceUtil' and test class 'org.hibernate.tools.test.util.ResourceUtilTest'

### DIFF
--- a/test/utils/src/main/java/org/hibernate/tools/test/util/JdbcUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/JdbcUtil.java
@@ -112,8 +112,7 @@ public class JdbcUtil {
 	
 	private static String[] getSqls(Object test, String scriptName) {
 		String[] result =  new String[] {};
-		String location = ResourceUtil.getResourcesLocation(test) + scriptName;
-		InputStream inputStream = test.getClass().getResourceAsStream(location);
+		InputStream inputStream = ResourceUtil.resolveResourceLocation(test.getClass(), scriptName);
 		if (inputStream != null) {
 			BufferedReader bufferedReader = 
 					new BufferedReader(new InputStreamReader(inputStream));

--- a/test/utils/src/main/java/org/hibernate/tools/test/util/ResourceUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/ResourceUtil.java
@@ -1,3 +1,22 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2017-2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tools.test.util;
 
 import java.io.File;
@@ -7,20 +26,10 @@ import java.nio.file.Files;
 
 public class ResourceUtil {
 
-	public static String getResourcesLocation(Object test) {
-		return '/' + test.getClass().getPackage().getName().replace('.', '/') + '/';
-	}
-	
 	public static void createResources(Object test, String[] resources, File resourcesDir) {
 		try {
-			String defaultResourceLocation = getResourcesLocation(test);
 			for (String resource : resources) {
-				String resourceLocation = 
-						(resource.startsWith("/")) 
-						? resource : defaultResourceLocation + resource;
-				InputStream inputStream = test
-						.getClass()
-						.getResourceAsStream(resourceLocation); 
+				InputStream inputStream = resolveResourceLocation(test.getClass(), resource);
 				File resourceFile = new File(resourcesDir, resource);
 				File parent = resourceFile.getParentFile();
 				if (!parent.exists()) {
@@ -31,6 +40,28 @@ public class ResourceUtil {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+	
+	public static InputStream resolveResourceLocation(Class<?> testClass, String resourceName) {
+		InputStream result = null;
+		if (resourceName.startsWith("/")) {
+			result = testClass.getResourceAsStream(resourceName);
+		} else {
+			result = resolveRelativeResourceLocation(testClass, resourceName);
+		}
+		return result;
+	}
+	
+	private static String getRelativeResourcesRoot(Class<?> testClass) {
+		return '/' + testClass.getPackage().getName().replace('.', '/') + '/';
+	}
+	
+	private static InputStream resolveRelativeResourceLocation(Class<?> testClass, String resourceName) {
+		InputStream result = testClass.getResourceAsStream(getRelativeResourcesRoot(testClass) + resourceName);
+		if (result == null && testClass.getSuperclass() != Object.class) {
+			result = resolveRelativeResourceLocation(testClass.getSuperclass(), resourceName);
+		}
+		return result;
 	}
 	
 }

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/ResourceUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/ResourceUtilTest.java
@@ -1,10 +1,31 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2017-2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tools.test.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -15,10 +36,14 @@ public class ResourceUtilTest {
 	public File outputFolder = new File("output");
 	
 	@Test
-	public void testGetResourcesLocation() {
-		assertEquals(
-				"/org/hibernate/tools/test/util/", 
-				ResourceUtil.getResourcesLocation(this));
+	public void testResolveResourceLocation() {
+		InputStream is = ResourceUtil.resolveResourceLocation(getClass(), "/foo");
+		assertNull(is);
+		is = ResourceUtil.resolveResourceLocation(getClass(), "/ResourceUtilTest.resource");
+		assertNotNull(is);
+		is = ResourceUtil.resolveResourceLocation(getClass(), "HelloWorld.foo.bar");
+		assertNull(is);
+		is = ResourceUtil.resolveResourceLocation(getClass(), "HelloWorld.hbm.xml");
 	}
 	
 	@Test

--- a/test/utils/src/test/resources/org/hibernate/tools/test/util/JUnitUtilTest.resource
+++ b/test/utils/src/test/resources/org/hibernate/tools/test/util/JUnitUtilTest.resource
@@ -1,1 +1,0 @@
-the file is not empty

--- a/test/utils/src/test/resources/org/hibernate/tools/test/util/hibernate.properties
+++ b/test/utils/src/test/resources/org/hibernate/tools/test/util/hibernate.properties
@@ -1,1 +1,0 @@
-hibernate.dialect org.hibernate.tools.test.util.HibernateUtil$Dialect


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
