### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getColumnIterator()' in 'org.hibernate.tool.internal.reveng.binder.VersionPropertyBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/VersionPropertyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/VersionPropertyBinder.java
@@ -1,6 +1,5 @@
 package org.hibernate.tool.internal.reveng.binder;
 
-import java.util.Iterator;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -46,9 +45,7 @@ class VersionPropertyBinder extends AbstractBinder {
 			Set<Column> processed) {
 		TableIdentifier identifier = TableIdentifier.create(table);
 		LOGGER.log(Level.INFO, "Scanning " + identifier + " for <version>/<timestamp> columns.");
-		Iterator<?> columnIterator = table.getColumnIterator();
-		while(columnIterator.hasNext()) {
-			Column column = (Column) columnIterator.next();
+		for (Column column : table.getColumns()) {
 			boolean useIt = getRevengStrategy().useColumnForOptimisticLock(identifier, column.getName());
 			if(useIt && !processed.contains(column)) {
 				bindVersionProperty(table, column, rc, processed);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
