### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getForeignKeyIterator()' from 'org.hibernate.tool.interval.reveng.binder.PrimaryKeyBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyUtils.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/ForeignKeyUtils.java
@@ -1,7 +1,7 @@
 package org.hibernate.tool.internal.reveng.binder;
 
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.mapping.Column;
@@ -18,23 +18,20 @@ public class ForeignKeyUtils {
 		return true;
 	}
 
-    public static List<Object> findForeignKeys(Iterator<?> foreignKeyIterator, List<Column> pkColumns) {
+    public static List<Object> findForeignKeys(Collection<ForeignKey> foreignKeys, List<Column> pkColumns) {
     	List<ForeignKey> tempList = new ArrayList<ForeignKey>();
-    	while(foreignKeyIterator.hasNext()) {
-    		tempList.add((ForeignKey)foreignKeyIterator.next());
+     	for (ForeignKey fk : foreignKeys) {
+    		tempList.add(fk);
     	}
     	List<Object> result = new ArrayList<Object>();
     	Column[] myPkColumns = pkColumns.toArray(new Column[pkColumns.size()]);
     	for (int i = 0; i < myPkColumns.length; i++) {
     		boolean foundKey = false;
-    		foreignKeyIterator = tempList.iterator();
-    		while(foreignKeyIterator.hasNext()) {
-    			ForeignKey key = (ForeignKey)foreignKeyIterator.next();
+    	    for (ForeignKey key : tempList) {
     			List<Column> matchingColumns = columnMatches(myPkColumns, i, key);
     			if(!matchingColumns.isEmpty()) {
     				result.add(new ForeignKeyForColumns(key, matchingColumns));
     				i+=matchingColumns.size()-1;
-    				foreignKeyIterator.remove();
     				foundKey=true;
     				break;
     			}

--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
@@ -306,7 +306,7 @@ class PrimaryKeyBinder extends AbstractBinder {
             return new ArrayList<Object>(keyColumns);
         }
 		else {
-            return ForeignKeyUtils.findForeignKeys(table.getForeignKeyIterator(), keyColumns);
+            return ForeignKeyUtils.findForeignKeys(table.getForeignKeys().values(), keyColumns);
         }
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
