### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.hbx2x.hbm2hbmxml.Hbm2HbmXmlTest.TestCase#testComments()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -240,8 +240,6 @@ public class TestCase {
 		assertEquals("delete, update", node.getAttribute("cascade"));	
 	}
 	
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
 	@Test
 	public void testComments() throws Exception {
 		File outputXml = new File(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
