### PR TITLE
HBX-2324: Replace the deprecated uses of 'java.lang.Class#newInstance(...)' with 'java.lang.reflect.Constructor#newInstance(...)' - Perform changes in 'org.hibernate.tool.ant.JDBCConfigurationTask'

### DIFF
--- a/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -132,8 +132,9 @@ public class JDBCConfigurationTask extends ConfigurationTask {
         catch (NoSuchMethodException e) {
 			try {
 				getProject().log("Could not find public " + className + "(ReverseEngineeringStrategy delegate) constructor on ReverseEngineeringStrategy. Trying no-arg version.",Project.MSG_VERBOSE);			
-				Class<?> clazz = ReflectionUtil.classForName(className);						
-				RevengStrategy rev = (RevengStrategy) clazz.newInstance();
+				Class<?> clazz = ReflectionUtil.classForName(className);	
+				Constructor<?> constructor = clazz.getConstructor(new Class[] {});
+				RevengStrategy rev = (RevengStrategy) constructor.newInstance();
 				getProject().log("Using non-delegating strategy, thus packagename and revengfile will be ignored.", Project.MSG_INFO);
 				return rev;
 			} 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
