### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools - Add test class 'org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContextTest' and implementation class 'org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/DummyMetadataBuildingContext.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/DummyMetadataBuildingContext.java
@@ -1,0 +1,31 @@
+package org.hibernate.tool.orm.jbt.util;
+
+import org.hibernate.boot.internal.BootstrapContextImpl;
+import org.hibernate.boot.internal.InFlightMetadataCollectorImpl;
+import org.hibernate.boot.internal.MetadataBuilderImpl;
+import org.hibernate.boot.internal.MetadataBuildingContextRootImpl;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.boot.spi.InFlightMetadataCollector;
+import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.cfg.AvailableSettings;
+
+public class DummyMetadataBuildingContext {
+	
+	public static MetadataBuildingContext INSTANCE = createInstance();
+	
+	private static MetadataBuildingContext createInstance() {
+		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
+		ssrb.applySetting(AvailableSettings.DIALECT, MockDialect.class.getName());
+		ssrb.applySetting(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
+		StandardServiceRegistry serviceRegistry = ssrb.build();
+		MetadataBuildingOptions metadataBuildingOptions = new MetadataBuilderImpl.MetadataBuildingOptionsImpl(serviceRegistry);
+		BootstrapContext bootstrapContext = new BootstrapContextImpl(serviceRegistry, metadataBuildingOptions);
+		((MetadataBuilderImpl.MetadataBuildingOptionsImpl)metadataBuildingOptions).setBootstrapContext(bootstrapContext);
+		InFlightMetadataCollector inflightMetadataCollector = new InFlightMetadataCollectorImpl(bootstrapContext, metadataBuildingOptions);
+		return new MetadataBuildingContextRootImpl("JBoss Tools", bootstrapContext, metadataBuildingOptions, inflightMetadataCollector);
+	}
+
+}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/DummyMetadataBuildingContextTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/DummyMetadataBuildingContextTest.java
@@ -1,0 +1,23 @@
+package org.hibernate.tool.orm.jbt.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.junit.jupiter.api.Test;
+
+public class DummyMetadataBuildingContextTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(DummyMetadataBuildingContext.INSTANCE);
+		StandardServiceRegistry serviceRegistry = DummyMetadataBuildingContext.INSTANCE
+				.getBootstrapContext().getServiceRegistry();
+		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
+		Dialect dialect = jdbcServices.getDialect();
+		assertTrue(dialect instanceof MockDialect);
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
