### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependency on 'junit.junit'

### DIFF
--- a/test/oracle/pom.xml
+++ b/test/oracle/pom.xml
@@ -17,10 +17,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>ojdbc8</artifactId>
         </dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
