### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools - Implement new method 'WrapperFactory#createReverseEngineeringStrategyWrapper(String)' that either returns a default strategy when the argument is null or a delegating strategy that delegates to an instance of the class that is named by the argument

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -5,7 +5,9 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
+import org.hibernate.tool.orm.jbt.util.ReflectUtil;
 
 public class WrapperFactory {
 
@@ -31,8 +33,13 @@ public class WrapperFactory {
 		return new RevengSettings((RevengStrategy)(revengStrategy));
 	}
 
-	public Object createReverseEngineeringStrategyWrapper() {
-		return new DefaultStrategy();
+	public Object createReverseEngineeringStrategyWrapper(String revengStrategyClassName) {
+		if (revengStrategyClassName == null) {
+			return new DefaultStrategy();
+		} else {
+			return new DelegatingStrategy(
+					(RevengStrategy)ReflectUtil.createInstance(revengStrategyClassName));
+		}
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.reflect.Field;
+
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.NamingStrategy;
 import org.hibernate.tool.api.reveng.RevengSettings;
@@ -15,6 +17,7 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,13 +95,22 @@ public class WrapperFactoryTest {
 	}
 	
 	@Test
-	public void testCreateReverseEngineeringStrategy() {
-		Object reverseEngineeringStrategyWrapper = wrapperFactory.createReverseEngineeringStrategyWrapper();
+	public void testCreateReverseEngineeringStrategy() throws Exception {
+		Object reverseEngineeringStrategyWrapper = wrapperFactory.createReverseEngineeringStrategyWrapper(null);
 		assertNotNull(reverseEngineeringStrategyWrapper);
 		assertTrue(reverseEngineeringStrategyWrapper instanceof DefaultStrategy);
+		reverseEngineeringStrategyWrapper = 
+				wrapperFactory.createReverseEngineeringStrategyWrapper(TestRevengStrategy.class.getName());
+		assertNotNull(reverseEngineeringStrategyWrapper);
+		assertTrue(reverseEngineeringStrategyWrapper instanceof DelegatingStrategy);
+		Field delegateField = DelegatingStrategy.class.getDeclaredField("delegate");
+		delegateField.setAccessible(true);
+		assertTrue(delegateField.get(reverseEngineeringStrategyWrapper) instanceof TestRevengStrategy);
 	}
 	
 	@SuppressWarnings("serial")
-	static public class TestNamingStrategy extends DefaultNamingStrategy {}
+	public static class TestNamingStrategy extends DefaultNamingStrategy {}
+	
+	public static class TestRevengStrategy extends DefaultStrategy {}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
