### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Cleanup of 'org.hibernate.tool.jdbc2cfg.Identity.TestCase'

### DIFF
--- a/test/oracle/src/test/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/oracle/src/test/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -31,7 +31,6 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
