### PR TITLE
HBX-2304: Update the dependency for H2 to 2.x.x - Use 'IDENTITY' as the type in the DB creation script for test class 'org.hibernate.tool.jdbc2cfg.Identity.TestCase'

### DIFF
--- a/test/h2/src/test/resources/org/hibernate/tool/jdbc2cfg/Identity/create.sql
+++ b/test/h2/src/test/resources/org/hibernate/tool/jdbc2cfg/Identity/create.sql
@@ -1,2 +1,2 @@
-CREATE TABLE `autoinc` (`id` int(11) NOT NULL identity,  `data` varchar(100) default NULL,  PRIMARY KEY  (`id`))
-CREATE TABLE `noautoinc` (`id` int(11) NOT NULL,  `data` varchar(100) default NULL,  PRIMARY KEY  (`id`))
+CREATE TABLE `autoinc` (`id` IDENTITY NOT NULL,  `data` varchar(100) default NULL,  PRIMARY KEY  (`id`))
+CREATE TABLE `noautoinc` (`id` int NOT NULL,  `data` varchar(100) default NULL,  PRIMARY KEY  (`id`))


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
