### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.ant.Query.TestCase#testQuery()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/Query/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Query/TestCase.java
@@ -31,7 +31,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -57,8 +56,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 	
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
 	@Test
 	public void testQuery() {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
