### PR TITLE
HBX-2335: Replace deprecated API calls - Remove use of 'org.hibernatetype.TypeResolver' from 'org.hibernate.tool.hbm2x.Cfg2JavaTool'

### DIFF
--- a/main/src/main/java/org/hibernate/tool/hbm2x/Cfg2JavaTool.java
+++ b/main/src/main/java/org/hibernate/tool/hbm2x/Cfg2JavaTool.java
@@ -33,7 +33,6 @@ import org.hibernate.tool.hbm2x.visitor.JavaTypeFromValueVisitor;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.PrimitiveType;
 import org.hibernate.type.Type;
-import org.hibernate.type.TypeResolver;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.jboss.logging.Logger;
 
@@ -337,14 +336,15 @@ public class Cfg2JavaTool {
 	public String asFinderArgumentList(Map<Object,Object> parameterTypes, ImportContext ctx) {
 		StringBuffer buf = new StringBuffer();
 		Iterator<Entry<Object,Object>> iter = parameterTypes.entrySet().iterator();
-		TypeResolver typeResolver = new TypeConfiguration().getTypeResolver();
 		while ( iter.hasNext() ) {
 			Entry<Object,Object> entry = iter.next();
 			String typename = null;
 			Type type = null;
 			if(entry.getValue() instanceof String) {
 				try {
-					type = typeResolver.heuristicType((String) entry.getValue());
+					type = new TypeConfiguration()
+							.getBasicTypeRegistry()
+							.getRegisteredType((String) entry.getValue());
 				} catch(Throwable t) {
 					type = null;
 					typename = (String) entry.getValue();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>

