### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Enable 'org.hibernate.tool.hbm2x.hbm2hbmxml.Hbm2HbmXmlTest.TestCase'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/Hbm2HbmXmlTest/TestCase.java
@@ -57,8 +57,6 @@ import org.w3c.dom.NodeList;
  * @author David Channon
  * @author koen
  */
-//TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2	
-@Disabled
 public class TestCase {
 
 	/**	@TempDir


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
