### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Some cleanup in 'org.hibernate.tool.hbm2x.CompositeElementTest'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/CompositeElementTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/CompositeElementTest/TestCase.java
@@ -100,8 +100,8 @@ public class TestCase {
         		srcDir, 
         		"org/hibernate/tool/hbm2x/hbm2hbmxml/CompositeElementTest/Glarch.hbm.xml"));
 		Properties properties = new Properties();
-		properties.setProperty(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
-		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
+		properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.put(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, files.toArray(new File[2]), properties);
         assertNotNull(metadataDescriptor.createMetadata());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
