### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -23,5 +23,7 @@ public interface PersistentClassWrapper {
 	Iterator<Property> getPropertyClosureIterator();
 	PersistentClass getSuperclass();
 	Iterator<Property> getPropertyIterator();
+	Property getProperty(String name);
+	default Property getProperty() { throw new RuntimeException("getProperty() is only allowed on SpecialRootClass"); }
 
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -1,6 +1,7 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
@@ -45,7 +46,11 @@ public class PersistentClassWrapperFactory {
 		
 		@Override
 		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-			return method.invoke(wrapper, args);
+			try {
+				return method.invoke(wrapper, args);
+			} catch (InvocationTargetException t) {
+				throw t.getTargetException();
+			}
 		}	
 		
 	}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
@@ -169,6 +170,30 @@ public class PersistentClassWrapperFactoryTest {
 		rootClassTarget.addProperty(property);
 		propertyIterator = rootClassWrapper.getPropertyIterator();
 		assertSame(property, propertyIterator.next());
+	}
+	
+	@Test
+	public void testGetProperty() {
+		try {
+			rootClassWrapper.getProperty("foo");
+			fail();
+		} catch (Throwable t) {
+			assertEquals(
+					"property [foo] not found on entity [null]", 
+					t.getMessage());
+		}
+		Property property = new Property();
+		property.setName("foo");
+		rootClassTarget.addProperty(property);
+		assertSame(property, rootClassWrapper.getProperty("foo"));
+		try {
+			rootClassWrapper.getProperty();
+			fail();
+		} catch (Throwable t) {
+			assertEquals(
+					"getProperty() is only allowed on SpecialRootClass", 
+					t.getMessage());
+		}
 	}
 	
 }


### PR DESCRIPTION
  - Add method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#getProperty(String)'
  - Add method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#getProperty()'
  - Unwrap InvocationTargetException in 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.PersistentClassWrapperInvocationHandler#invoke(...)'
  - Provide new test method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testGetProperty()'
