### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tool.jdbc2cfg.Identity.TestCaase' for mssql

### DIFF
--- a/test/mssql/src/test/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/mssql/src/test/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -4,6 +4,9 @@
  */
 package org.hibernate.tool.jdbc2cfg.Identity;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.sql.SQLException;
 
 import org.hibernate.boot.Metadata;
@@ -11,11 +14,10 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tools.test.util.JdbcUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author max
@@ -25,7 +27,7 @@ public class TestCase {
 
 	private Metadata metadata = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		JdbcUtil.createDatabase(this);
 		MetadataDescriptorFactory
@@ -33,18 +35,18 @@ public class TestCase {
 			.createMetadata();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
 
 	// TODO HBX-1413: Enable the test below
-	@Ignore 
+	@Disabled
 	@Test
 	public void testIdentity() throws SQLException {
 		PersistentClass classMapping = metadata.getEntityBinding("WithIdentity");
-		Assert.assertNotNull(classMapping);
-		Assert.assertEquals(
+		assertNotNull(classMapping);
+		assertEquals(
 				"identity", 
 				((SimpleValue)classMapping
 						.getIdentifierProperty()
@@ -53,12 +55,12 @@ public class TestCase {
 	}
 	
 	// TODO HBX-1413: Enable the test below
-	@Ignore 
+	@Disabled
 	@Test
 	public void testGuid() throws SQLException {
 		PersistentClass classMapping = metadata.getEntityBinding("WithGuid");
-		Assert.assertNotNull(classMapping);
-		Assert.assertEquals(
+		assertNotNull(classMapping);
+		assertEquals(
 				"guid", 
 				((SimpleValue)classMapping
 						.getIdentifierProperty()


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
