### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tools.test.util.HibernateUtilTest'

### DIFF
--- a/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/HibernateUtilTest.java
@@ -1,5 +1,29 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2017-2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tools.test.util;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.File;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -11,29 +35,27 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class HibernateUtilTest {
 	
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
+	@TempDir
+	public File outputFolder = new File("output");
+	
 	@Test
 	public void testGetForeignKey() {
 		Table table = new Table();
-		Assert.assertNull(HibernateUtil.getForeignKey(table, "foo"));
-		Assert.assertNull(HibernateUtil.getForeignKey(table, "bar"));
-		table.createForeignKey("foo", Collections.emptyList(), "bar", null);
-		Assert.assertNotNull(HibernateUtil.getForeignKey(table, "foo"));
-		Assert.assertNull(HibernateUtil.getForeignKey(table, "bar"));
+		assertNull(HibernateUtil.getForeignKey(table, "foo"));
+		assertNull(HibernateUtil.getForeignKey(table, "bar"));
+		table.createForeignKey("foo", Collections.emptyList(), "Bar", null);
+		assertNotNull(HibernateUtil.getForeignKey(table, "foo"));
+		assertNull(HibernateUtil.getForeignKey(table, "bar"));
 	}
 	
 	@Test
 	public void testDialectInstantiation() {
-		Assert.assertNotNull(new HibernateUtil.Dialect());
+		assertNotNull(new HibernateUtil.Dialect());
 	}
 	
 	@Test
@@ -42,27 +64,26 @@ public class HibernateUtilTest {
 				.initializeMetadataDescriptor(
 						this, 
 						new String[] { "HelloWorld.hbm.xml" },
-						temporaryFolder.getRoot())
+						outputFolder)
 				.createMetadata();
-		Assert.assertSame(
+		assertSame(
 				HibernateUtil.Dialect.class, 
 				metadata.getDatabase().getDialect().getClass());
-		Assert.assertNotNull(metadata.getEntityBinding("HelloWorld"));
+		assertNotNull(metadata.getEntityBinding("HelloWorld"));
 	}
 	
 	@Test
 	public void testAddAnnotatedClass() {
 		Properties properties = new Properties();
 		properties.setProperty(AvailableSettings.DIALECT, HibernateUtil.Dialect.class.getName());
-		properties.setProperty(AvailableSettings.CONNECTION_PROVIDER, HibernateUtil.ConnectionProvider.class.getName());
 		MetadataDescriptor metadataDescriptor = MetadataDescriptorFactory
 				.createNativeDescriptor(null, null, properties);
-		Assert.assertNull(metadataDescriptor
+		assertNull(metadataDescriptor
 				.createMetadata()
 				.getEntityBinding(
 						"org.hibernate.tools.test.util.HibernateUtilTest$Dummy"));
 		HibernateUtil.addAnnotatedClass(metadataDescriptor, Dummy.class);
-		Assert.assertNotNull(metadataDescriptor
+		assertNotNull(metadataDescriptor
 				.createMetadata()
 				.getEntityBinding(
 						"org.hibernate.tools.test.util.HibernateUtilTest$Dummy"));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
