### PR TITLE
HBX-2325: Replace the API calls that were deprecated since Hibernate Core 6.0 - Remove deprecated use of 'Session.load(Class,Object)' from 'org.hibernate.tool.jdbc2cfg.PersistentClasses.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -160,7 +160,7 @@ public class TestCase {
         session = sf.openSession();
 		t = session.beginTransaction();
         
-		order = (Orders) session.load(Orders.class, Integer.valueOf(1) );
+		order = (Orders) session.getReference(Orders.class, Integer.valueOf(1) );
         assertFalse(Hibernate.isInitialized(order) );
         assertFalse(Hibernate.isInitialized(order.getItemsForOrderId() ) );
         


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
