### PR TITLE
HBX-2324: Replace the deprecated uses of 'java.lang.Class#newInstance(...)' with 'java.lang.reflect.Constructor#newInstance(...)' - Perform changes in 'org.hibernate.tool.internal.xml.XMLPrettyPrinterStrategyFactory'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/xml/XMLPrettyPrinterStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/xml/XMLPrettyPrinterStrategyFactory.java
@@ -1,5 +1,7 @@
 package org.hibernate.tool.internal.xml;
 
+import java.lang.reflect.Constructor;
+
 import org.hibernate.tool.api.xml.XMLPrettyPrinterStrategy;
 
 public final class XMLPrettyPrinterStrategyFactory {
@@ -22,7 +24,8 @@ public final class XMLPrettyPrinterStrategyFactory {
         if (strategyClass != null) {
             try {
                 Class<XMLPrettyPrinterStrategy> clazz = (Class<XMLPrettyPrinterStrategy>) Class.forName(strategyClass);
-                return clazz.newInstance();
+                Constructor<XMLPrettyPrinterStrategy> constructor = clazz.getConstructor(new Class[] {});
+                return constructor.newInstance();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
