### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'HibernateUtil.ConnectionPovider' as the connection povider in 'org.hibernate.tool.hbm2x.DocExporterTest'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
@@ -88,6 +88,7 @@ public class TestCase {
 		Properties properties = new Properties();
 		properties.put( "jdk5", "true"); // test generics
 		properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.put(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 		if(File.pathSeparator.equals(";")) { // to work around windows/jvm not seeming to respect executing just "dot"
 			properties.put("dot.executable", System.getProperties().getProperty("dot.executable","dot.exe"));
 		} else {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
