### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove unneeded dependency on 'org.junit.jupiter.junit-jupiter-api' from module 'ant' + some cleanup

### DIFF
--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -41,10 +41,6 @@
 		</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
 		<dependency>

--- a/ant/src/test/java/org/hibernate/tool/ant/fresh/HibernateToolTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/fresh/HibernateToolTaskTest.java
@@ -26,10 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.tool.ant.fresh.ExportCfgTask;
-import org.hibernate.tool.ant.fresh.ExportDdlTask;
-import org.hibernate.tool.ant.fresh.HibernateToolTask;
-import org.hibernate.tool.ant.fresh.MetadataTask;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.junit.jupiter.api.Test;

--- a/ant/src/test/java/org/hibernate/tool/ant/fresh/MetadataTaskTest.java
+++ b/ant/src/test/java/org/hibernate/tool/ant/fresh/MetadataTaskTest.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.selectors.FilenameSelector;
-import org.hibernate.tool.ant.fresh.MetadataTask;
 import org.hibernate.tool.ant.fresh.MetadataTask.Type;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
