### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Enable 'org.hibernate.ant.JPAPropertyOverridesPUnit.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/JPAPropertyOverridesPUnit/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/JPAPropertyOverridesPUnit/TestCase.java
@@ -31,12 +31,9 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2		
-@Disabled
 public class TestCase {
 	
 	@TempDir
@@ -59,8 +56,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 	
-	//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2		
-	@Disabled
 	@Test
 	public void testJPAPUnit() {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
