### PR TITLE
HBX-2234: Change the Maven coordinates for 'hibernate-core' from 'org.hibernate' to 'org.hibernate.orm'

### DIFF
--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -65,7 +65,7 @@
 			<artifactId>freemarker</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.hibernate</groupId>
+			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-core</artifactId>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
 			    <version>${freemarker.version}</version>
 		    </dependency>
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-core</artifactId>
                 <version>${hibernate-core.version}</version>
             </dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
