### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Session.createQuery(String)' from 'org.hibernate.tool.internal.export.query.QueryExporter'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/query/QueryExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/query/QueryExporter.java
@@ -19,7 +19,6 @@ import org.hibernate.tool.internal.export.common.AbstractExporter;
  **/
 public class QueryExporter extends AbstractExporter {
 
-	@SuppressWarnings({ "unchecked" })
 	public void doStart() {
 		Session session = null;
 		SessionFactory sessionFactory = null;
@@ -31,7 +30,7 @@ public class QueryExporter extends AbstractExporter {
 			for (Iterator<?> iter = getQueryList().iterator(); iter.hasNext();) {
 				String query = (String) iter.next();
 				
-				List<Object> list = session.createQuery(query).getResultList();
+				List<Object> list = session.createQuery(query, null).getResultList();
 				
 				if(getFileName()!=null) {
 					PrintWriter pw = null;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
