### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getUniqueKeyIterator()' from 'org.hibernate.tool.internal.export.java.EntityPOJOClass'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/EntityPOJOClass.java
@@ -194,10 +194,8 @@ public class EntityPOJOClass extends BasicPOJOClass {
 	}
 
 	protected String generateAnnTableUniqueConstraint(Table table) {
-		Iterator<UniqueKey> uniqueKeys = table.getUniqueKeyIterator();
 		List<String> cons = new ArrayList<String>();
-		while ( uniqueKeys.hasNext() ) {
-			UniqueKey key = (UniqueKey) uniqueKeys.next();
+		for (UniqueKey key : table.getUniqueKeys().values()) {
 			if (table.hasPrimaryKey() && table.getPrimaryKey().getColumns().equals(key.getColumns())) {
 				continue;
 			}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
