### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -1,8 +1,28 @@
 /*
- * Created on 07-Dec-2004
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
  *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.hibernate.tool.hbm2x.GenerateFromJDBC;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.sql.SQLException;
@@ -28,12 +48,10 @@ import org.hibernate.tool.hbm2x.HibernateMappingExporter;
 import org.hibernate.tool.hbm2x.POJOExporter;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -44,23 +62,21 @@ import org.w3c.dom.NodeList;
  */
 public class TestCase {
 	
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public File outputDir = new File("output");
 	
 	private MetadataDescriptor metadataDescriptor = null;
-	private File outputDir = null;
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
-		outputDir = temporaryFolder.getRoot();
 		DefaultReverseEngineeringStrategy configurableNamingStrategy = new DefaultReverseEngineeringStrategy();
 		configurableNamingStrategy.setSettings(new ReverseEngineeringSettings(configurableNamingStrategy).setDefaultPackageName("org.reveng").setCreateCollectionForForeignKey(false));
 		metadataDescriptor = MetadataDescriptorFactory
 				.createJdbcDescriptor(configurableNamingStrategy, null, true);
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
@@ -86,15 +102,15 @@ public class TestCase {
 		exporter.start();	
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "org/reveng/Child.hbm.xml"));
 		File file = new File(outputDir, "GeneralHbmSettings.hbm.xml");
-		Assert.assertTrue(file + " should not exist", !file.exists() );
+		assertTrue(!file.exists(), file + " should not exist" );
 		File[] files = new File[2];
 		files[0] = new File(outputDir, "org/reveng/Child.hbm.xml");
 		files[1] = new File(outputDir, "org/reveng/Master.hbm.xml");
 		Metadata metadata = MetadataDescriptorFactory
 				.createNativeDescriptor(null, files, null)
 				.createMetadata();
-		Assert.assertNotNull(metadata.getEntityBinding("org.reveng.Child") );
-		Assert.assertNotNull(metadata.getEntityBinding("org.reveng.Master") );
+		assertNotNull(metadata.getEntityBinding("org.reveng.Child") );
+		assertNotNull(metadata.getEntityBinding("org.reveng.Master") );
 	}
 	
 	@Test
@@ -116,11 +132,11 @@ public class TestCase {
 		for (int i = 0; i < nodeList.getLength(); i++) {
 			elements[i] = (Node)nodeList.item(i);
 		}
-		Assert.assertEquals(2, elements.length);
+		assertEquals(2, elements.length);
 		for (int i = 0; i < elements.length; i++) {
 			Node element = elements[i];
-			Assert.assertNotNull(element.getAttributes().getNamedItem("resource"));
-			Assert.assertNull(element.getAttributes().getNamedItem("class"));
+			assertNotNull(element.getAttributes().getNamedItem("resource"));
+			assertNull(element.getAttributes().getNamedItem("class"));
 		}		
 	}
 	
@@ -145,11 +161,11 @@ public class TestCase {
 		for (int i = 0; i < nodeList.getLength(); i++) {
 			elements[i] = (Node)nodeList.item(i);
 		}
-		Assert.assertEquals(2, elements.length);
+		assertEquals(2, elements.length);
 		for (int i = 0; i < elements.length; i++) {
 			Node element = elements[i];
-			Assert.assertNull(element.getAttributes().getNamedItem("resource"));
-			Assert.assertNotNull(element.getAttributes().getNamedItem("class"));
+			assertNull(element.getAttributes().getNamedItem("resource"));
+			assertNotNull(element.getAttributes().getNamedItem("class"));
 		}		
 	}
 	
@@ -170,7 +186,7 @@ public class TestCase {
 				.iterator();
 		while (iter.hasNext() ) {
 			PersistentClass element = iter.next();
-			Assert.assertEquals("org.reveng", StringHelper.qualifier(element.getClassName() ) );
+			assertEquals("org.reveng", StringHelper.qualifier(element.getClassName() ) );
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
