### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Session#createQuery(String)' from 'org.hibernate.tool.jdbc2cfg.PersistentClasses.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -164,7 +164,7 @@ public class TestCase {
         assertFalse(Hibernate.isInitialized(order) );
         assertFalse(Hibernate.isInitialized(order.getItemsForOrderId() ) );
         
-        order = (Orders) session.createQuery("from " + PACKAGE_NAME + ".Orders").getSingleResult();
+        order = (Orders) session.createQuery("from " + PACKAGE_NAME + ".Orders", null).getSingleResult();
          
         assertFalse(Hibernate.isInitialized(order.getItemsForOrderId() ) );
 		t.commit();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
