### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Value#getColumnIterator()' from 'org.hibernate.tool.jdbc2cfg.CompositeId.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/CompositeId/TestCase.java
@@ -121,7 +121,7 @@ public class TestCase {
         						null, 
         						JdbcUtil.toIdentifier(this, "LINE_ITEM"))));       
         assertEquals(4,lineMapping.getIdentifier().getColumnSpan() );
-        Iterator<?> columnIterator = lineMapping.getIdentifier().getColumnIterator();
+        Iterator<Column> columnIterator = lineMapping.getIdentifier().getColumns().iterator();
         assertEquals(((Column)(columnIterator.next())).getName(), "CUSTOMER_ID_REF");
         assertEquals(((Column)(columnIterator.next())).getName(), "EXTRA_PROD_ID");
         assertEquals(((Column)(columnIterator.next())).getName(), "ORDER_NUMBER");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
