### PR TITLE
HBX-2324: Replace the deprecated uses of 'java.lang.Class#newInstance(...)' with 'java.lang.reflect.Constructor#newInstance(...)' - Perform changes in 'org.hibernate.tool.api.reveng.RevengStrategyFactory'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/reveng/RevengStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/api/reveng/RevengStrategyFactory.java
@@ -1,6 +1,8 @@
 package org.hibernate.tool.api.reveng;
 
 import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
@@ -20,8 +22,9 @@ public class RevengStrategyFactory {
 							reverseEngineeringClassName == null ? 
 									DEFAULT_REVERSE_ENGINEERING_STRATEGY_CLASS_NAME : 
 									reverseEngineeringClassName);
-			result = (RevengStrategy)reverseEngineeringClass.newInstance();
-		} catch (ClassNotFoundException | IllegalAccessException | InstantiationException exception) {
+			Constructor<?> reverseEngineeringConstructor = reverseEngineeringClass.getConstructor(new Class[] {});
+			result = (RevengStrategy)reverseEngineeringConstructor.newInstance();
+		} catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException exception) {
 			throw new RuntimeException("An exporter of class '" + reverseEngineeringClassName + "' could not be created", exception);
 		}
 		return result;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
