### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'org.hibernate.tools.test.util.HibernateUtil' as the connection povider and 'org.hibernate.tools.test.util.HibernateUtil' as the dialect in 'org.hibernate.tool.ant.Exception'

### DIFF
--- a/test/nodb/src/test/resources/org/hibernate/tool/ant/Exception/hibernate.properties
+++ b/test/nodb/src/test/resources/org/hibernate/tool/ant/Exception/hibernate.properties
@@ -1,1 +1,2 @@
-hibernate.dialect org.hibernate.dialect.H2Dialect
+hibernate.dialect org.hibernate.tools.test.util.HibernateUtil$Dialect
+hibernate.connection.provider_class org.hibernate.tools.test.util.HibernateUtil$ConnectionProvider


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
