### PR TITLE
HBX-2331: Replace deprecated API calls - Replace 'OneToOne(MetadataImplementor,Table,PersistentClass)' in 'org.hibernate.cfg.JDBCBinder'

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
+++ b/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
@@ -72,6 +72,7 @@ public class JDBCBinder {
 
 	private final MetadataBuildingContext mdbc;
 	
+	
 	private final InFlightMetadataCollector metadataCollector;
 	
 	private Metadata metadata;
@@ -278,7 +279,7 @@ public class JDBCBinder {
     private Property bindOneToOne(PersistentClass rc, Table targetTable,
             ForeignKey fk, Set<Column> processedColumns, boolean constrained, boolean inverseProperty) {
 
-        OneToOne value = new OneToOne((MetadataImplementor)metadata, targetTable, rc);
+        OneToOne value = new OneToOne(mdbc, targetTable, rc);
         value.setReferencedEntityName(revengStrategy
                 .tableToClassName(TableIdentifier.create(targetTable)));
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
