### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove unneeded dependency on 'org.junit.jupiter.junit-jupiter-api' from 'test/nodb'

### DIFF
--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -59,10 +59,6 @@
     	</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
     </dependencies>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
