### PR TITLE
HBX-2472: Reenable disabled tests after update to ORM version 6.2.0.CR1 - Reenable 'org.hibernate.tool.test.db.h2.TestSuite.H2TestSuite'

### DIFF
--- a/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
+++ b/test/h2/src/test/java/org/hibernate/tool/test/db/h2/TestSuite.java
@@ -20,13 +20,10 @@
 package org.hibernate.tool.test.db.h2;
 
 import org.hibernate.tool.test.db.DbTestSuite;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 
 public class TestSuite {
 	
-	// TODO Reenable this test suite and investigate the failure, see HBX-2472
-	@Disabled	
 	@Nested
 	public class H2TestSuite extends DbTestSuite {}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
