### PR TITLE
HBX-2190: Make the tests run with the Oracle database - Fix test class 'org.hibernate.tool.jdbc2cfg.Versioning.TestCase' (versions in Oracle are of type BigIntegerType)

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Versioning/TestCase.java
@@ -34,7 +34,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.hbm2x.Exporter;
 import org.hibernate.tool.hbm2x.HibernateMappingExporter;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.hibernate.type.BigDecimalType;
+import org.hibernate.type.BigIntegerType;
 import org.hibernate.type.IntegerType;
 import org.hibernate.type.RowVersionType;
 import org.hibernate.type.TimestampType;
@@ -117,7 +117,7 @@ public class TestCase {
 		assertNotNull(version);
 		assertTrue(
 				version.getType() instanceof IntegerType ||
-				version.getType() instanceof BigDecimalType); // on Oracle
+				version.getType() instanceof BigIntegerType); // on Oracle
 	}
     
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
