### PR TITLE
HBX-2250 Improve whitespace around ejb3 annotations in generated POJOs

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/BasicPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/BasicPOJOClass.java
@@ -370,7 +370,9 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 						//annotations.append("/* TODO formula in multicolumns not supported by annotations */");
 					}
 					else {
-						annotations.append( "\n        " );
+						if (annotations.length() > 0) {
+							annotations.append( "\n        " );
+						}
 						buildColumnAnnotation( selectable, annotations, insertable, updatable );
 						annotations.append( ", " );
 					}

--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
@@ -444,7 +444,8 @@ public class EntityPOJOClass extends BasicPOJOClass {
 	}
 
 	public String generateManyToOneAnnotation(Property property) {
-		StringBuffer buffer = new StringBuffer(AnnotationBuilder.createAnnotation( importType("jakarta.persistence.ManyToOne") )
+		StringBuffer buffer = new StringBuffer("    ");
+		buffer.append(new StringBuffer(AnnotationBuilder.createAnnotation( importType("jakarta.persistence.ManyToOne") )
 				.addAttribute( "cascade", getCascadeTypes(property))
 				.addAttribute( "fetch", getFetchType(property))
 				.getResult());
@@ -484,7 +485,8 @@ public class EntityPOJOClass extends BasicPOJOClass {
 			ab.addQuotedAttribute("mappedBy", getOneToOneMappedBy(md, oneToOne));
 		}
 
-		StringBuffer buffer = new StringBuffer(ab.getResult());
+		StringBuffer buffer = new StringBuffer("    ");
+		buffer.append(ab.getResult());
 		buffer.append(getHibernateCascadeTypeAnnotation(property));
 
 		if ( pkIsAlsoFk && oneToOne.getForeignKeyType().equals(ForeignKeyDirection.FROM_PARENT) ){
@@ -563,7 +565,7 @@ public class EntityPOJOClass extends BasicPOJOClass {
 	}
 
 	public String generateCollectionAnnotation(Property property, Metadata md) {
-		StringBuffer annotation = new StringBuffer();
+		StringBuffer annotation = new StringBuffer("    ");
 		Value value = property.getValue();
 		if ( value != null && value instanceof Collection) {
 			Collection collection = (Collection) value;

--- a/orm/src/main/resources/pojo/Ejb3PropertyGetAnnotation.ftl
+++ b/orm/src/main/resources/pojo/Ejb3PropertyGetAnnotation.ftl
@@ -1,12 +1,12 @@
 <#if ejb3>
+
 <#if pojo.hasIdentifierProperty()>
 <#if property.equals(clazz.identifierProperty)>
- ${pojo.generateAnnIdGenerator()}
+${pojo.generateAnnIdGenerator()}
 <#-- if this is the id property (getter)-->
 <#-- explicitly set the column name for this property-->
 </#if>
 </#if>
-
 <#if c2h.isOneToOne(property)>
 ${pojo.generateOneToOneAnnotation(property, md)}
 <#elseif c2h.isManyToOne(property)>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HBX-2250

The results are more pleasing to the eye. Even though this is generated code, you do sometimes look at it. Multiple newlines are a little ugly, but there are plenty of them around. There are also plenty of other indentation problems... the `equals` and `hashCode` methods are indented with only 3 spaces. But now the annotations are indented to match the getters that they sit on top of. 