### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools - Change method 'WrapperFactory#createReverseEngineeringSettingsWrapper()' as ReverseEngineeringSettings are always created with a root ReverseEngineeringStrategy

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -2,6 +2,7 @@ package org.hibernate.tool.orm.jbt.wrp;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
@@ -20,8 +21,10 @@ public class WrapperFactory {
 		return new DefaultNamingStrategy();
 	}
 
-	public Object createReverseEngineeringSettingsWrapper() {
-		return new RevengSettings(null);
+	public Object createReverseEngineeringSettingsWrapper(Object revengStrategy) {
+		assert revengStrategy != null;
+		assert revengStrategy instanceof RevengStrategy;
+		return new RevengSettings((RevengStrategy)(revengStrategy));
 	}
 
 	public Object createReverseEngineeringStrategyWrapper() {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -1,10 +1,13 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
+import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
@@ -43,9 +46,24 @@ public class WrapperFactoryTest {
 	
 	@Test
 	public void testCreateReverseEngineeringSettings() {
-		Object reverseEngineeringSettinsWrapper = wrapperFactory.createReverseEngineeringSettingsWrapper();
-		assertNotNull(reverseEngineeringSettinsWrapper);
-		assertTrue(reverseEngineeringSettinsWrapper instanceof RevengSettings);
+		Object reverseEngineeringSettingsWrapper = null;
+		try {
+			reverseEngineeringSettingsWrapper = wrapperFactory.createReverseEngineeringSettingsWrapper(null);
+			fail();
+		} catch (Throwable t) {
+			assertTrue(t instanceof AssertionError);
+		}
+		try {
+			reverseEngineeringSettingsWrapper = wrapperFactory.createReverseEngineeringSettingsWrapper(new Object());
+			fail();
+		} catch (Throwable t) {
+			assertTrue(t instanceof AssertionError);
+		}
+		RevengStrategy strategy = new DefaultStrategy();
+		reverseEngineeringSettingsWrapper = wrapperFactory.createReverseEngineeringSettingsWrapper(strategy);
+		assertNotNull(reverseEngineeringSettingsWrapper);
+		assertTrue(reverseEngineeringSettingsWrapper instanceof RevengSettings);
+		assertSame(strategy, ((RevengSettings)reverseEngineeringSettingsWrapper).getRootStrategy());
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
