### PR TITLE
HBX-2042: Track the ignored tests that fail because of org.hibernate.NotYetImplementedFor6Exception - Reenable 'org.hibernate.tool.jdbc2cfg.CompositeId#testGeneration()'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -56,7 +56,6 @@ import org.hibernate.tools.test.util.JavaUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -190,8 +189,6 @@ public class TestCase {
         assertFalse(extraId.getValue() instanceof ManyToOne);
     }
      
-	// TODO HBX-2042: Reenable when implemented in ORM 6.0
-	@Disabled
     @Test
     public void testGeneration() throws Exception {
         Exporter exporter = new HbmExporter();	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
