### PR TITLE
HBX-2241: Remove unused functionality that uses Hibernate Core classes that have been removed in 6.0.0.Beta1 - Remove 'org.hibernate.tool.internal.export.hbm.Cfg2HbmTool#getNamedSQLReturnRole(NativeSQLQueryCollectionReturn)'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -291,10 +291,6 @@ public class Cfg2HbmTool {
 		return value.isExtraLazy() ? "extra" : Boolean.toString(value.isLazy());
 	}
 
-	public String getNamedSQLReturnRole(NativeSQLQueryCollectionReturn o) {
-		return o.getOwnerEntityName() + "." + o.getOwnerProperty();
-	}
-
 	public boolean isNamedSQLReturnRoot(NativeSQLQueryReturn sqlret) {
 		return sqlret instanceof NativeSQLQueryRootReturn;
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
