### PR TITLE
HBX-2365: Remove the Jaxen dependency where not needed - Remove from the 'orm' module

### DIFF
--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -40,10 +40,6 @@
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
         </dependency>
- 		<dependency>
-			<groupId>jaxen</groupId>
-			<artifactId>jaxen</artifactId>
-		</dependency> 
   		<dependency>
 	        <groupId>org.antlr</groupId>
 			<artifactId>antlr4-runtime</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
