### PR TITLE
HBX-2331: Replace deprecated API calls - Remove use of 'TypeResolver#heuristicType(String)' from 'org.hibernate.cfg.JDBCBinder'

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
+++ b/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
@@ -904,7 +904,10 @@ public class JDBCBinder {
 				column.getLength(), column.getPrecision(), column.getScale(), column.isNullable(), generatedIdentifier
 		);
 
-		Type wantedType = metadataCollector.getTypeResolver().heuristicType(preferredHibernateType);
+		Type wantedType = metadataCollector
+				.getTypeConfiguration()
+				.getBasicTypeRegistry()
+				.getRegisteredType(preferredHibernateType);
 
 		if(wantedType!=null) {
 			int[] wantedSqlTypes = wantedType.sqlTypes(mapping);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
