### PR TITLE
HBX-2335: Replace deprecated API calls - Suppress the 'serial' warning in 'org.hibernate.tool.ant.Query.SerializableResult'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/Query/SerializableResult.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Query/SerializableResult.java
@@ -21,6 +21,7 @@ package org.hibernate.tool.ant.Query;
 
 import java.io.Serializable;
 
+@SuppressWarnings("serial")
 public class SerializableResult implements Serializable {
 	
 	public String id;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
