### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'org.hibernate.tools.test.util.HibernateUtil' as the connection povider and 'org.hibernate.tools.test.util.HibernateUtil' as the dialect in 'org.hibernate.tool.ant.fresh.ExportCfgTask'

### DIFF
--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -47,6 +47,11 @@
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.hibernate.tool</groupId>
+			<artifactId>hibernate-tools-tests-utils</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/ant/src/test/java/org/hibernate/tool/ant/fresh/ExportCfgTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/fresh/ExportCfgTaskTest.java
@@ -31,11 +31,11 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 import org.apache.tools.ant.types.Environment.Variable;
-import org.hibernate.tool.ant.fresh.ExportCfgTask;
-import org.hibernate.tool.ant.fresh.HibernateToolTask;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tools.test.util.HibernateUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -55,7 +55,8 @@ public class ExportCfgTaskTest {
 	public void testExecute() throws Exception {
 		ExportCfgTask ect = new ExportCfgTask(null);
 		Properties properties = new Properties();
-		properties.put("hibernate.dialect", "H2");
+		properties.put(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
+		properties.put(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 		MetadataDescriptor mdd = MetadataDescriptorFactory.createNativeDescriptor(
 				null, 
 				new File[] {}, 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
