### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tools.test.util.ConnectionLeakUtilTest'

### DIFF
--- a/test/utils/src/test/java/org/hibernate/tools/test/util/ConnectionLeakUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/ConnectionLeakUtilTest.java
@@ -1,17 +1,37 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2018-2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tools.test.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ConnectionLeakUtilTest {
 	
 	private ConnectionLeakUtil connectionLeakUtil = null;
 	
-	@Before
+	@BeforeEach
 	public void before() {
 		connectionLeakUtil = ConnectionLeakUtil.forH2();
 		connectionLeakUtil.initialize();
@@ -24,7 +44,7 @@ public class ConnectionLeakUtilTest {
 			connectionLeakUtil.assertNoLeaks();
 			throw new RuntimeException("should not happen");
 		} catch (AssertionError e) {
-			Assert.assertEquals("1 connections are leaked.", e.getMessage());
+			assertEquals("1 connections are leaked.", e.getMessage());
 		}
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
