### PR TITLE
HBX-2331: Replace deprecated API calls - Replace 'OneToMany(MetadataImplementor,Table)' in 'org.hibernate.cfg.JDBCBinder'

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
+++ b/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
@@ -503,7 +503,7 @@ public class JDBCBinder {
         } else {
         	String tableToClassName = bindCollection( rc, foreignKey, null, collection );
 
-        	OneToMany oneToMany = new OneToMany((MetadataImplementor)metadata, collection.getOwner() );
+        	OneToMany oneToMany = new OneToMany(mdbc, collection.getOwner() );
 
 			oneToMany.setReferencedEntityName( tableToClassName ); // Child
         	metadataCollector.addSecondPass( new JDBCCollectionSecondPass(mdbc, collection) );


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
