### PR TITLE
HBX-2472: Reenable disabled tests after update to ORM version 6.2.0.CR1 - Reenable 'org.hibernate.tool.hbx1093.TestCase#testGenerateJava()'

### DIFF
--- a/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
+++ b/test/h2/src/test/java/org/hibernate/tool/hbx1093/TestCase.java
@@ -37,7 +37,6 @@ import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tools.test.util.JdbcUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -65,8 +64,6 @@ public class TestCase {
 		JdbcUtil.dropDatabase(this);
 	}
 
-	// TODO Reenable this test and investigate the failure, see HBX-2472
-	@Disabled
 	@Test
 	public void testGenerateJava() throws IOException {
 		Exporter exporter = ExporterFactory.createExporter(ExporterType.JAVA);	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
