### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Add 'org.hibernate.tool.test.db.h2.TestSuiteJupiter' assembling the JUnit Jupiter tests for H2

### DIFF
--- a/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuiteJupiter.java
+++ b/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuiteJupiter.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hibernate.tool.test.db.h2;
+
+import org.hibernate.tool.test.db.DbTestSuite;
+import org.junit.jupiter.api.Nested;
+
+public class TestSuiteJupiter {
+	
+	@Nested
+	public class H2TestSuite extends DbTestSuite {}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
