### PR TITLE
HBX-2331: Replace deprecated API calls - Remove unused import 'org.junit.jupiter.api.Disabled' from 'org.hibernate.tool.jdbc2cfg.Identity.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/Query/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Query/TestCase.java
@@ -31,7 +31,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/test/oracle/src/test/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
+++ b/test/oracle/src/test/java/org/hibernate/tool/jdbc2cfg/Identity/TestCase.java
@@ -31,7 +31,6 @@ import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
