### PR TITLE
HBX-2472: Reenable disabled tests after update to ORM version 6.2.0.CR1 - Reenable 'org.hibernate.tool.hbm2x.hbm2hbmxml.SetElementTest.TestCase#testKey()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
@@ -101,8 +101,6 @@ public class TestCase {
         assertNotNull(metadataDescriptor.createMetadata());
     }
 
-	// TODO Reenable this test and investigate the failure, see HBX-2472
-	@Disabled
 	@Test
 	public void testKey() throws Exception {
 		File outputXml = 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>

