### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Constraint#getColumnIterator()' from 'org.hibernate.tool.internal.reveng.binder.RootClassBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
@@ -133,7 +133,7 @@ public class RootClassBinder extends AbstractBinder {
 		for(Iterator<?> iterator = table.getForeignKeyIterator(); iterator.hasNext();) {
 			ForeignKey foreignKey = (ForeignKey) iterator.next();
 			boolean mutable = true;
-            if ( contains( foreignKey.getColumnIterator(), processedColumns ) ) {
+            if ( contains( foreignKey.getColumns().iterator(), processedColumns ) ) {
 				if ( !preferBasicCompositeIds() ) continue; //it's in the pk, so skip this one
 				mutable = false;
             }           


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
