### PR TITLE
HBX-2335: Replace deprecated API calls - Remove unused import of 'orgjunit.jupiter.api.Disabled' from 'org.hibernate.tool.ant.Query.TestCase'

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/ant/Query/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/ant/Query/TestCase.java
@@ -31,7 +31,6 @@ import org.hibernate.tools.test.util.JdbcUtil;
 import org.hibernate.tools.test.util.ResourceUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
