### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Constraint#getColumnIterator()' from ''org.hibernate.tool.internal.export.java.EntityPOJOClass'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
@@ -202,7 +202,7 @@ public class EntityPOJOClass extends BasicPOJOClass {
 				continue;
 			}
 			AnnotationBuilder constraint = AnnotationBuilder.createAnnotation( importType("jakarta.persistence.UniqueConstraint") );
-			constraint.addQuotedAttributes( "columnNames", new IteratorTransformer<Column>(key.getColumnIterator()) {
+			constraint.addQuotedAttributes( "columnNames", new IteratorTransformer<Column>(key.getColumns().iterator()) {
 				public String transform(Column column) {
 					return column.getName();
 				}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
