### PR TITLE
HBX-2365: Remove the Jaxen dependency where not needed - Remove from the 'test/nodb' module

### DIFF
--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -41,10 +41,6 @@
 		    <groupId>javax</groupId>
 		    <artifactId>javaee-api</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>jaxen</groupId>
-			<artifactId>jaxen</artifactId>
-		</dependency>
     	<dependency>
     		<groupId>org.hibernate.tool</groupId>
     		<artifactId>hibernate-tools-ant</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
