### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependency on 'org.junit.vintage:junit-vintage-engine' from 'test/utils'

### DIFF
--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -30,10 +30,6 @@
 		    <artifactId>junit-jupiter-engine</artifactId>
 		    <scope>compile</scope>
 		</dependency>
-		<dependency>
-		    <groupId>org.junit.vintage</groupId>
-		    <artifactId>junit-vintage-engine</artifactId>
-		</dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
