### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Add 'junit' and 'junit-vintage-engine' dependencies to 'test/mssql/pom.xml'

### DIFF
--- a/test/mssql/pom.xml
+++ b/test/mssql/pom.xml
@@ -28,6 +28,14 @@
     		<groupId>org.hibernate</groupId>
     		<artifactId>hibernate-tools-tests-common</artifactId>
     	</dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.vintage</groupId>
+		    <artifactId>junit-vintage-engine</artifactId>
+		</dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
