### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Session#createQuery(String)' from 'org.hibernate.tool.stat.Statistics.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/stat/Statistics/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/stat/Statistics/TestCase.java
@@ -72,7 +72,7 @@ public class TestCase {
 		}
 		s.flush();
 		s.clear();
-		s.createQuery( "from java.lang.Object" ).getResultList();
+		s.createQuery( "from java.lang.Object", null).getResultList();
 		tx.commit();
 		s.close();
 		sf.close();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
