### PR TITLE
HBX-2472: Reenable disabled tests after update to ORM version 6.2.0.CR1 - Reenable 'org.hibernate.tool.hbm2x.hbm2hbmxml.SetElementTest.TestCase#testSetElement()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/SetElementTest/TestCase.java
@@ -41,7 +41,6 @@ import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tools.test.util.HibernateUtil;
 import org.hibernate.tools.test.util.JUnitUtil;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
@@ -125,8 +124,6 @@ public class TestCase {
 		}
 	}
 
-	// TODO Reenable this test and investigate the failure, see HBX-2472
-	@Disabled
 	@Test
 	public void testSetElement() throws Exception {
 		File outputXml = 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
