### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Enable 'org.hibernate.tool.hbm2x.hbm2hbmxml.AbstractTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/AbstractTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/AbstractTest/TestCase.java
@@ -42,7 +42,6 @@ import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
@@ -53,8 +52,6 @@ import org.w3c.dom.NodeList;
  * @author Dmitry Geraskov
  * @author koen
  */
-//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2	
-@Disabled
 public class TestCase {
 
 	private static final String[] HBM_XML_FILES = new String[] {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
