### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'PersistentClass#getPropertyClosureIterator()' from 'org.hibernate.tool.internal.reveng.binder.PrimaryKeyBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/PrimaryKeyBinder.java
@@ -213,9 +213,7 @@ class PrimaryKeyBinder extends AbstractBinder {
     }
 
 	private Property getConstrainedOneToOne(RootClass rc) {
-		Iterator<?> propertyClosureIterator = rc.getPropertyClosureIterator();
-		while (propertyClosureIterator.hasNext()) {
-			Property property = (Property) propertyClosureIterator.next();
+		for (Property property : rc.getProperties()) {
 			if(property.getValue() instanceof OneToOne) {
 				OneToOne oto = (OneToOne) property.getValue();
 				if(oto.isConstrained()) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
