### PR TITLE
HBX-2054: Track ignored tests that fail because Hibernate ORM 6.0 cannot resolve named type - Fix problem in 'org.hibernate.tool.hbm2x.OtherCfg2HbmTest: Customer.hbm.xml' (User type is not relevant for test)

### DIFF
--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/Customer.hbm.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/OtherCfg2HbmTest/Customer.hbm.xml
@@ -49,8 +49,7 @@
 		<property name="address" type="string" not-null="true"
 			length="200" />
 
- <!--  TODO: HBX-2054: Hibernate ORM cannot resolve named type 'java.lang.String[]' -->
- <!--        <property name="customDate" type="org.hibernate.tool.hbm2x.DummyDateType" not-null="true" length="200"/> -->
+        <property name="customDate" type="date" not-null="true" length="200"/>
         
         <property name="acl" type="byte[]">
          <meta attribute="use-in-equals">true</meta>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
