### PR TITLE
HBX-2184: Replace JUnit4 tests with JUnit Jupiter tests - Remove dependency on 'org.junit.vintage:junit-vintage-engine:5.7.2'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,12 +159,6 @@
                 <version>${junit-jupiter.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
