### PR TITLE
HBX-2420: Hibernate tools are not published to Maven Central - Override release management in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -776,4 +776,17 @@
 
 	</profiles>
 
+    <distributionManagement>
+      <repository>
+        <id>ossrh-releases-repository</id>
+        <name>Sonatype OSSRH Releases</name>
+        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      </repository>
+      <snapshotRepository>
+        <id>ossrh-snapshots-repository</id>
+        <name>Sonatype OSSRH Snapshots</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      </snapshotRepository>
+    </distributionManagement>
+
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
