### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Enable 'org.hibernate.tool.ant.Cfg2HbmWithPackageNameAndReverseNamingStrategy.TestCase#testCfg2HbmWithPackageNameAndReverseNamingStrategy()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithPackageNameAndReverseNamingStrategy/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Cfg2HbmWithPackageNameAndReverseNamingStrategy/TestCase.java
@@ -28,7 +28,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -54,8 +53,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 	
-	// TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2		
-	@Disabled
 	@Test
 	public void testCfg2HbmWithPackageNameAndReverseNamingStrategy() {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
