### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getColumnIterator()' from 'org.hibernate.tool.internal.export.lint.RelationalModelDetector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/RelationalModelDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/RelationalModelDetector.java
@@ -17,9 +17,7 @@ public abstract class RelationalModelDetector extends Detector {
 	abstract protected void visit(Table table, Column col, IssueCollector collector);
 
 	protected void visitColumns(Table table, IssueCollector collector) {
-		Iterator<?> columnIter = table.getColumnIterator();
-		while ( columnIter.hasNext() ) {
-			Column col = ( Column ) columnIter.next();
+		for (Column col : table.getColumns()) {
 			this.visit(table, col, collector );
 		}		
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
