### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Rename class 'org.hibernate.tool.test.db.oracle.TestSuiteJupiter' into 'org.hibernate.tool.test.db.oracle.TestSuite'

### DIFF
--- a/test/oracle/src/test/java/org/hibernate/tool/test/db/oracle/TestSuite.java
+++ b/test/oracle/src/test/java/org/hibernate/tool/test/db/oracle/TestSuite.java
@@ -22,7 +22,7 @@ package org.hibernate.tool.test.db.oracle;
 import org.hibernate.tool.test.db.DbTestSuite;
 import org.junit.jupiter.api.Nested;
 
-public class TestSuiteJupiter {
+public class TestSuite {
 	
 	@Nested
 	public class OracleTestSuite extends DbTestSuite {}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
