### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'TablegetForeignKeyIterator()' from 'org.hibernate.tool.interval.reveng.strategy.OverrideRepository'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/OverrideRepository.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/OverrideRepository.java
@@ -574,9 +574,7 @@ public class OverrideRepository  {
 	}
 
 	public void addTable(Table table, String wantedClassName) {
-		Iterator<?> fkIter = table.getForeignKeyIterator();
-		while ( fkIter.hasNext() ) {
-			ForeignKey fk = (ForeignKey) fkIter.next();
+		for (ForeignKey fk : table.getForeignKeys().values()) {
 			TableIdentifier identifier = TableIdentifier.create(fk.getReferencedTable());
 			List<ForeignKey> existing = foreignKeys.get(identifier);
 			if(existing==null) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
