### PR TITLE
HBX-2324: Replace the deprecated uses of 'java.lang.Class#newInstance(...)' with 'java.lang.reflect.Constructor#newInstance(...)' - Perform changes in 'org.hibernate.tool.jdbc2cfg.CompositeId.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
+import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Iterator;
@@ -226,7 +227,8 @@ public class TestCase {
         		.getResultList();
         assertTrue(list.size()>0);     
         Class<?> productIdClass = ucl.loadClass("ProductId");
-        Object object = productIdClass.newInstance();
+        Constructor<?> productIdClassConstructor = productIdClass.getConstructor(new Class[] {});
+        Object object = productIdClassConstructor.newInstance();
         int hash = -1;
         try {
         	hash = object.hashCode();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
