### PR TITLE
HBX-2472: Reenable disabled tests after update to ORM version 6.2.0.CR1 - Reimplement 'org.hibernate.tool.internal.export.hbm.Cfg2HbmTool#getIdentifierGeneratorProperties(Property)' to account for a 'identifierGeneratorParameters' map that is null

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/hbm/Cfg2HbmTool.java
@@ -178,7 +178,13 @@ public class Cfg2HbmTool {
 	}
 	
 	public Properties getIdentifierGeneratorProperties(Property property) {
-		return ( (SimpleValue) property.getValue() ).getIdentifierGeneratorProperties();
+		SimpleValue simpleValue = (SimpleValue)property.getValue();
+		Properties result = new Properties();
+		Map<String, Object> idGenParams = simpleValue.getIdentifierGeneratorParameters();
+		if (idGenParams != null) {
+			result.putAll(idGenParams);
+		}
+		return result;
 	}
 	
 	/**


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
