### PR TITLE
HBX-2190: Make the tests run with the Oracle database - Update 'hibernate.properties' with the new Oracle service name

### DIFF
--- a/test/oracle/src/test/resources/hibernate.properties
+++ b/test/oracle/src/test/resources/hibernate.properties
@@ -2,6 +2,6 @@ hibernate.dialect org.hibernate.dialect.Oracle12cDialect
 hibernate.connection.driver_class oracle.jdbc.driver.OracleDriver
 hibernate.connection.username HTT
 hibernate.connection.password HTT
-hibernate.connection.url jdbc:oracle:thin:@//localhost:1521/xe.oracle.docker
+hibernate.connection.url jdbc:oracle:thin:@//localhost:1521/ORCLPDB1.localdomain
 
 hibernate.default_schema HTT


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
