### PR TITLE
HBX-2375: Fix the problem while publishing the test results with 'scacap/action-surefire-report' - Add 'scripts/check_build_result.sh'

### DIFF
--- a/.github/scripts/check_build_result.sh
+++ b/.github/scripts/check_build_result.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Expected build log as argument"
+    exit 1
+fi
+
+if grep -q 'BUILD FAILURE' $1 ; then
+    echo "Build failure detected, please inspect build log"
+    exit 1
+else
+    echo "Build successful"
+    exit 0
+fi


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
