### PR TITLE
HBX-2045: Track the ignored tests that fail because of java.lang.UnsupportedOperationException thrown in ORM 6.0.0.x - Fix the problem(s) and reenable 'org.hibernate.tool.jdbc2cfg.PersistentClasses.TestCase.testBinding()'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
@@ -64,6 +64,7 @@ class PrimaryKeyBinder extends AbstractBinder {
 				id, 
 				RevengUtils.createAssociationInfo(null, null, true, true));
 		rc.setIdentifierProperty(property);
+		rc.setDeclaredIdentifierProperty(property);
 		rc.setIdentifier(id);
 		return pki;
 	}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
@@ -10,6 +10,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.hibernate.DuplicateMappingException;
+import org.hibernate.engine.OptimisticLockStyle;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
@@ -94,6 +95,7 @@ public class RootClassBinder extends AbstractBinder {
 		rc.setMetaAttributes(getMetaAttributes(table));
 		rc.setDiscriminatorValue( rc.getEntityName() );
 		rc.setTable(table);
+		rc.setOptimisticLockStyle(OptimisticLockStyle.NONE);
 		return rc;
 	}
 	

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -47,7 +47,6 @@ import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -109,8 +108,6 @@ public class TestCase {
 		assertTrue(itemset.getValue() instanceof Set);		
 	}
 	
-	// TODO HBX-2045: Reenable when supported in ORM 6.0
-	@Disabled
 	@Test
 	public void testBinding() throws HibernateException, SQLException {	
 		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
