### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapper.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryDelegatingImpl;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
 
@@ -12,6 +13,11 @@ public class SessionFactoryWrapper extends SessionFactoryDelegatingImpl {
 	
 	public SessionFactoryWrapper(SessionFactory delegate) {
 		super((SessionFactoryImplementor)delegate);
+	}
+	
+	@Override
+	public SessionImplementor openSession() {
+		return SessionWrapperFactory.createSessionWrapper(super.openSession());
 	}
 	
 	public Map<String, EntityPersister> getAllClassMetadata() {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapperTest.java
@@ -3,14 +3,18 @@ package org.hibernate.tool.orm.jbt.wrp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -70,6 +74,14 @@ public class SessionFactoryWrapperTest {
 		configuration.configure(cfgXmlFile);
 		sessionFactoryWrapper = new SessionFactoryWrapper(
 				(SessionFactoryImplementor)configuration.buildSessionFactory());
+	}
+	
+	@Test
+	public void testOpenSession() {
+		Session session = sessionFactoryWrapper.openSession();
+		assertTrue(session instanceof Proxy);
+		InvocationHandler invocationHandler = Proxy.getInvocationHandler(session);
+		assertEquals("org.hibernate.tool.orm.jbt.wrp.SessionWrapperFactory$SessionWrapperInvocationHandler", invocationHandler.getClass().getName());
 	}
 	
 	@Test


### PR DESCRIPTION
  - Override method 'openSession()' in class 'org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapper' in order to wrap the returned instance of 'org.hibernate.engine.spi.SessionImplementor'

Signed-off-by: Koen Aers <koen.aers@gmail.com>
