### PR TITLE
HBX-2260: Update Hibernate Core dependency to version 6.0.0.Beta2 - Cleanup '.gitignore' and add '.java-version' as ignored file (this file is used by 'jenv' to be able to use a specific Java version on Mac'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,8 @@
 target
-testdb
-toolstestoutput
-bin
-*~
-reverseoutput
 .classpath
 .project
 .settings
 .DS_Store
 .idea
 *.iml
+.java-version


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
