### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use class 'org.hibernate.tools.test.util.DummyConnectionProvider' as connection provider property in 'org.hibernate.tools.test.util.HibernateUtil'

### DIFF
--- a/test/utils/src/main/java/org/hibernate/tools/test/util/HibernateUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/HibernateUtil.java
@@ -79,6 +79,7 @@ public class HibernateUtil {
 		}
 		Properties properties = new Properties();
 		properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, DummyConnectionProvider.class.getName());
 		return MetadataDescriptorFactory.createNativeDescriptor(null, hbmFiles, properties);
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
