### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'PersistentClass#getUnjoinedPropertyIterator()' from 'org.hibernate.tool.internal.export.hbm.Cfg2HbmTool'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -461,6 +461,6 @@ public class Cfg2HbmTool {
 	}
 
 	public Iterator<?> getProperties(PersistentClass pc) {
-		return new SkipBackRefPropertyIterator(pc.getUnjoinedPropertyIterator());
+		return new SkipBackRefPropertyIterator(pc.getProperties().iterator());
 	}
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
