### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'PersistentClass#getPropertyClosureIterator()' from ''org.hibernate.tool.internal.reveng.binder.BinderUtils'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
@@ -49,7 +49,7 @@ public class BinderUtils {
         if( clazz.isVersioned() ) {
             list.add( clazz.getVersion() );
         }
-		Iterator<Property> propertyClosureIterator = clazz.getPropertyClosureIterator();
+		Iterator<Property> propertyClosureIterator = clazz.getProperties().iterator();
         JoinedIterator<Property> iterator = 
         		new JoinedIterator<Property>( 
         				list.iterator(), 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
