### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Enable 'org.hibernate.tool.hbm2x.hbm2hbmxml.InheritanceTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/InheritanceTest/TestCase.java
@@ -54,8 +54,6 @@ import org.w3c.dom.NodeList;
  * @author max
  *
  */
-//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2	
-@Disabled
 public class TestCase {
 
 	private static final String[] HBM_XML_FILES = new String[] {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>

