### PR TITLE
HBX-2472: Reenable disabled tests after update to ORM version 6.2.0.CR1 - Reenable 'org.hibernate.tool.hbm2x.hbm2hbmxml.IdBagTest.TestCase#testIdBagAttributes()'

### DIFF
--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/hbm2hbmxml/IdBagTest/TestCase.java
@@ -118,8 +118,6 @@ public class TestCase {
         assertNotNull(metadataDescriptor.createMetadata());
     }
 	
-	// TODO Reenable this test and investigate the failure, see HBX-2472
-	@Disabled
 	@Test
 	public void testIdBagAttributes() throws Exception {
 		File outputXml = new File(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>
