### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependencies on 'junit.junit' and 'org.junit.vintage.junit-vintage-engine' from parent module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <javaee-api.version>8.0.1</javaee-api.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <jaxen.version>1.2.0</jaxen.version>
-        <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.7.2</junit-jupiter.version>
         <mysql.version>8.0.22</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
@@ -108,11 +107,6 @@
                 <scope>runtime</scope>
             </dependency> 
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql.version}</version>
@@ -162,12 +156,6 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
                 <version>${junit-jupiter.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
