### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.hbx2x.hbm2hbmxml.Hbm2HbmXmlTest.TestCase#testIdGeneratorHasNotArgumentParameters()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -336,8 +336,6 @@ public class TestCase {
 		assertEquals("false", root.getAttribute("auto-import"), "Unexpected cascade setting" );
 	}
 
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
 	@Test
 	public void testIdGeneratorHasNotArgumentParameters()  throws Exception {
 		File outputXml = new File(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
