### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'HibernateUtil.ConnectionPovider' as the connection povider in 'HibernateUtilTest'

### DIFF
--- a/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
@@ -35,7 +35,6 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.hibernate.tools.test.util.internal.ConnectionProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -82,7 +81,7 @@ public class HibernateUtilTest {
 	public void testAddAnnotatedClass() {
 		Properties properties = new Properties();
 		properties.setProperty(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
-		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, ConnectionProvider.class.getName());
+		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, null, properties);
 		assertNull(metadataDescriptor


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
