### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'HibernateUtil.ConnectionPovider' as the connection povider in 'org.hibernate.tool.hbm2x.hbm2hbmxml.JoinTest'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/TestCase.java
@@ -78,7 +78,8 @@ public class TestCase {
         		srcDir, 
         		"/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Child.hbm.xml"));
 		Properties properties = new Properties();
-		properties.setProperty(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.put(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, files.toArray(new File[2]), properties);
         assertNotNull(metadataDescriptor.createMetadata());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
