### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependency on 'junit.junit:4.13.2' from parent module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <javaee-api.version>8.0.1</javaee-api.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <jaxen.version>1.2.0</jaxen.version>
-        <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.7.2</junit-jupiter.version>
         <mysql.version>8.0.22</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
@@ -107,11 +106,6 @@
                 <version>${jaxen.version}</version>
                 <scope>runtime</scope>
             </dependency> 
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-            </dependency>
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
