### PR TITLE
 HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getColumnIterator()' from 'org.hibernate.tool.internal.export.doc.DocHelper'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
@@ -174,9 +174,7 @@ public final class DocHelper {
 			}
 			tableList.add(table);
 
-			Iterator<Column> columns = table.getColumnIterator();
-			while (columns.hasNext()) {
-				Column column = columns.next();
+			for(Column column : table.getColumns()) {
 				String columnFQN = getQualifiedColumnName(table, column);
 				List<Value> values = valuesByColumn.get(columnFQN);
 				if (values == null) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
