### PR TITLE
HBX-2260: Update Hibernate Core dependency to version 6.0.0.Beta2 - Use Java 11 as this is needed by 6.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     </modules>
 
     <properties>
+
         <ant.version>1.10.12</ant.version>
         <antlr.version>4.9.3</antlr.version>
         <commons-collections.version>4.4</commons-collections.version>
@@ -99,6 +100,10 @@
         <mysql.version>8.0.22</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
         <sqlserver.version>9.2.1.jre8</sqlserver.version>
+
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+
     </properties>
     
     <dependencyManagement>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
