### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Session#createQuery(String)' from 'org.hibernate.tool.jdbc2cfg.KeyPropertyCompositeId.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/KeyPropertyCompositeId/TestCase.java
@@ -204,11 +204,11 @@ public class TestCase {
 				.buildSessionFactory();
 		Session session = factory.openSession();
 		JdbcUtil.populateDatabase(this);;
-		session.createQuery("from LineItem").getResultList();
-		List<?> list = session.createQuery("from Product").getResultList();
+		session.createQuery("from LineItem", null).getResultList();
+		List<?> list = session.createQuery("from Product", null).getResultList();
 		assertEquals(2, list.size());
 		list = session
-				.createQuery("select li.id.customerOrder.id from LineItem as li")
+				.createQuery("select li.id.customerOrder.id from LineItem as li", null)
 				.getResultList();
 		assertTrue(list.size() > 0);
 		Class<?> productIdClass = ucl.loadClass("ProductId");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
