### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Create test suite 'org.hibernate.tool.test.db.oracle.TestSuiteJupiter' incorporating the common database tests for Oracle

### DIFF
--- a/test/oracle/pom.xml
+++ b/test/oracle/pom.xml
@@ -28,6 +28,14 @@
     		<groupId>org.hibernate</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
-    </dependencies>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
+     </dependencies>
     
 </project>

--- a/test/oracle/src/test/java/org/hibernate/tool/test/db/oracle/TestSuiteJupiter.java
+++ b/test/oracle/src/test/java/org/hibernate/tool/test/db/oracle/TestSuiteJupiter.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hibernate.tool.test.db.oracle;
+
+import org.hibernate.tool.test.db.DbTestSuite;
+import org.junit.jupiter.api.Nested;
+
+public class TestSuiteJupiter {
+	
+	@Nested
+	public class OracleTestSuite extends DbTestSuite {}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
