### PR TITLE
HBX-2375: Fix the problem while publishing the test results with 'scacap/action-surefire-report' - Add a new step to write Maven output to console

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,7 +26,10 @@ jobs:
       with: 
         run: mvn clean install -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true --log-file build.output
 
-    - name: Check for test failures
+    - name: Write Maven Output to Console
+      run: cat build.output
+
+    - name: Check for Test Failures
       run: ./.github/scripts/check_build_result.sh build.output
 
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
