### PR TITLE
HBX-2054: Track ignored tests that fail because Hibernate ORM 6.0 cannot resolve named type - Fix problem in 'org.hibernate.tool.hbm2x.DocExporterTest: Customer.hbm.xml'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/DocExporterTest/TestCase.java
@@ -33,6 +33,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Properties;
+import java.util.function.BiConsumer;
 
 import javax.xml.parsers.SAXParserFactory;
 
@@ -43,6 +44,9 @@ import org.hibernate.tool.internal.export.doc.DocExporter;
 import org.hibernate.tools.test.util.FileUtil;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
+import org.hibernate.type.descriptor.java.JdbcDateJavaTypeDescriptor;
+import org.hibernate.type.descriptor.jdbc.DateJdbcType;
+import org.hibernate.usertype.BaseUserTypeSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -199,6 +203,14 @@ public class TestCase {
 		public void fatalError(SAXParseException exception) throws SAXException {
 			errors++;
 		}		
+	}
+	
+	public static class DummyDateType extends BaseUserTypeSupport<JdbcDateJavaTypeDescriptor> {
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Override
+		protected void resolve(BiConsumer resolutionConsumer) {
+			resolutionConsumer.accept(new JdbcDateJavaTypeDescriptor(), new DateJdbcType());
+		}
 	}
 	
 }

--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/DocExporterTest/Customer.hbm.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/DocExporterTest/Customer.hbm.xml
@@ -30,8 +30,7 @@
 		<property name="address" type="string" not-null="true"
 			length="200" />
 
-<!--  TODO: HBX-2054: Hibernate ORM cannot resolve named type 'org.hibernate.tool.hbm2x.DummyDateType' -->
-<!--       <property name="customDate" type="org.hibernate.tool.hbm2x.DummyDateType" not-null="true" length="200"/> -->
+       <property name="customDate" type="org.hibernate.tool.hbm2x.DocExporterTest.TestCase$DummyDateType" not-null="true" length="200"/> 
         
         <property name="acl" type="byte[]">
          <meta attribute="use-in-equals">true</meta>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
