### PR TITLE
HBX-2381: Update Javassist Maven dependency to version 3.29.0-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.24.1-GA</version>
+            <version>3.29.0-GA</version>
             <scope>test</scope>
         </dependency>	
 	    <dependency>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
