### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use class 'org.hibernate.tools.test.util.DummyConnectionProvider' as connection provider property in 'org.hibernate.tools.test.util.HibernateUtilTest'

### DIFF
--- a/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
@@ -76,6 +76,7 @@ public class HibernateUtilTest {
 	public void testAddAnnotatedClass() {
 		Properties properties = new Properties();
 		properties.setProperty(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, DummyConnectionProvider.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, null, properties);
 		assertNull(metadataDescriptor


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
