### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'HibernateUtil.ConnectionPovider' as the connection povider in 'org.hibernate.tool.ide.completion.ModelCompletion'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/ide/completion/ModelCompletion/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/ide/completion/ModelCompletion/TestCase.java
@@ -679,7 +679,8 @@ public class TestCase {
     
     private Metadata buildMetadata() {
      	StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
-    		ssrb.applySetting(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+    	ssrb.applySetting(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+    	ssrb.applySetting(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
        	MetadataSources metadataSources = new MetadataSources()
        		.addInputStream(getClass().getResourceAsStream("Product.hbm.xml"))
        		.addInputStream(getClass().getResourceAsStream("Store.hbm.xml"))


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
