### PR TITLE
HBX-2229: Remove the dependency on 'com.microsoft.sqlserver.mssql-jdbc' from module 'org.hibernate.tool.hibernate-tools-tests-utils'

### DIFF
--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -41,10 +41,6 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
-         <dependency>
-            <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>mssql-jdbc</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.hibernate.tool</groupId>
             <artifactId>hibernate-tools-orm</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
