### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Add test 'HibernateUtilTest#testConnectionProviderInstantiation()' and inner class 'HibernateUtil.ConnectionProvider'

### DIFF
--- a/test/utils/src/main/java/org/hibernate/tools/test/util/HibernateUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/HibernateUtil.java
@@ -31,16 +31,19 @@ import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tools.test.util.internal.ConnectionProvider;
 
 public class HibernateUtil {
 	
 	public static class Dialect extends org.hibernate.dialect.Dialect {
 		@Override
 		public int getVersion() {
-			// TODO Auto-generated method stub
 			return 0;
 		}
+	}
+	
+	public static class ConnectionProvider 
+			extends org.hibernate.tools.test.util.internal.ConnectionProvider {
+		private static final long serialVersionUID = 1L;
 	}
 	
 	public static ForeignKey getForeignKey(Table table, String fkName) {

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
@@ -60,6 +60,11 @@ public class HibernateUtilTest {
 	}
 	
 	@Test
+	public void testConnectionProviderInstantiation() {
+		assertNotNull(new HibernateUtil.ConnectionProvider());
+	}
+	
+	@Test
 	public void testInitializeConfiguration() {
 		Metadata metadata = HibernateUtil
 				.initializeMetadataDescriptor(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
