### PR TITLE
HBX-2331: Replace deprecated API calls - Replace 'ManyToOne(MetadataImplementor,Table)' in 'org.hibernate.cfg.JDBCBinder' (part 2)

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
+++ b/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
@@ -470,7 +470,7 @@ public class JDBCBinder {
 
         if(manyToMany) {
 
-        	ManyToOne element = new ManyToOne((MetadataImplementor)metadata, collection.getCollectionTable() );
+        	ManyToOne element = new ManyToOne(mdbc, collection.getCollectionTable() );
         	//TODO: find the other foreignkey and choose the other side.
         	Iterator<?> foreignKeyIterator = foreignKey.getTable().getForeignKeyIterator();
         	List<ForeignKey> keys = new ArrayList<ForeignKey>();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
