### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getForeignKeyIterator()' from 'org.hibernate.tools.test.util.HibernateUtil'

### DIFF
--- a/test/utils/src/main/java/org/hibernate/tools/test/util/HibernateUtil.java
+++ b/test/utils/src/main/java/org/hibernate/tools/test/util/HibernateUtil.java
@@ -48,9 +48,7 @@ public class HibernateUtil {
 	
 	public static ForeignKey getForeignKey(Table table, String fkName) {
 		ForeignKey result = null;
-		Iterator<?> iter = table.getForeignKeyIterator();
-		while (iter.hasNext()) {
-			ForeignKey fk = (ForeignKey) iter.next();
+		for (ForeignKey fk : table.getForeignKeys().values()) {
 			if (fk.getName().equals(fkName)) {
 				result = fk;
 				break;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
