### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove unneeded '@SuppressWarnings('unchecked')' from 'org.hibernate.tool.internal.reveng.binder.BinderUtils'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/BinderUtils.java
@@ -40,7 +40,6 @@ public class BinderUtils {
         return propertyName;
     }
 
-    @SuppressWarnings("unchecked")
     public static String makeUnique(PersistentClass clazz, String propertyName) {
         List<Property> list = new ArrayList<Property>();
         if( clazz.hasIdentifierProperty() ) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
