### PR TITLE
HBX-2230: Adapt the tests that fail when run on the GitHub workflows - Adapt 'org.hibernate.tool.hbm2x.GenericExporterTest.TestCase#testFreeMarkerSyntaxFailureExpected()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/GenericExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/GenericExporterTest/TestCase.java
@@ -102,10 +102,10 @@ public class TestCase {
 		ge.setFilePattern("{class-name}.ftltest");
 		ge.start();
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "Author.ftltest" ) );	
-		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "Article.ftlTest" ) );
-		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "BaseHelloWorld.ftlTest" ) );	
-		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "HelloUniverse.ftlTest" ) );
-		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "UniversalAddress.ftlTest" ) );
+		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "Article.ftltest" ) );
+		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "BaseHelloWorld.ftltest" ) );	
+		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "HelloUniverse.ftltest" ) );
+		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "UniversalAddress.ftltest" ) );
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
