### PR TITLE
HBX-2362: Update the dependency on hibernate-commons-annotations to version 6.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <freemarker.version>2.3.31</freemarker.version>
         <google-java-format.version>1.13.0</google-java-format.version>
         <h2.version>2.1.210</h2.version>
-        <hibernate-commons-annotations.version>6.0.1.Final</hibernate-commons-annotations.version>
+        <hibernate-commons-annotations.version>6.0.2.Final</hibernate-commons-annotations.version>
         <hibernate-orm.version>6.0.2.Final</hibernate-orm.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <javaee-api.version>8.0.1</javaee-api.version>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
