### PR TITLE
HBX-2365: Remove the Jaxen dependency where not needed - Remove from the 'main' module

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -68,10 +68,6 @@
 			<groupId>javax.persistence</groupId>
 			<artifactId>javax.persistence-api</artifactId>
 		</dependency>
- 		<dependency>
-			<groupId>jaxen</groupId>
-			<artifactId>jaxen</artifactId>
-		</dependency> 
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
