### PR TITLE
HBX-2241: Remove unused functionality that uses Hibernate Core classes that have been removed in 6.0.0.Beta1 - Remove 'org.hibernate.tool.internal.export.hbm.Cfg2HbmTool#isNamedSQLReturnCollection(NativeSQLQueryReturn)'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -19,7 +19,6 @@ import org.hibernate.engine.OptimisticLockStyle;
 import org.hibernate.engine.query.spi.sql.NativeSQLQueryCollectionReturn;
 import org.hibernate.engine.query.spi.sql.NativeSQLQueryJoinReturn;
 import org.hibernate.engine.query.spi.sql.NativeSQLQueryReturn;
-import org.hibernate.engine.query.spi.sql.NativeSQLQueryRootReturn;
 import org.hibernate.engine.spi.FilterDefinition;
 import org.hibernate.id.PersistentIdentifierGenerator;
 import org.hibernate.mapping.Any;
@@ -289,10 +288,6 @@ public class Cfg2HbmTool {
 
 	public String getCollectionLazy(Collection value){
 		return value.isExtraLazy() ? "extra" : Boolean.toString(value.isLazy());
-	}
-
-	public boolean isNamedSQLReturnRoot(NativeSQLQueryReturn sqlret) {
-		return sqlret instanceof NativeSQLQueryRootReturn;
 	}
 
 	public boolean isNamedSQLReturnCollection(NativeSQLQueryReturn sqlret) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
