### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove remaining dependencies on 'org.junit.jupiter.junit-jupiter-api'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,12 +213,6 @@
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit-jupiter.version}</version>
                 <scope>test</scope>

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -20,12 +20,7 @@
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
 		</dependency>
-		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-api</artifactId>
-		    <scope>compile</scope>
-		</dependency>
-    	<dependency>
+	   	<dependency>
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-orm</artifactId>
     	</dependency>
@@ -33,6 +28,11 @@
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-tests-utils</artifactId>
      	</dependency>
-    </dependencies>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
+		    <scope>compile</scope>
+		</dependency>
+     </dependencies>
     
 </project>

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -47,12 +47,8 @@
         </dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-api</artifactId>
-		    <scope>compile</scope>
-		</dependency>
-		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
+		    <scope>compile</scope>
 		</dependency>
     </dependencies>
     


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
