### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove unchecked conversion warning by using 'Map<String,PersistentClass>' in 'org.hibernate.tool.internal.reveng.binder.CollectionSecondPass'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/CollectionSecondPass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/CollectionSecondPass.java
@@ -26,11 +26,10 @@ public class CollectionSecondPass extends org.hibernate.cfg.CollectionSecondPass
 
    @SuppressWarnings("rawtypes")
    public void secondPass(Map persistentClasses, Map inheritedMetas) throws MappingException {
-        bindCollectionSecondPass(getCollection(), persistentClasses, mdbc, inheritedMetas);
+        bindCollectionSecondPass(getCollection(), mdbc, inheritedMetas);
     }
 
-    @SuppressWarnings("rawtypes")
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
     	Value element = getCollection().getElement();
     	DependantValue elementDependantValue = null;
     	String oldElementForeignKeyName = null;
@@ -58,8 +57,7 @@ public class CollectionSecondPass extends org.hibernate.cfg.CollectionSecondPass
 
     private void bindCollectionSecondPass(
             Collection collection,
-            Map<?,?> persistentClasses,
-            MetadataBuildingContext mdbc,
+             MetadataBuildingContext mdbc,
             Map<?,?> inheritedMetas) throws MappingException {
         if(collection.isOneToMany() ) {
             OneToMany oneToMany = (OneToMany) collection.getElement();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
