### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'ForeignKey#getColumnIterator()' in 'org.hibernate.tool.internal.reveng.strategy.AbstractStrategy'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
@@ -251,7 +251,7 @@ public abstract class AbstractStrategy implements RevengStrategy {
 				fkColumns != null && pkForeignTableColumns != null
 				&& fkColumns.size() == pkForeignTableColumns.size();
 
-			Iterator<Column> columns = foreignKey.getColumnIterator();
+			Iterator<Column> columns = foreignKey.getColumns().iterator();
 			while (equals && columns.hasNext()) {
 				Column fkColumn = (Column) columns.next();
 				equals = equals && pkForeignTableColumns.contains(fkColumn);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
