### PR TITLE
HBX-2249 @Entity declaration needs name if the generated-class meta attribute is used

### DIFF
--- a/orm/src/main/resources/pojo/Ejb3TypeDeclaration.ftl
+++ b/orm/src/main/resources/pojo/Ejb3TypeDeclaration.ftl
@@ -2,7 +2,7 @@
 <#if pojo.isComponent()>
 @${pojo.importType("jakarta.persistence.Embeddable")}
 <#else>
-@${pojo.importType("jakarta.persistence.Entity")}
+@${pojo.importType("jakarta.persistence.Entity")}(name="${pojo.shortName}")
 @${pojo.importType("jakarta.persistence.Table")}(name="${clazz.table.name}"
 <#if clazz.table.schema?exists>
     ,schema="${clazz.table.schema}"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HBX-2249

I'm not sure if there's a way to check if the generated name is different to the entity name? So I've just always output the entity name, which I believe to be harmless.

I investigated using `${clazz.entityName}` but it is fully-qualified, which I understand to not be correct.