### PR TITLE
HBX-2300: Update the dependency for H2 to 2.x.x - Add 'dbtimestamp' as possible column name for auto detection for optimistic lock (as 'timestamp' is a reserved word for H2 2.x)

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
@@ -37,6 +37,7 @@ public abstract class AbstractStrategy implements RevengStrategy {
 		AUTO_OPTIMISTICLOCK_COLUMNS = new HashSet<String>();
 		AUTO_OPTIMISTICLOCK_COLUMNS.add("version");
 		AUTO_OPTIMISTICLOCK_COLUMNS.add("timestamp");
+		AUTO_OPTIMISTICLOCK_COLUMNS.add("dbtimestamp");
 	}
 	
 		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
