### PR TITLE
HBX-2331: Replace deprecated API calls - Remove references to 'org.hibernate.stat.SecondLevelCacheStatistics' from 'org.hibernate.tool.stat.StatisticsTreeModel'

### DIFF
--- a/main/src/main/java/org/hibernate/tool/stat/StatisticsTreeModel.java
+++ b/main/src/main/java/org/hibernate/tool/stat/StatisticsTreeModel.java
@@ -1,10 +1,11 @@
 package org.hibernate.tool.stat;
 
+import java.util.Collections;
 import java.util.Map;
 
-import org.hibernate.stat.SecondLevelCacheStatistics;
-import org.hibernate.stat.Statistics;
 import org.hibernate.internal.util.collections.IdentityMap;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.hibernate.stat.Statistics;
 
 public class StatisticsTreeModel extends AbstractTreeModel {
 
@@ -36,10 +37,9 @@ public class StatisticsTreeModel extends AbstractTreeModel {
 		} else if(parent==queries) {
 			return stats.getQueryStatistics(stats.getQueries()[index]);
 		} else if(parent==secondlevelcache) {
-			return stats.getSecondLevelCacheStatistics( stats.getSecondLevelCacheRegionNames()[index]);
-		} else if(parent instanceof SecondLevelCacheStatistics) {
-			SecondLevelCacheStatistics slcs = (SecondLevelCacheStatistics) parent;			
-			return slcs.getEntries();
+			return stats.getCacheRegionStatistics(stats.getSecondLevelCacheRegionNames()[index]);
+		} else if (parent instanceof CacheRegionStatistics) {
+			return Collections.emptyMap();
 		}
 		return null;
 	}
@@ -55,9 +55,8 @@ public class StatisticsTreeModel extends AbstractTreeModel {
 			return stats.getQueries().length;
 		} else if(parent==secondlevelcache) {
 			return stats.getSecondLevelCacheRegionNames().length;
-		} else if(parent instanceof SecondLevelCacheStatistics) {
-			/*SecondLevelCacheStatistics stats = (SecondLevelCacheStatistics) parent;
-			return stats.getEntries().size();*/
+		} else if(parent instanceof CacheRegionStatistics) {
+			return 0;
 		}
 		return 0;
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
