### PR TITLE
Fixed HBX-2220: Fixed typo in PojoEqualsHashcode.ftl

### DIFF
--- a/orm/src/main/resources/pojo/PojoEqualsHashcode.ftl
+++ b/orm/src/main/resources/pojo/PojoEqualsHashcode.ftl
@@ -1,5 +1,5 @@
 <#if pojo.needsEqualsHashCode() && !clazz.superclass?exists>
-<#assign classNameToCastTo><#if clazz.getProxyInterfaceName?exists>${clazz.getProxyInterfaceName()}<#else>${pojo.getDeclarationName()}</#if></#assign>
+<#assign classNameToCastTo><#if clazz.getProxyInterfaceName()?exists>${clazz.getProxyInterfaceName()}<#else>${pojo.getDeclarationName()}</#if></#assign>
    public boolean equals(Object other) {
          if ( (this == other ) ) return true;
 		 if ( (other == null ) ) return false;


### PR DESCRIPTION
Presence of meta attribute="use-in-tostring" in hibernate-mapping XML file causes "SEVERE: Error executing FreeMarker template" due to a typo. Fixed the typo.