### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'PersistentClass#getPropertyIterator()' from 'org.hibernate.tool.internal.export.doc.DocHelper'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/doc/DocHelper.java
@@ -196,9 +196,7 @@ public final class DocHelper {
 
 			this.processClass(pojoClazz);
 
-			Iterator<Property> propertyIterator = clazz.getPropertyIterator();
-			while (propertyIterator.hasNext()) {
-				Property property = propertyIterator.next();
+			for (Property property : clazz.getProperties()) {
 				Value value = property.getValue();
 				List<Property> props = propsByValue.get(value);
 				if (props == null) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
