### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tool.ide.completion.CompletionHelperTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/ide/completion/CompletionHelperTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/ide/completion/CompletionHelperTest/TestCase.java
@@ -1,29 +1,33 @@
 /*
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
  *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.hibernate.tool.ide.completion.CompletionHelperTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.tool.ide.completion.CompletionHelper;
 import org.hibernate.tool.ide.completion.EntityNameReference;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author leon
@@ -36,17 +40,17 @@ public class TestCase {
         qts.add(new EntityNameReference("Article", "art"));
         qts.add(new EntityNameReference("art.descriptions", "descr"));
         qts.add(new EntityNameReference("descr.name", "n"));
-        Assert.assertEquals("Invalid path", "Article/descriptions/name/locale", CompletionHelper.getCanonicalPath(qts, "n.locale"));
-        Assert.assertEquals("Invalid path", "Article/descriptions", CompletionHelper.getCanonicalPath(qts, "descr"));
+        assertEquals("Article/descriptions/name/locale", CompletionHelper.getCanonicalPath(qts, "n.locale"), "Invalid path");
+        assertEquals("Article/descriptions", CompletionHelper.getCanonicalPath(qts, "descr"), "Invalid path");
         //
         qts.clear();
         qts.add(new EntityNameReference("com.company.Clazz", "clz"));
         qts.add(new EntityNameReference("clz.attr", "a"));
-        Assert.assertEquals("Invalid path", "com.company.Clazz/attr", CompletionHelper.getCanonicalPath(qts, "a"));
+        assertEquals("com.company.Clazz/attr", CompletionHelper.getCanonicalPath(qts, "a"), "Invalid path");
         //
         qts.clear();
         qts.add(new EntityNameReference("Agga", "a"));
-        Assert.assertEquals("Invalid path", "Agga", CompletionHelper.getCanonicalPath(qts, "a"));
+        assertEquals("Agga", CompletionHelper.getCanonicalPath(qts, "a"), "Invalid path");
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
