### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Enable 'org.hibernate.tool.hbm2x.JdbcHbm2JavaEjb3.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/JdbcHbm2JavaEjb3/TestCase.java
@@ -37,7 +37,6 @@ import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -48,8 +47,6 @@ import jakarta.persistence.Persistence;
  * @author koen
  *
  */
-//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2		
-@Disabled
 public class TestCase {
 	
 	@TempDir
@@ -74,23 +71,17 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 	
-	//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2		
-	@Disabled
 	@Test
 	public void testFileExistence() {
 		JUnitUtil.assertIsNonEmptyFile( new File(outputDir.getAbsolutePath() + "/Master.java") );
 	}
 
-	//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2		
-	@Disabled
 	@Test
 	public void testUniqueConstraints() {
 		assertEquals(null, FileUtil.findFirstString( "uniqueConstraints", new File(outputDir,"Master.java") ));
 		assertNotNull(FileUtil.findFirstString( "uniqueConstraints", new File(outputDir,"Uniquemaster.java") ));
 	}
 	
-	//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2		
-	@Disabled
 	@Test
 	public void testCompile() {
 		File destination = new File(outputDir, "destination");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
