### PR TITLE
HBX-2304: Update the dependency for H2 to 2.x.x - Adapt the returned table type from 'BASE TABLE' to 'TABLE'

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/dialect/H2MetaDataDialect.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/dialect/H2MetaDataDialect.java
@@ -35,6 +35,14 @@ public class H2MetaDataDialect extends JDBCMetaDataDialect {
         }
 	}
 
+	protected void putTableType(Map<String, Object> element, ResultSet tableRs) throws SQLException {
+		String tableType = tableRs.getString("TABLE_TYPE");
+		if ("BASE TABLE".equals(tableType)) {
+			tableType = "TABLE";
+		}
+		element.put("TABLE_TYPE", tableType);
+	}
+
 	protected void putTablePart(Map<String, Object> element, ResultSet tableRs) throws SQLException {		
 		super.putTablePart( element, tableRs );
 		if ( !understandsCatalogName ) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
