### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'ForeignKey.getColumnIterator()' from 'org.hibernate.tool.internal.reveng.binder.OneToOneBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToOneBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/OneToOneBinder.java
@@ -1,6 +1,5 @@
 package org.hibernate.tool.internal.reveng.binder;
 
-import java.util.Iterator;
 import java.util.Set;
 
 import org.hibernate.FetchMode;
@@ -54,9 +53,7 @@ class OneToOneBinder extends AbstractBinder {
     }
     
     private void addColumns(ForeignKey foreignKey, OneToOne oneToOne, Set<Column> processedColumns) {
-        Iterator<Column> columns = foreignKey.getColumnIterator();
-        while (columns.hasNext()) {
-            Column fkcolumn = (Column) columns.next();
+        for (Column fkcolumn : foreignKey.getColumns()) {
 			BinderUtils.checkColumnForMultipleBinding(fkcolumn);
             oneToOne.addColumn(fkcolumn);
             processedColumns.add(fkcolumn);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
