### PR TITLE
HBX-2375: Fix the problem while publishing the test results with 'scacap/action-surefire-report' - Just use 'mvn clean install' and let the workflow fail when there are failures/errors

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -24,13 +24,5 @@ jobs:
     - name: Build and Test
       uses: GabrielBB/xvfb-action@v1
       with: 
-        run: mvn clean install  --log-file build.output
-
-    - name: Write Maven Output to Console
-      run: cat build.output
-
-    - name: Check for Test Failures
-      run: ./.github/scripts/check_build_result.sh build.output
-
-
+        run: mvn clean install 
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
