### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.hbx2x.hbm2hbmxml.Hbm2HbmXmlTest.TestCase#testGlobalSettingsGeneratedAccessAndCascadeNonDefault()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -160,8 +160,6 @@ public class TestCase {
 		assertEquals("mycatalog", root.getAttribute("catalog"), "Unexpected mycatalog name" );
 	}
 
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
 	@Test
 	public void testGlobalSettingsGeneratedAccessAndCascadeNonDefault()  throws Exception {
 		HibernateMappingGlobalSettings hgs = new HibernateMappingGlobalSettings();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
