### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.hbx2x.hbm2hbmxml.Hbm2HbmXmlTest.TestCase#testIdGeneratorHasArgumentParameters()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -359,8 +359,6 @@ public class TestCase {
 		assertTrue(nodeList.getLength() == 0, "Expected to get no generator param elements");	
 	}
     
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
 	@Test
     public void testIdGeneratorHasArgumentParameters()  throws Exception {
 		File outputXml = new File(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
