### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove unneeded dependency on 'org.junit.jupiter.junit-jupiter-api' from module 'orm' + some cleanup

### DIFF
--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -78,10 +78,6 @@
 		</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
 	</dependencies>

--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
@@ -115,13 +115,6 @@ public final class DocHelper {
 	
 	private Metadata metadata;
 
-	/**
-	 * Constructor.
-	 * 
-	 * @param cfg
-	 *            Hibernate configuration.
-	 */
-	@SuppressWarnings("unchecked")
 	public DocHelper(Metadata metadata, Properties properties, Cfg2JavaTool cfg2JavaTool) {
 
 		super();

--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/ComponentPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/ComponentPOJOClass.java
@@ -72,7 +72,6 @@ public class ComponentPOJOClass extends BasicPOJOClass {
 		}
 	}
 	
-	@SuppressWarnings("unchecked")
 	public Iterator<Property> getAllPropertiesIterator() {
 		return clazz.getPropertyIterator();
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
@@ -335,7 +335,6 @@ public class EntityPOJOClass extends BasicPOJOClass {
 		return propertyValue != null && propertyValue.equals( defaultValue );
 	}
 
-	@SuppressWarnings("unchecked")
 	public String generateJoinColumnsAnnotation(Property property, Metadata md) {
 		boolean insertable = property.isInsertable();
 		boolean updatable = property.isUpdateable();

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
@@ -57,7 +57,6 @@ public class BinderUtils {
         return BinderUtils.makeUnique(iterator, propertyName);
     }
  
-    @SuppressWarnings("unchecked")
 	public static String makeUnique(Component clazz, String propertyName) {
         return BinderUtils.makeUnique(clazz.getPropertyIterator(), propertyName);
     }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
