### PR TITLE
HBX-2182: Review and adapt the tests to remove the stack traces caused by the dialect and/or connection not being specified - Use 'org.hibernate.tools.test.util.HibernateUtil' as the connection povider and 'org.hibernate.tools.test.util.HibernateUtil' as the dialect in 'org.hibernate.tool.ant.it.NativeMetadataCfgTest'

### DIFF
--- a/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataCfgTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/test/it/NativeMetadataCfgTest.java
@@ -27,7 +27,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.tools.ant.Project;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.tool.ant.test.util.ProjectUtil;
+import org.hibernate.tools.test.util.HibernateUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -56,7 +58,10 @@ public class NativeMetadataCfgTest {
 	}
 	
 	private File createPropertyFile() throws Exception {
-		String propertyString = "hibernate.dialect=H2";
+		String propertyString = AvailableSettings.DIALECT + " ";
+		propertyString += HibernateUtil.Dialect.class.getName() + "\n";
+		propertyString += AvailableSettings.CONNECTION_PROVIDER + " ";
+		propertyString += HibernateUtil.ConnectionProvider.class.getName() + "\n";
 		File result = new File(tempDir.toFile(), "hibernate.properties");
 		Files.write(result.toPath(), propertyString.getBytes());
 		return result;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
