### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getForeignKeyIterator()' from ''org.hibernate.tool.internal.reveng.binder.ForeignKeyUtils'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyUtils.java
@@ -10,9 +10,7 @@ import org.hibernate.mapping.ForeignKey;
 public class ForeignKeyUtils {
 
     public static boolean isUniqueReference(ForeignKey foreignKey) {
-    	Iterator<?> foreignKeyIterator = foreignKey.getTable().getForeignKeyIterator();
-    	while ( foreignKeyIterator.hasNext() ) {
-			ForeignKey element = (ForeignKey) foreignKeyIterator.next();
+		for (ForeignKey element : foreignKey.getTable().getForeignKeys().values()) {
 			if(element!=foreignKey && element.getReferencedTable().equals(foreignKey.getReferencedTable())) {
 				return false;
 			}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
