### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Constraint#getColumnIterator()' from 'org.hibernate.tool.internal.export.doc.DocHelper'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
@@ -431,7 +431,7 @@ public final class DocHelper {
 	}
 	
 	public Iterator<Column> getPrimaryKeyColumnIterator(Table table) {
-		return table.getPrimaryKey().getColumnIterator();
+		return table.getPrimaryKey().getColumns().iterator();
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
