### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Rename class 'org.hibernate.tools.test.util.DummyConnectionProvider' to 'org.hibernate.tools.test.util.internal.ConnectionProvider'

### DIFF
--- a/test/utils/src/main/java/org/hibernate/tools/test/util/internal/ConnectionProvider.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/internal/ConnectionProvider.java
@@ -1,4 +1,4 @@
-package org.hibernate.tools.test.util;
+package org.hibernate.tools.test.util.internal;
 
 import java.sql.Array;
 import java.sql.Blob;
@@ -21,7 +21,7 @@ import java.util.concurrent.Executor;
 
 import org.hibernate.engine.jdbc.connections.internal.UserSuppliedConnectionProviderImpl;
 
-public class DummyConnectionProvider extends UserSuppliedConnectionProviderImpl {
+public class ConnectionProvider extends UserSuppliedConnectionProviderImpl {
 	
 	private static final long serialVersionUID = 1L;
 	

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
@@ -35,6 +35,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tools.test.util.internal.ConnectionProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -75,7 +76,8 @@ public class HibernateUtilTest {
 	@Test
 	public void testAddAnnotatedClass() {
 		Properties properties = new Properties();
-		properties.setProperty(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.put(AvailableSettings.CONNECTION_PROVIDER, ConnectionProvider.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, null, properties);
 		assertNull(metadataDescriptor

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/internal/ConnectionProviderTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/internal/ConnectionProviderTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tools.test.util;
+package org.hibernate.tools.test.util.internal;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.junit.jupiter.api.Test;
 
-public class DummyConnectionProviderTest {
+public class ConnectionProviderTest {
 	
-	private ConnectionProvider connectionProvider = new DummyConnectionProvider();
+	private ConnectionProvider connectionProvider = new org.hibernate.tools.test.util.internal.ConnectionProvider();
 	
 	@Test
 	public void testGetConnection() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
