### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove unused import 'org.junit.jupiter.api.Disabled' from 'org.hibernate.tool.jdbc2cfg.SearchEscapeString.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/SearchEscapeString/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/SearchEscapeString/TestCase.java
@@ -32,7 +32,6 @@ import org.hibernate.tools.test.util.JUnitUtil;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
