### PR TITLE
HBX-2365: Remove the Jaxen dependency where not needed - Remove from the 'test/nodb' module

### DIFF
--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -26,10 +26,6 @@
    		    <artifactId>hibernate-tools-tests-utils</artifactId>
    	    </dependency>
 		<dependency>
-			<groupId>jaxen</groupId>
-			<artifactId>jaxen</artifactId>
-		</dependency>
-		<dependency>
 		    <groupId>javax</groupId>
 		    <artifactId>javaee-api</artifactId>
 		</dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
