### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Refactor test class 'org.hibernate.tool.hbm2x.query.QueryExporterTest.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/Group.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/Group.java
@@ -1,4 +1,22 @@
-//$Id: Group.java 7085 2005-06-08 17:59:47Z oneovthafew $
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.hbm2x.query.QueryExporterTest;
 
 import java.io.ObjectStreamClass;

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/TestCase.java
@@ -1,4 +1,25 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.hbm2x.query.QueryExporterTest;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -19,28 +40,26 @@ import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestCase {
 
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public File temporaryFolder = new File("temp");
 
 	private File destinationDir = null;
 	private File resourcesDir = null;
 	private File userGroupHbmXmlFile = null;
 	
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		JdbcUtil.createDatabase(this);
-		destinationDir = new File(temporaryFolder.getRoot(), "destination");
+		destinationDir = new File(temporaryFolder, "destination");
 		destinationDir.mkdir();
-		resourcesDir = new File(temporaryFolder.getRoot(), "resources");
+		resourcesDir = new File(temporaryFolder, "resources");
 		resourcesDir.mkdir();
 		String[] resources = { "UserGroup.hbm.xml" };		
 		ResourceUtil.createResources(this, resources, resourcesDir);
@@ -77,14 +96,14 @@ public class TestCase {
 		JUnitUtil.assertIsNonEmptyFile(new File(destinationDir, "queryresult.txt"));		
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		SchemaExport export = new SchemaExport();
 		final EnumSet<TargetType> targetTypes = EnumSet.noneOf( TargetType.class );
 		targetTypes.add( TargetType.DATABASE );
 		export.drop(targetTypes, createMetadata());		
 		if (export.getExceptions() != null && export.getExceptions().size() > 0){
-			Assert.fail("Schema export failed");
+			fail("Schema export failed");
 		}		
 		JdbcUtil.dropDatabase(this);
 	}

--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/User.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/query/QueryExporterTest/User.java
@@ -1,4 +1,22 @@
-//$Id: User.java 7085 2005-06-08 17:59:47Z oneovthafew $
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ * 
+ * Copyright 2004-2021 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License (LGPL), 
+ * version 2.1 or later (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may read the licence in the 'lgpl.txt' file in the root folder of 
+ * project or obtain a copy at
+ *
+ *     http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hibernate.tool.hbm2x.query.QueryExporterTest;
 
 import java.io.ObjectStreamClass;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
