### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -2,6 +2,8 @@ package org.hibernate.tool.orm.jbt.wrp;
 
 import java.util.Map;
 
+import org.hibernate.mapping.JoinedSubclass;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Subclass;
 import org.hibernate.tool.api.reveng.RevengSettings;
@@ -62,8 +64,12 @@ public class WrapperFactory {
 		return new RootClass(DummyMetadataBuildingContext.INSTANCE);
 	}
 
-	public Object createSingleTableSubClassWrapper(Object rootClassWrapper) {
-		return new Subclass((RootClass)rootClassWrapper, DummyMetadataBuildingContext.INSTANCE);
+	public Object createSingleTableSubClassWrapper(Object persistentClassWrapper) {
+		return new Subclass((PersistentClass)persistentClassWrapper, DummyMetadataBuildingContext.INSTANCE);
+	}
+
+	public Object createJoinedTableSubClassWrapper(Object persistentClassWrapper) {
+		return new JoinedSubclass((PersistentClass)persistentClassWrapper, DummyMetadataBuildingContext.INSTANCE);
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Field;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.NamingStrategy;
+import org.hibernate.mapping.JoinedSubclass;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Subclass;
 import org.hibernate.tool.api.reveng.RevengSettings;
@@ -150,6 +151,16 @@ public class WrapperFactoryTest {
 		assertNotNull(singleTableSubclassWrapper);
 		assertTrue(singleTableSubclassWrapper instanceof Subclass);
 		assertSame(((Subclass)singleTableSubclassWrapper).getRootClass(), rootClassWrapper);
+	}
+	
+	@Test
+	public void testCreateJoinedSubclassWrapper() {
+		Object rootClassWrapper = wrapperFactory.createRootClassWrapper();
+		Object joinedTableSubclassWrapper = wrapperFactory.createJoinedTableSubClassWrapper(
+				rootClassWrapper);
+		assertNotNull(joinedTableSubclassWrapper);
+		assertTrue(joinedTableSubclassWrapper instanceof JoinedSubclass);
+		assertSame(((Subclass)joinedTableSubclassWrapper).getRootClass(), rootClassWrapper);
 	}
 		
 	@SuppressWarnings("serial")


### PR DESCRIPTION
  - Add new test method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateJoinedSubclassWrapper()'
  - Add new implementation method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createJoinedTableSubClassWrapper(Object)'

Please delete this text, and add a link to the Jira issue solved by this PR;
see https://hibernate.atlassian.net/browse/HBX.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HBX-<digits>`).
