### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Value#getColumnIterator()' from 'org.hibernate.tool.internal.export.hbm.Cfg2HbmTool'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -31,6 +31,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.PersistentClassVisitor;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
+import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Subclass;
@@ -327,11 +328,9 @@ public class Cfg2HbmTool {
 
 
 	public Formula getFormulaForProperty(Property prop) {
-		Iterator<?> iter = prop.getValue().getColumnIterator();
-		while ( iter.hasNext() ) {
-			Object o = iter.next();
-			if (o instanceof Formula)
-				return (Formula) o;
+		for (Selectable selectable : prop.getValue().getSelectables()) {
+			if (selectable instanceof Formula)
+				return (Formula) selectable;
 		}
 		return null;
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
