### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Reenable the tests in the 'maven' module

### DIFF
--- a/test/maven/pom.xml
+++ b/test/maven/pom.xml
@@ -41,8 +41,7 @@
 
     <build>
         <plugins>
- 			<!-- TODO: HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 -->
- <!--            <plugin>
+             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>${maven-invoker-plugin.version}</version>
                 <configuration>
@@ -61,7 +60,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> --> 
+            </plugin>  
         </plugins>
     </build>
     


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
