### PR TITLE
HBX-2375: Fix the problem while publishing the test results with 'scacap/action-surefire-report' - Remove step 'Archive Test Artifacts' from 'workflows/build_test.yml'

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,11 +26,4 @@ jobs:
       with: 
         run: mvn clean install -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
 
-    - name: Archive Test Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-reports
-        path: |
-          **/*target/surefire-reports/
-          **/*.log
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
