### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Some cleanup in 'org.hibernate.tool.hbm2x.OtherCfg2HbmTest'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/TestCase.java
@@ -95,7 +95,7 @@ public class TestCase {
     public void testReadable() {
 		Properties properties = new Properties();
 		properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
-		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
+		properties.put(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
         File[] hbmFiles = new File[4];
         hbmFiles[0] = new File(srcDir, "org/hibernate/tool/hbm2x/Customer.hbm.xml");
         hbmFiles[1] = new File(srcDir, "org/hibernate/tool/hbm2x/LineItem.hbm.xml");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
