### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getColumnIterator()' in 'org.hibernate.tool.internal.reveng.strategy.AbstractStrategy'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
@@ -290,9 +290,7 @@ public abstract class AbstractStrategy implements RevengStrategy {
 			
 			// tests that all columns are implied in the fks
 			Set<Column> columns = new HashSet<Column>();
-			Iterator<?> columnIterator = table.getColumnIterator();
-			while ( columnIterator.hasNext() ) {
-				Column column = (Column) columnIterator.next();
+			for (Column column : table.getColumns()) {
 				columns.add(column);
 			}
 			


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
