### PR TITLE
HBX-2371: Update Hibernate ORM Dependency to Version 6.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <google-java-format.version>1.15.0</google-java-format.version>
         <h2.version>2.1.214</h2.version>
         <hibernate-commons-annotations.version>6.0.2.Final</hibernate-commons-annotations.version>
-        <hibernate-orm.version>6.0.2.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.1.0.Final</hibernate-orm.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <javaee-api.version>8.0.1</javaee-api.version>
         <jboss-logging.version>3.4.3.Final</jboss-logging.version>


### PR DESCRIPTION
fixes: [HBX-2371](https://hibernate.atlassian.net/browse/HBX-2371)
Signed-off-by: blafond [blafond@redhat.com](mailto:blafond@redhat.com)