### PR TITLE
HBX-2241: Remove unused functionality that uses Hibernate Core classes that have been removed in 6.0.0.Beta1 - Replace call to 'org.hibernate.dialect.Dialect#supportsSequences()' with 'Dialect#getSequenceSupport()#supportsSequences()'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
@@ -91,7 +91,7 @@ public class SchemaByMetaDataDetector extends RelationalModelDetector {
 		Iterator<?> iter = iterateGenerators();
 		
 		Set<?> sequences = Collections.EMPTY_SET;
-		if(dialect.supportsSequences()) {
+		if(dialect.getSequenceSupport().supportsSequences()) {
 			sequences = sequenceCollector.readSequences(dialect.getQuerySequencesString());
 		}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
