### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Rename 'orghibernate.tool.test.db.hsql.TestSuiteJupiter' into 'org.hibernate.tool.test.db.hsql.TestSuite'

### DIFF
--- a/test/hsql/src/test/java/org/hibernate/tool/test/db/hsql/TestSuite.java
+++ b/test/hsql/src/test/java/org/hibernate/tool/test/db/hsql/TestSuite.java
@@ -22,7 +22,7 @@ package org.hibernate.tool.test.db.hsql;
 import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
-public class TestSuiteJupiter {
+public class TestSuite {
 	
 	@Nested
 	public class HsqlTestSuite extends DbTestSuite {}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
