### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.hbx2x.hbm2hbmxml.Hbm2HbmXmlTest.TestCase#testNoComments()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -264,8 +264,6 @@ public class TestCase {
 		assertEquals(node.getTextContent(),"columnd comment");
 	}
 
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
 	@Test
 	public void testNoComments() throws Exception {
 		File outputXml = new File(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>

