### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Table#getColumnIterator()' from 'org.hibernate.tool.internal.reveng.binder.RootClassBinder'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/binder/RootClassBinder.java
@@ -142,8 +142,7 @@ public class RootClassBinder extends AbstractBinder {
 	}
 
 	private void bindColumnsToProperties(Table table, RootClass rc, Set<Column> processedColumns) {
-		for (Iterator<?> iterator = table.getColumnIterator(); iterator.hasNext();) {
-			Column column = (Column) iterator.next();
+		for (Column column : table.getColumns()) {
 			if ( !processedColumns.contains(column) ) {
 				BinderUtils.checkColumnForMultipleBinding(column);
 				String propertyName = getColumnToPropertyNameInRevengStrategy(table, column);				


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
