### PR TITLE
HBX-2241: Remove unused functionality that uses Hibernate Core classes that have been removed in 6.0.0.Beta1 - Remove 'org.hibernate.tool.internal.export.hbm.Cfg2HbmTool#getNamedSQLReturnProperty(NativeSQLQueryJoinReturn)'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -291,13 +291,6 @@ public class Cfg2HbmTool {
 		return value.isExtraLazy() ? "extra" : Boolean.toString(value.isLazy());
 	}
 
-	public String getNamedSQLReturnProperty(NativeSQLQueryJoinReturn o) {
-		/*if(o instanceof NativeSQLQueryCollectionReturn) {
-			return ((NativeSQLQueryCollectionReturn)o).getOwnerEntityName() + "." + ((NativeSQLQueryCollectionReturn)o).getOwnerProperty();
-		}*/
-		return o.getOwnerAlias() + "." + o.getOwnerProperty();
-	}
-
 	public String getNamedSQLReturnRole(NativeSQLQueryCollectionReturn o) {
 		return o.getOwnerEntityName() + "." + o.getOwnerProperty();
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
