### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tool.ant.Cfg2HbmWithCustomReverseNamingStrategy.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithCustomReverseNamingStrategy/Strategy.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithCustomReverseNamingStrategy/Strategy.java
@@ -1,3 +1,22 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.ant.Cfg2HbmWithCustomReverseNamingStrategy;
 
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;

--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithCustomReverseNamingStrategy/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithCustomReverseNamingStrategy/TestCase.java
@@ -1,4 +1,26 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.ant.Cfg2HbmWithCustomReverseNamingStrategy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -6,31 +28,29 @@ import org.hibernate.tools.test.util.AntUtil;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestCase {
 	
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public File outputFolder = new File("output");
 	
 	private File destinationDir = null;
 	private File resourcesDir = null;
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
-		destinationDir = new File(temporaryFolder.getRoot(), "destination");
+		destinationDir = new File(outputFolder, "destination");
 		destinationDir.mkdir();
-		resourcesDir = new File(temporaryFolder.getRoot(), "resources");
+		resourcesDir = new File(outputFolder, "resources");
 		resourcesDir.mkdir();
 		JdbcUtil.createDatabase(this);
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		JdbcUtil.dropDatabase(this);
 	}
@@ -48,12 +68,12 @@ public class TestCase {
 		project.setProperty("resourcesDir", resourcesDir.getAbsolutePath());
 
 		File hbmxml = new File(destinationDir, "foo/Bar.hbm.xml");
-		Assert.assertFalse(hbmxml.exists());
+		assertFalse(hbmxml.exists());
 		
 		project.executeTarget("testCfg2HbmWithCustomReverseNamingStrategy");
 		
-		Assert.assertTrue(hbmxml.exists());
-		Assert.assertTrue(FileUtil
+		assertTrue(hbmxml.exists());
+		assertTrue(FileUtil
 				.findFirstString("class", hbmxml)
 				.contains("foo.Bar"));
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
