### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Rename class 'org.hibernate.tool.test.db.h2.TestSuite' to 'org.hibernate.tool.test.db.h2.JUnit4TestSuite'

### DIFF
--- a/test/h2/src/test/java/org/hibernate/tool/test/db/h2/JUnit4TestSuite.java
+++ b/test/h2/src/test/java/org/hibernate/tool/test/db/h2/JUnit4TestSuite.java
@@ -8,4 +8,4 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ 
 	org.hibernate.tool.test.db.CommonTestSuite.class
 })
-public class TestSuite {}
+public class JUnit4TestSuite {}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
