### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'PersistentClass#getPropertyIterator()' from 'org.hibernate.tool.internal.export.java.Cfg2JavaTool'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/Cfg2JavaTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/Cfg2JavaTool.java
@@ -309,10 +309,8 @@ public class Cfg2JavaTool {
 	 *         TODO: handle this in a template ?
 	 */
 	public String asNaturalIdParameterList(PersistentClass clazz) {
-		Iterator<?> fields = clazz.getRootClass().getPropertyIterator();
 		StringBuffer buf = new StringBuffer();
-		while ( fields.hasNext() ) {
-			Property field = (Property) fields.next();
+		for (Property field : clazz.getRootClass().getProperties()) {
 			if ( field.isNaturalIdentifier() ) {
 				buf.append( getJavaTypeName( field, false ) ) 
 						.append( " " )


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
