### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'PersistentClass#getPropertyIterator()' from ''org.hibernate.tool.internal.export.lint.EntityModelDetector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/EntityModelDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/EntityModelDetector.java
@@ -22,11 +22,8 @@ public abstract class EntityModelDetector extends Detector {
 		if(clazz.hasIdentifierProperty()) {
 			this.visitProperty(clazz, clazz.getIdentifierProperty(), collector);								
 		}
-		Iterator<?> propertyIterator = clazz.getPropertyIterator();
-		while ( propertyIterator.hasNext() ) {
-			Property property = (Property) propertyIterator.next();
-			this.visitProperty(clazz, property, collector);					
-			
+		for (Property property : clazz.getProperties()) {
+			this.visitProperty(clazz, property, collector);							
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
