### PR TITLE
HBX-2190: Make the tests run with the Oracle database - Update 'readme.txt' for use with the Oracle 12c Docker image

### DIFF
--- a/test/oracle/readme.txt
+++ b/test/oracle/readme.txt
@@ -6,29 +6,28 @@ To do this on your own machine execute the following steps:
 
 1. Install Docker.
 
-2. Pull the Docker image of the Oracle DB: 'docker pull sath89/oracle-12c'
+2. Pull the Docker image of the Oracle DB: 'docker pull store/oracle/database-enterprise:12.2.0.1-slim'
 
-3. Start the database: 'docker run -d -p 8080:8080 -p 1521:1521 sath89/oracle-12c'. 
+3. Start the database: 'docker run --name oracle -d -p 1521:1521 store/oracle/database-enterprise:12.2.0.1-slim'. 
 This step takes a while the first time. Use 'docker logs' and specify the id of your docker container
 to monitor the progress. When the logs say 'Database is ready to use' you can move to 
 step 4.
 
-4. Connect to the database using your favorite client (e.g. DBeaver: http://dbeaver.jkiss.org)
+4. Connect to the database: 'docker exec -it oracle bash -c "source /home/oracle/.bashrc; sqlplus sys/Oradoc_db1@ORCLPDB1 as sysdba"'
+Alternatively you can use your favorite database client (e.g. DBeaver: http://dbeaver.jkiss.org)
 hostname: localhost
 port: 1521
-service name: xe.oracle.docker
-username: system
-password: oracle
-The complete JDBC URL is: jdbc:oracle:thin:@//localhost:1521/xe.oracle.docker
+service name: ORCLPDB1.localdomain
+username: SYS
+password: Oradoc_db1
+role: SYSDBA
+The complete JDBC URL is: jdbc:oracle:thin:@//localhost:1521/ORCLPDB1.localdomain
 
 5. Create the Hibernate Tools test ('HTT') database. You can do this by executing the following SQL: 
-
-create user HTT
-       identified by HTT
-       default tablespace USERS
-       temporary tablespace TEMP
-       quota unlimited on USERS;
+create user HTT identified by HTT;
 grant all privileges to HTT with admin option;
 
 6. You can now connect with username 'HTT' and password 'HTT' and verify the existence of the 'HTT' schema.
 If that is the case you are ready to run the tests. 
+
+7. Run only the Oracle tests using the 'oracle' profile: mvn clean test -P oracle


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
