### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Rename 'orghibernate.tool.test.db.h2.TestSuiteJupiter' to 'org.hibernate.tool.test.db.h2.TestSuite'

### DIFF
--- a/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
+++ b/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
@@ -22,7 +22,7 @@ package org.hibernate.tool.test.db.h2;
 import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
-public class TestSuiteJupiter {
+public class TestSuite {
 	
 	@Nested
 	public class H2TestSuite extends DbTestSuite {}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
