### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Environment.getBytecodeProvider()' from 'org.hibernate.tool.internal.export.lint.InstrumentationDetector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/InstrumentationDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/InstrumentationDetector.java
@@ -18,7 +18,7 @@ public class InstrumentationDetector extends EntityModelDetector {
 	
 	public void initialize(Metadata metadata) {
 		super.initialize(metadata);	
-		BytecodeProvider bytecodeProvider = Environment.getBytecodeProvider();
+		BytecodeProvider bytecodeProvider = Environment.buildBytecodeProvider(Environment.getProperties());
 		if(bytecodeProvider != null 
 				&& !(bytecodeProvider instanceof org.hibernate.bytecode.internal.none.BytecodeProviderImpl)) {
 			enhanceEnabled = true;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
