### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove unneeded dependency on 'org.junit.jupiter.junit-jupiter-api' from 'utils'

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -33,10 +33,6 @@
 	<dependencies>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
