### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependencies on 'junit' and 'junit-vintage-engine' from 'test/common'

### DIFF
--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -16,10 +16,6 @@
     <name>Hibernate Tools Common Database Tests Project</name>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
 		<dependency>
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
@@ -36,10 +32,6 @@
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		    <scope>compile</scope>
-		</dependency>
-		<dependency>
-		    <groupId>org.junit.vintage</groupId>
-		    <artifactId>junit-vintage-engine</artifactId>
 		</dependency>
     </dependencies>
     


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
