### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools - Add test class 'org.hibernate.tool.orm.jbt.util.DummyMetadataDescriptorTest' and implementation class 'org.hibernate.tool.orm.jbt.util.DummyMetadataDescriptor

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/DummyMetadataDescriptor.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/DummyMetadataDescriptor.java
@@ -1,0 +1,40 @@
+package org.hibernate.tool.orm.jbt.util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+
+public class DummyMetadataDescriptor implements MetadataDescriptor {
+
+	private static final MetadataInvocationHandler HANDLER = new MetadataInvocationHandler();	
+	private static final Class<?>[] INTERFACES = new Class[] { Metadata.class };
+	private static final ClassLoader LOADER = Metadata.class.getClassLoader();
+
+	@Override
+	public Metadata createMetadata() {
+		return (Metadata)Proxy.newProxyInstance(LOADER, INTERFACES, HANDLER);
+	}
+
+	@Override
+	public Properties getProperties() {
+		return null;
+	}
+
+	private static class MetadataInvocationHandler implements InvocationHandler {
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			if ("getEntityBindings".equals(method.getName()) || 
+					"collectTableMappings".equals(method.getName())) {
+				return Collections.emptySet();
+			} else {
+				return null;
+			}
+		}		
+	}
+
+}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/DummyMetadataDescriptorTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/DummyMetadataDescriptorTest.java
@@ -1,0 +1,34 @@
+package org.hibernate.tool.orm.jbt.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.junit.jupiter.api.Test;
+
+public class DummyMetadataDescriptorTest {
+	
+	@Test
+	public void testConstruction() {
+		assertTrue(new DummyMetadataDescriptor() instanceof MetadataDescriptor);
+	}
+	
+	@Test
+	public void testGetProperties() {
+		assertNull(new DummyMetadataDescriptor().getProperties());
+	}
+	
+	@Test
+	public void testCreateMetadata() {
+		Metadata metadata = new DummyMetadataDescriptor().createMetadata();
+		assertNotNull(metadata);
+		assertEquals(Collections.emptySet(), metadata.getEntityBindings());
+		assertEquals(Collections.emptySet(), metadata.collectTableMappings());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
