### PR TITLE
HBX-2260: Update Hibernate Core dependency to version 6.0.0.Beta2 - Update version, comment out compilation errors and disable failing tests (tracked by HBX-2261)

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,10 +14,10 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
-    - name: Setup Java 8
+    - name: Setup Java 11
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
         java-package: jdk
         architecture: x64
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
