### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependency on 'org.junit.vintage.junit-vintage-engine' from 'test/oracle'

### DIFF
--- a/test/oracle/pom.xml
+++ b/test/oracle/pom.xml
@@ -28,10 +28,6 @@
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
-		<dependency>
-		    <groupId>org.junit.vintage</groupId>
-		    <artifactId>junit-vintage-engine</artifactId>
-		</dependency>
      </dependencies>
     
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
