### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Suppress 'deprecation' warning in 'org.hibernate.tool.internal.export.lint.SchemaByMetaDataDetector'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/lint/SchemaByMetaDataDetector.java
@@ -39,6 +39,7 @@ import org.hibernate.tool.internal.reveng.strategy.TableSelectorStrategy;
 import org.hibernate.tool.internal.util.JdbcToHibernateTypeHelper;
 import org.hibernate.tool.internal.util.TableNameQualifier;
 
+@SuppressWarnings("deprecation")
 public class SchemaByMetaDataDetector extends RelationalModelDetector {
 
 	public String getName() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
