### PR TITLE
HBX-2404: Replace DTD references to 'http://hibernate.sourceforge.net' with 'http://hibernate.org/dtd/'

### DIFF
--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/hbm2hbmxml/FormulaTest/Customer.hbm.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/hbm2hbmxml/FormulaTest/Customer.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC 
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+	"http://hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <!--
 

--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Parent.hbm.xml
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/hbm2hbmxml/JoinTest/Parent.hbm.xml
@@ -20,7 +20,7 @@
   -->
 <!DOCTYPE hibernate-mapping PUBLIC 
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+	"http://hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <!-- 
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
