### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependencies on 'junit' and 'junit-vintage-engine' from 'test/mssql'

### DIFF
--- a/test/mssql/pom.xml
+++ b/test/mssql/pom.xml
@@ -17,10 +17,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
@@ -31,10 +27,6 @@
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
-		</dependency>
-		<dependency>
-		    <groupId>org.junit.vintage</groupId>
-		    <artifactId>junit-vintage-engine</artifactId>
 		</dependency>
     </dependencies>
     


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
