### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Add method 'accept(BasicValue)' to class 'org.hibernate.tool.internal.export.hbm.HBMTagForValueVisitor'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HBMTagForValueVisitor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/HBMTagForValueVisitor.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.internal.export.hbm;
 import org.hibernate.mapping.Any;
 import org.hibernate.mapping.Array;
 import org.hibernate.mapping.Bag;
+import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.DependantValue;
 import org.hibernate.mapping.IdentifierBag;
@@ -53,6 +54,10 @@ public class HBMTagForValueVisitor extends DefaultValueVisitor {
 	}
 
 	public Object accept(SimpleValue value) {		
+		return "property";
+	}
+
+	public Object accept(BasicValue value) {		
 		return "property";
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
