### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'org.hibernate.tools.test.util.HibernateUtil' as the connection povider and 'org.hibernate.tools.test.util.HibernateUtil' as the dialect in 'org.hibernate.tool.ant.NoConnInfoExport'

### DIFF
--- a/test/nodb/src/test/resources/org/hibernate/tool/ant/NoConnInfoExport/hibernate.cfg.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/ant/NoConnInfoExport/hibernate.cfg.xml
@@ -5,6 +5,7 @@
 <hibernate-configuration>
    <session-factory name="context">
         <property name="hibernate.connection.driver_class">org.h2.Driver</property>
-        <property name="hibernate.dialect">org.hibernate.dialect.H2Dialect</property>
+        <property name="hibernate.dialect">org.hibernate.tools.test.util.HibernateUtil$Dialect</property>
+        <property name="hibernate.connection.provider_class">org.hibernate.tools.test.util.HibernateUtil$ConnectionProvider</property>
     </session-factory>
 </hibernate-configuration>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
