### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.hbx2x.hbm2hbmxml.Hbm2HbmXmlTest.TestCase#testGlobalSettingsGeneratedAccessAndCascadeDefault()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -284,8 +284,6 @@ public class TestCase {
 		assertEquals(0, nodeList.getLength(), "Expected to get no comment element");	
 	}
 
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
 	@Test
 	public void testGlobalSettingsGeneratedAccessAndCascadeDefault()  throws Exception {
 		HibernateMappingGlobalSettings hgs = new HibernateMappingGlobalSettings();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
