### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove JUnit dependency from module 'hibernate-tools-tests-nodb'

### DIFF
--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -17,18 +17,14 @@
     <name>Hibernate Tools No Database Tests Project</name>
 
     <dependencies>
-    	    <dependency>
-    		    <groupId>org.hibernate</groupId>
-    		    <artifactId>hibernate-tools</artifactId>
-    	    </dependency>
-    	    <dependency>
-    		    <groupId>org.hibernate</groupId>
-    		    <artifactId>hibernate-tools-tests-utils</artifactId>
-    	    </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
+   	    <dependency>
+   		    <groupId>org.hibernate</groupId>
+   		    <artifactId>hibernate-tools</artifactId>
+   	    </dependency>
+   	    <dependency>
+   		    <groupId>org.hibernate</groupId>
+   		    <artifactId>hibernate-tools-tests-utils</artifactId>
+   	    </dependency>
 		<dependency>
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
