### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Add test 'HibernateUtilTest#testConnectionProviderInstantiation()' and make inner class 'HibernateUtil.ConnectionProvider' a subclass of 'org.hibernate.tools.test.util.internal.ConnectionProvider'

### DIFF
--- a/test/utils/src/main/java/org/hibernate/tools/test/util/HibernateUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/HibernateUtil.java
@@ -2,16 +2,12 @@ package org.hibernate.tools.test.util;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.engine.jdbc.connections.internal.UserSuppliedConnectionProviderImpl;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
@@ -21,16 +17,11 @@ public class HibernateUtil {
 	
 	public static class Dialect extends org.hibernate.dialect.Dialect {}
 	
-	public static class ConnectionProvider extends UserSuppliedConnectionProviderImpl {
+	public static class ConnectionProvider 
+			extends org.hibernate.tools.test.util.internal.ConnectionProvider {
 		private static final long serialVersionUID = 1L;
-		@Override
-		public Connection getConnection() throws SQLException {
-			return DATABASE_META_DATA.getConnection();
-		}
-		@Override
-		public void closeConnection(Connection conn) throws SQLException {}
 	}
-	
+
 	public static ForeignKey getForeignKey(Table table, String fkName) {
 		ForeignKey result = null;
 		Iterator<?> iter = table.getForeignKeyIterator();
@@ -87,7 +78,5 @@ public class HibernateUtil {
 			throw new RuntimeException(e);
 		}
 	}
-	
-	private static DatabaseMetaData DATABASE_META_DATA = new DummyDatabaseMetadata();
 	
 }

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
@@ -60,6 +60,11 @@ public class HibernateUtilTest {
 	}
 	
 	@Test
+	public void testConnectionProviderInstantiation() {
+		assertNotNull(new HibernateUtil.ConnectionProvider());
+	}
+	
+	@Test
 	public void testInitializeConfiguration() {
 		Metadata metadata = HibernateUtil
 				.initializeMetadataDescriptor(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
