### PR TITLE
HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2 - Enable 'org.hibernate.tool.hbm2x.GenerateFromJDBC.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/hbm2x/GenerateFromJDBC/TestCase.java
@@ -52,7 +52,6 @@ import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
@@ -97,8 +96,6 @@ public class TestCase {
 		exporter.start();
 	}
 	
-	// TODO HBX-2261: Investigate, fix and reenable failing tests after update to 6.0.0.Beta2		
-	@Disabled
 	@Test
 	public void testGenerateMappings() {
 		Exporter exporter = new HbmExporter();	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
