### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tool.hbm2x.hbm2hbmxml.IdBagTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/Group.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/Group.java
@@ -1,3 +1,23 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.hibernate.tool.hbm2x.hbm2hbmxml.IdBagTest;
 
 public class Group {

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
@@ -1,20 +1,28 @@
 /*
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
  *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.hibernate.tool.hbm2x.hbm2hbmxml.IdBagTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -33,11 +41,9 @@ import org.hibernate.tool.hbm2x.Exporter;
 import org.hibernate.tool.hbm2x.HibernateMappingExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -52,44 +58,44 @@ public class TestCase {
 			"UserGroup.hbm.xml"
 	};
 	
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public File outputFolder = new File("output");
 	
-	private File outputDir = null;
+	private File srcDir = null;
 	private File resourcesDir = null;
 	
 	private Exporter hbmexporter = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		outputDir = new File(temporaryFolder.getRoot(), "output");
-		outputDir.mkdir();
-		resourcesDir = new File(temporaryFolder.getRoot(), "resources");
+		srcDir = new File(outputFolder, "output");
+		srcDir.mkdir();
+		resourcesDir = new File(outputFolder, "resources");
 		resourcesDir.mkdir();
 		MetadataDescriptor metadataDescriptor = HibernateUtil
 				.initializeMetadataDescriptor(this, HBM_XML_FILES, resourcesDir);
 		hbmexporter = new HibernateMappingExporter();
 		hbmexporter.setMetadataDescriptor(metadataDescriptor);
-		hbmexporter.setOutputDirectory(outputDir);
+		hbmexporter.setOutputDirectory(srcDir);
 		hbmexporter.start();
 	}
 	
 	@Test
 	public void testAllFilesExistence() {
-		Assert.assertFalse(new File(
-				outputDir,
+		assertFalse(new File(
+				srcDir,
 				"/GeneralHbmSettings.hbm.xml").exists());
 		JUnitUtil.assertIsNonEmptyFile(new File(
-				outputDir,
+				srcDir,
 				"/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/User.hbm.xml"));
 		JUnitUtil.assertIsNonEmptyFile(new File(
-				outputDir,
+				srcDir,
 				"/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/Group.hbm.xml"));		
 	}
 	
 	@Test
 	public void testArtifactCollection() {
-		Assert.assertEquals(
+		assertEquals(
 				2,
 				hbmexporter.getArtifactCollector().getFileCount("hbm.xml"));
 	}
@@ -98,23 +104,23 @@ public class TestCase {
 	public void testReadable() {
         ArrayList<File> files = new ArrayList<File>(4); 
         files.add(new File(
-        		outputDir, 
+        		srcDir, 
         		"/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/User.hbm.xml"));
         files.add(new File(
-        		outputDir, 
+        		srcDir, 
         		"/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/Group.hbm.xml"));
 		Properties properties = new Properties();
 		properties.setProperty(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
 		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, files.toArray(new File[2]), properties);
-        Assert.assertNotNull(metadataDescriptor.createMetadata());
+        assertNotNull(metadataDescriptor.createMetadata());
     }
 	
 	@Test
 	public void testIdBagAttributes() throws Exception {
 		File outputXml = new File(
-				outputDir,  
+				srcDir,  
 				"/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/User.hbm.xml");
 		JUnitUtil.assertIsNonEmptyFile(outputXml);
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -124,18 +130,18 @@ public class TestCase {
 		NodeList nodeList = (NodeList)xpath
 				.compile("//hibernate-mapping/class/idbag")
 				.evaluate(document, XPathConstants.NODESET);
-		Assert.assertEquals("Expected to get one idbag element", 1, nodeList.getLength());
+		assertEquals(1, nodeList.getLength(), "Expected to get one idbag element");
 		Element node = (Element) nodeList.item(0);
-		Assert.assertEquals(node.getAttribute( "table" ),"`UserGroups`");
-		Assert.assertEquals(node.getAttribute( "name" ),"groups");
-		Assert.assertEquals(node.getAttribute( "lazy" ),"false");
-		Assert.assertEquals(node.getAttribute( "access" ),"field");
+		assertEquals(node.getAttribute( "table" ),"`UserGroups`");
+		assertEquals(node.getAttribute( "name" ),"groups");
+		assertEquals(node.getAttribute( "lazy" ),"false");
+		assertEquals(node.getAttribute( "access" ),"field");
 	}
 	
 	@Test
 	public void testCollectionId() throws Exception {
 		File outputXml = new File(
-				outputDir,  
+				srcDir,  
 				"/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/User.hbm.xml");
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		DocumentBuilder db = dbf.newDocumentBuilder();
@@ -144,14 +150,14 @@ public class TestCase {
 		NodeList nodeList = (NodeList)xpath
 				.compile("//hibernate-mapping/class/idbag/collection-id")
 				.evaluate(document, XPathConstants.NODESET);
-		Assert.assertEquals("Expected to get one collection-id element", 1, nodeList.getLength());
+		assertEquals(1, nodeList.getLength(), "Expected to get one collection-id element");
 		Element node = (Element) nodeList.item(0);
-		Assert.assertEquals(node.getAttribute( "column" ),"userGroupId");
-		Assert.assertEquals(node.getAttribute( "type" ),"long");
+		assertEquals(node.getAttribute( "column" ),"userGroupId");
+		assertEquals(node.getAttribute( "type" ),"long");
 		nodeList = node.getElementsByTagName("generator");
-		Assert.assertEquals("Expected to get one generator element", 1, nodeList.getLength());
+		assertEquals(1, nodeList.getLength(), "Expected to get one generator element");
 		node = (Element) nodeList.item(0);
-		Assert.assertEquals(node.getAttribute( "class" ),"increment");
+		assertEquals(node.getAttribute( "class" ),"increment");
 	}
 	
 }

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/User.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/User.java
@@ -1,3 +1,23 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.hibernate.tool.hbm2x.hbm2hbmxml.IdBagTest;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
