### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Statistics#getStartTime()' from 'org.hibernate.tool.internal.stat.StatisticsCellRenderer'

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/stat/StatisticsCellRenderer.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/stat/StatisticsCellRenderer.java
@@ -29,7 +29,7 @@ public class StatisticsCellRenderer extends DefaultTreeCellRenderer {
 		String tooltip = null;
 		if(value instanceof Statistics) {
 			Statistics stats = (Statistics) value;
-			text = "Statistics " + formatter.format( new Date(stats.getStartTime()) );
+			text = "Statistics " + formatter.format( new Date(stats.getStart().toEpochMilli()) );
 			tooltip = stats.toString();
 		}
 		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
