### PR TITLE
HBX-2472: Reenable disabled tests after update to ORM version 6.2.0.CR1 - Default implementation of 'org.hibernate.tool.internal.reveng.strategy.AbstractStrategy#getTableIdentifierProperties(TableIdentifier)' should not return null

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/strategy/AbstractStrategy.java
@@ -163,7 +163,7 @@ public abstract class AbstractStrategy implements RevengStrategy {
 	}
 
 	public Properties getTableIdentifierProperties(TableIdentifier identifier) {
-		return null;
+		return new Properties();
 	}
 
 	public List<String> getPrimaryKeyColumnNames(TableIdentifier identifier) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
