### PR TITLE
HBX-2241: Remove unused functionality that uses Hibernate Core classes that have been removed in 6.0.0.Beta1 - Remove 'org.hibernate.tool.internal.export.hbm.Cfg2HbmTool#getNamedSQLReturnTag(NativeSQLQueryReturn)'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -291,17 +291,6 @@ public class Cfg2HbmTool {
 		return value.isExtraLazy() ? "extra" : Boolean.toString(value.isLazy());
 	}
 
-	public String getNamedSQLReturnTag(NativeSQLQueryReturn sqlret) {
-		String retVal = "return";
-		if (isNamedSQLReturnRole(sqlret) ) {
-			retVal = "return-join";
-		}
-		else if (isNamedSQLReturnCollection(sqlret) ) {
-			retVal = "load-collection";
-		}
-		return retVal;
-	}
-
 	public String getNamedSQLReturnProperty(NativeSQLQueryJoinReturn o) {
 		/*if(o instanceof NativeSQLQueryCollectionReturn) {
 			return ((NativeSQLQueryCollectionReturn)o).getOwnerEntityName() + "." + ((NativeSQLQueryCollectionReturn)o).getOwnerProperty();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
