### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getColumnIterator()' from 'org.hibernate.tool.internal.reveng.binder.PrimaryKeyBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
@@ -167,9 +167,7 @@ class PrimaryKeyBinder extends AbstractBinder {
 		else {
 			LOGGER.log(Level.INFO, "No primary key found for " + table + ", using all properties as the identifier.");
 			result = new ArrayList<Column>();
-			Iterator<?> iter = table.getColumnIterator();
-			while (iter.hasNext() ) {
-				Column col = (Column) iter.next();
+			for (Column col : table.getColumns()) {
 				result.add(col);
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
