### PR TITLE
HBX-2331: Replace deprecated API calls - Remove reference to 'Environment#getBytecodeProvider()' from 'org.hibernate.tool.hbmlint.detector.InstrumentationDetector'

### DIFF
--- a/main/src/main/java/org/hibernate/tool/hbmlint/detector/InstrumentationDetector.java
+++ b/main/src/main/java/org/hibernate/tool/hbmlint/detector/InstrumentationDetector.java
@@ -20,7 +20,7 @@ public class InstrumentationDetector extends EntityModelDetector {
 	
 	public void initialize(Metadata metadata) {
 		super.initialize(metadata);	
-		BytecodeProvider bytecodeProvider = Environment.getBytecodeProvider();
+		BytecodeProvider bytecodeProvider = Environment.buildBytecodeProvider(Environment.getProperties());
 		if(bytecodeProvider instanceof org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl) {
 			enhanceEnabled = true;
 		}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
