### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.hbx2x.hbm2hbmxml.Hbm2HbmXmlTest.TestCase#testGlobalSettingsLazyAndAutoImportNonDefault()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -310,10 +310,8 @@ public class TestCase {
 		assertEquals("none", root.getAttribute("default-cascade"), "Unexpected cascade setting" );	
 	}
 
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
 	@Test
-	public void testGlobalSettingsLasyAndAutoImportNonDefault()  throws Exception {
+	public void testGlobalSettingsLazyAndAutoImportNonDefault()  throws Exception {
 		HibernateMappingGlobalSettings hgs = new HibernateMappingGlobalSettings();
 		hgs.setDefaultPackage("org.hibernate.tool.hbm2x.hbm2hbmxml.Hbm2HbmXmlTest");
 		hgs.setDefaultLazy(false);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
