### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools - Change 'WrapperFactory.createNamingStrategyWrapper()' into 'WrapperFactory.createNamingStrategyWrapper(String namingStrategyClassName)' as the method should accept the name of the class to be created

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -17,8 +17,16 @@ public class WrapperFactory {
 		return new Cfg2HbmTool();
 	}
 
-	public Object createNamingStrategyWrapper() {
-		return new DefaultNamingStrategy();
+	public Object createNamingStrategyWrapper(String namingStrategyClassName) {
+		Object result = new DefaultNamingStrategy();
+		if (namingStrategyClassName != null) {
+			try {
+				result = Class.forName(namingStrategyClassName).getDeclaredConstructor().newInstance();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return result;
 	}
 
 	public Object createReverseEngineeringSettingsWrapper(Object revengStrategy) {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -1,6 +1,9 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -39,9 +42,24 @@ public class WrapperFactoryTest {
 	
 	@Test
 	public void testCreateNamingStrategyWrapper() {
-		Object namingStrategyWrapper = wrapperFactory.createNamingStrategyWrapper();
+		Object namingStrategyWrapper = wrapperFactory.createNamingStrategyWrapper(null);
 		assertNotNull(namingStrategyWrapper);
 		assertTrue(namingStrategyWrapper instanceof DefaultNamingStrategy);
+		namingStrategyWrapper = null;
+		assertNull(namingStrategyWrapper);
+		namingStrategyWrapper = wrapperFactory.createNamingStrategyWrapper(TestNamingStrategy.class.getName());
+		assertNotNull(namingStrategyWrapper);
+		assertTrue(namingStrategyWrapper instanceof TestNamingStrategy);
+		namingStrategyWrapper = null;
+		assertNull(namingStrategyWrapper);
+		try {
+			namingStrategyWrapper = wrapperFactory.createNamingStrategyWrapper("foo");
+			fail();
+		} catch (Exception e) {
+			assertTrue(e.getCause() instanceof ClassNotFoundException);
+			assertEquals(e.getCause().getMessage(), "foo");
+		}
+		assertNull(namingStrategyWrapper);
 	}
 	
 	@Test
@@ -72,5 +90,8 @@ public class WrapperFactoryTest {
 		assertNotNull(reverseEngineeringStrategyWrapper);
 		assertTrue(reverseEngineeringStrategyWrapper instanceof DefaultStrategy);
 	}
+	
+	@SuppressWarnings("serial")
+	static class TestNamingStrategy extends DefaultNamingStrategy {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
