### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Rename 'orghibernate.tool.test.db.sqlserver.TestSuiteJupiter' to 'org.hibernate.tool.test.db.sqlserver.TestSuite'

### DIFF
--- a/test/mssql/src/test/java/org/hibernate/tool/test/db/sqlserver/TestSuite.java
+++ b/test/mssql/src/test/java/org/hibernate/tool/test/db/sqlserver/TestSuite.java
@@ -22,7 +22,7 @@ package org.hibernate.tool.test.db.sqlserver;
 import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
-public class TestSuiteJupiter {
+public class TestSuite {
 	
 	@Nested
 	public class SqlServerTestSuite extends DbTestSuite {}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
