### PR TITLE
HBX-2365: Remove the Jaxen dependency where not needed - Remove from the 'test/common' module

### DIFF
--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -36,10 +36,6 @@
     <name>Hibernate Tools Common Database Tests Project</name>
 
     <dependencies>
-		<dependency>
-			<groupId>jaxen</groupId>
-			<artifactId>jaxen</artifactId>
-		</dependency>
 	   	<dependency>
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-orm</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
