### PR TITLE
HBX-2304: Update the dependency for H2 to 2.x.x - Add 'dbtimestamp' as possible column name for auto detection for optimistic lock (as 'timestamp' is a reserved word for H2 2.x)

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/DefaultReverseEngineeringStrategy.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/DefaultReverseEngineeringStrategy.java
@@ -32,6 +32,7 @@ public class DefaultReverseEngineeringStrategy implements ReverseEngineeringStra
 		AUTO_OPTIMISTICLOCK_COLUMNS = new HashSet<String>();
 		AUTO_OPTIMISTICLOCK_COLUMNS.add("version");
 		AUTO_OPTIMISTICLOCK_COLUMNS.add("timestamp");
+		AUTO_OPTIMISTICLOCK_COLUMNS.add("dbtimestamp");
 	}
 	
 		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
