### PR TITLE
HBX-2203: Investigate and reenable the disabled tests after updating ORM dependency to 6.0.0.Alpha9 - Reenable 'org.hibernate.tool.jdbc2cfg.KeyPropertyCompositeId#testKeyProperty()

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -146,7 +146,6 @@ public class TestCase {
 		assertFalse(extraId.getValue() instanceof ManyToOne);
 	}
 
-	@Disabled
 	@Test
 	public void testKeyProperty() {
 		PersistentClass product = metadataDescriptor.createMetadata().getEntityBinding(
@@ -157,8 +156,13 @@ public class TestCase {
 		Component cmpid = (Component) identifierProperty.getValue();
 		assertEquals(2, cmpid.getPropertySpan());
 		Iterator<?> iter = cmpid.getPropertyIterator();
-		Property id = (Property) iter.next();
-		Property extraId = (Property) iter.next();
+		Property id = (Property)iter.next();
+		Property extraId = (Property)iter.next();
+		if ("extraId".equals(id.getName())) {
+			Property temp = id;
+			id = extraId;
+			extraId = temp;
+		}
 		assertEquals(
 				reverseEngineeringStrategy.columnToPropertyName(
 						null, 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
