### PR TITLE
 HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Replace deprecated use of 'Session#saveOrUpdate(...)' by 'Session#persist(...)'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/stat/Statistics/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/stat/Statistics/TestCase.java
@@ -67,7 +67,7 @@ public class TestCase {
 			group.addUser(new User("max" + i, "figo123"));
 			group.addUser(new User("anthony" + i, "figo123"));
 
-			s.saveOrUpdate( group );
+			s.persist( group );
 			if(i % 20==0) s.flush();
 		}
 		s.flush();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
