### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependency on 'junit.junit' from 'test/utils'

### DIFF
--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -18,11 +18,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
