### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Rename class 'org.hibernate.tool.test.db.h2.JUnit4TestSuite' to 'org.hibernate.tool.test.db.h2.TestSuiteJUnit4'

### DIFF
--- a/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuiteJUnit4.java
+++ b/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuiteJUnit4.java
@@ -8,4 +8,4 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ 
 	org.hibernate.tool.test.db.CommonTestSuite.class
 })
-public class JUnit4TestSuite {}
+public class TestSuiteJUnit4 {}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
