### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'HibernateUtil.ConnectionPovider' as the connection povider in 'org.hibernate.tool.hbm2x.Hbm2CfgTest'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/Hbm2CfgTest/TestCase.java
@@ -79,11 +79,12 @@ public class TestCase {
 	public void testMagicPropertyHandling() {
 	   Exporter exporter = ExporterFactory.createExporter(ExporterType.CFG);
 	   Properties properties = exporter.getProperties();
-	   properties.setProperty( "hibernate.basic", "aValue" );
-	   properties.setProperty( Environment.SESSION_FACTORY_NAME, "shouldNotShowUp");
-	   properties.setProperty( Environment.HBM2DDL_AUTO, "false");
-	   properties.setProperty( "hibernate.temp.use_jdbc_metadata_defaults", "false");	   
-	   properties.setProperty("hibernate.dialect", HibernateUtil.Dialect.class.getName());
+	   properties.put( "hibernate.basic", "aValue" );
+	   properties.put(AvailableSettings.SESSION_FACTORY_NAME, "shouldNotShowUp");
+	   properties.put(AvailableSettings.HBM2DDL_AUTO, "false");
+	   properties.put( "hibernate.temp.use_jdbc_metadata_defaults", "false");	   
+	   properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+	   properties.put(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 	   exporter.getProperties().put(
 			   ExporterConstants.METADATA_DESCRIPTOR, 
 			   MetadataDescriptorFactory.createNativeDescriptor(null, null, properties));
@@ -101,8 +102,9 @@ public class TestCase {
 			   FileUtil.findFirstString("hibernate.temp.use_jdbc_metadata_defaults", file ));
 	   exporter = ExporterFactory.createExporter(ExporterType.CFG);
 	   properties = exporter.getProperties();
-	   properties.setProperty( Environment.HBM2DDL_AUTO, "validator");   
-	   properties.setProperty("hibernate.dialect", HibernateUtil.Dialect.class.getName());
+	   properties.put( Environment.HBM2DDL_AUTO, "validator");   
+	   properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+	   properties.put(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 	   exporter.getProperties().put(
 			   ExporterConstants.METADATA_DESCRIPTOR, 
 			   MetadataDescriptorFactory.createNativeDescriptor(null, null, properties));
@@ -112,8 +114,9 @@ public class TestCase {
 			   FileUtil.findFirstString( Environment.HBM2DDL_AUTO, file ));
 	   exporter = ExporterFactory.createExporter(ExporterType.CFG);
 	   properties = exporter.getProperties();
-	   properties.setProperty( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "org.hibernate.console.FakeTransactionManagerLookup"); // Hack for seam-gen console configurations
-	   properties.setProperty("hibernate.dialect", HibernateUtil.Dialect.class.getName());
+	   properties.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "org.hibernate.console.FakeTransactionManagerLookup"); // Hack for seam-gen console configurations
+	   properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+	   properties.put(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 	   exporter.getProperties().put(
 			   ExporterConstants.METADATA_DESCRIPTOR, 
 			   MetadataDescriptorFactory.createNativeDescriptor(null, null, properties));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
