### PR TITLE
HBX-2300: Update the dependency for H2 to 2.x.x - Update dependency to version 2.0.202 and adapt class 'org.hibernate.tools.test.util.ConnectionLeakUtil'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <freemarker.version>2.3.31</freemarker.version>
         <!-- 1.7 is the last google-java-format version that is compiled against Java 1.8 -->
         <google-java-format.version>1.7</google-java-format.version>
-        <h2.version>1.4.200</h2.version>
+        <h2.version>2.0.202</h2.version>
         <hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
         <hibernate-core.version>5.6.4.Final</hibernate-core.version>
         <hsqldb.version>2.5.2</hsqldb.version>

--- a/test/utils/src/main/java/org/hibernate/tools/test/util/ConnectionLeakUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/ConnectionLeakUtil.java
@@ -57,7 +57,7 @@ public class ConnectionLeakUtil {
 				ResultSet resultSet = statement.executeQuery(
 						"SELECT COUNT(*) " +
 						"FROM information_schema.sessions " + 
-						"WHERE statement IS NULL");
+						"WHERE executing_statement IS NULL");
 				while (resultSet.next()) {
 					result = resultSet.getInt(1);
 				}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>

