### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'TablegetForeignKeyIterator()' from 'org.hibernate.tool.interval.reveng.binder.OneToManyBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToManyBinder.java
@@ -113,12 +113,10 @@ class OneToManyBinder extends AbstractBinder {
 	}
 	
 	private ForeignKey getToForeignKey(ForeignKey fromForeignKey) {
-    	Iterator<?> foreignKeyIterator = fromForeignKey.getTable().getForeignKeyIterator();
     	List<ForeignKey> keys = new ArrayList<ForeignKey>();
-    	while (foreignKeyIterator.hasNext()) {
-			ForeignKey next = (ForeignKey)foreignKeyIterator.next();
-			if(next!=fromForeignKey) {
-				keys.add(next);
+		for (ForeignKey foreignKey : fromForeignKey.getTable().getForeignKeys().values()) {
+			if(foreignKey!=fromForeignKey) {
+				keys.add(foreignKey);
 			}
 		}
     	if(keys.size()>1) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
