### PR TITLE
HBX-2365: Remove the Jaxen dependency where not needed - Remove from the parent module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
 	    <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
-        <jaxen.version>1.2.0</jaxen.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <mysql.version>8.0.22</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
@@ -93,12 +92,6 @@
 			    <version>${jaxb-api.version}</version>
 			    <scope>runtime</scope>
 		    </dependency>
-  	        <dependency>
-                <groupId>jaxen</groupId>
-                <artifactId>jaxen</artifactId>
-                <version>${jaxen.version}</version>
-                <scope>runtime</scope>
-            </dependency> 
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
