### PR TITLE
HBX-2335: Replace deprecated API calls - Remove use of 'Environment.getBytecodeProvider()' from 'org.hibernate.tool.hbmlint.detector.InstrumentationDetector'

### DIFF
--- a/main/src/main/java/org/hibernate/tool/hbmlint/detector/InstrumentationDetector.java
+++ b/main/src/main/java/org/hibernate/tool/hbmlint/detector/InstrumentationDetector.java
@@ -20,9 +20,8 @@ public class InstrumentationDetector extends EntityModelDetector {
 	
 	public void initialize(Metadata metadata) {
 		super.initialize(metadata);	
-		BytecodeProvider bytecodeProvider = Environment.getBytecodeProvider();
-		if(bytecodeProvider instanceof org.hibernate.bytecode.internal.javassist.BytecodeProviderImpl ||
-		   bytecodeProvider instanceof org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl) {
+		BytecodeProvider bytecodeProvider = Environment.buildBytecodeProvider(Environment.getProperties());
+		if(bytecodeProvider instanceof org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl) {
 			enhanceEnabled = true;
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
