### PR TITLE
HBX-2300: Update the dependency for H2 to 2.x.x - Update dependency to version 2.0.202 and adapt class 'org.hibernate.tools.test.util.ConnectionLeakUtil'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <commons-collections.version>4.4</commons-collections.version>
         <freemarker.version>2.3.31</freemarker.version>
         <google-java-format.version>1.13.0</google-java-format.version>
-        <h2.version>1.4.200</h2.version>
+        <h2.version>2.0.202</h2.version>
         <hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
         <hibernate-orm.version>6.0.0.CR1</hibernate-orm.version>
         <hsqldb.version>2.5.2</hsqldb.version>

--- a/test/utils/src/main/java/org/hibernate/tools/test/util/ConnectionLeakUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/ConnectionLeakUtil.java
@@ -76,7 +76,7 @@ public class ConnectionLeakUtil {
 				ResultSet resultSet = statement.executeQuery(
 						"SELECT COUNT(*) " +
 						"FROM information_schema.sessions " + 
-						"WHERE statement IS NULL");
+						"WHERE executing_statement IS NULL");
 				while (resultSet.next()) {
 					result = resultSet.getInt(1);
 				}

--- a/test/utils/src/test/java/org/hibernate/tools/test/util/ConnectionLeakUtilTest.java
+++ b/test/utils/src/test/java/org/hibernate/tools/test/util/ConnectionLeakUtilTest.java
@@ -54,5 +54,5 @@ public class ConnectionLeakUtilTest {
 		connection.close();
 		connectionLeakUtil.assertNoLeaks();
 	}
-
+	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
