### PR TITLE
HBX-2331: Replace deprecated API calls - Replace 'ManyToOne(MetadataImplementor,Table)' in 'org.hibernate.cfg.JDBCBinder'

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
+++ b/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
@@ -334,7 +334,7 @@ public class JDBCBinder {
      * @param propName
      */
     private Property bindManyToOne(String propertyName, boolean mutable, Table table, ForeignKey fk, Set<Column> processedColumns) {
-        ManyToOne value = new ManyToOne((MetadataImplementor)metadata, table);
+        ManyToOne value = new ManyToOne(mdbc, table);
         value.setReferencedEntityName( fk.getReferencedEntityName() );
 		Iterator<Column> columns = fk.getColumnIterator();
         while ( columns.hasNext() ) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
