### PR TITLE
HBX-2304: Update the dependency for H2 to 2.x.x - Add switch to change the suggested primary key strategy query depending on version 1.x or 2.x

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/dialect/H2MetaDataDialect.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/dialect/H2MetaDataDialect.java
@@ -19,7 +19,7 @@ import org.hibernate.tool.util.ReflectHelper;
  */
 public class H2MetaDataDialect extends JDBCMetaDataDialect {
 
-	private static final String H2_1_X_SQL =
+	private static final String SPKSQ_H2_1_X =
 			"SELECT " + 
 			"  idx.TABLE_CATALOG TABLE_CAT, " + 
 			"  idx.TABLE_SCHEMA TABLE_SCHEM, " + 
@@ -34,10 +34,28 @@ public class H2MetaDataDialect extends JDBCMetaDataDialect {
 			"  idx.TABLE_SCHEMA = cols.TABLE_SCHEMA AND " +
 			"  idx.TABLE_NAME = cols.TABLE_NAME AND " +
             "  idx.PRIMARY_KEY = TRUE AND " +
-            "  COLUMN_DEFAULT like '%NEXT VALUE FOR%' ";				
-
+            "  COLUMN_DEFAULT like '%NEXT VALUE FOR%' ";	
+	
+	private static final String SPKSQ_H2_2_X =
+			"SELECT " +
+			"  idx.TABLE_CATALOG TABLE_CAT, " +
+			"  idx.TABLE_SCHEMA TABLE_SCHEM, " +
+			"  idx.TABLE_NAME, " +
+			"  cols.COLUMN_NAME, " +
+			"  cols.COLUMN_DEFAULT " +
+			"FROM " + 
+			"  INFORMATION_SCHEMA.INDEXES idx, " + 
+			"  INFORMATION_SCHEMA.COLUMNS cols " +
+			"WHERE                                     " +
+			"   idx.TABLE_CATALOG = cols.TABLE_CATALOG AND " + 
+			"   idx.TABLE_SCHEMA = cols.TABLE_SCHEMA   AND " +
+			"   idx.TABLE_NAME = cols.TABLE_NAME AND " + 
+			"   idx.INDEX_TYPE_NAME = 'PRIMARY KEY' AND " +
+			"   cols.COLUMN_DEFAULT LIKE '%NEXT VALUE FOR%'";
 
 	private static boolean understandsCatalogName = true;
+
+	private String suggested_primary_key_strategy_query = null;
 
 	public H2MetaDataDialect() {
 		super();
@@ -47,6 +65,7 @@ public class H2MetaDataDialect extends JDBCMetaDataDialect {
 			if ( build.intValue() < 55 ) {
 				understandsCatalogName = false;
 			}
+			suggested_primary_key_strategy_query = build.intValue() > 200 ? SPKSQ_H2_2_X : SPKSQ_H2_1_X;
 		}
         catch( Throwable e ) {
             // ignore (probably H2 not in the classpath)
@@ -83,7 +102,7 @@ public class H2MetaDataDialect extends JDBCMetaDataDialect {
 				
 				log.debug("geSuggestedPrimaryKeyStrategyName(" + catalog + "." + schema + "." + table + ")");
 				
-				String sql =  H2_1_X_SQL;				
+				String sql =  suggested_primary_key_strategy_query;				
 				if(catalog!=null) {
 					sql += "AND idx.TABLE_CATALOG like '" + catalog + "' ";
 				}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
