### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/SpecialRootClass.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/SpecialRootClass.java
@@ -1,13 +1,32 @@
 package org.hibernate.tool.orm.jbt.util;
 
+import java.lang.reflect.Field;
+
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 
 public class SpecialRootClass extends RootClass {
 
-	public SpecialRootClass(Property property, MetadataBuildingContext buildingContext) {
-		super(buildingContext);
+	public SpecialRootClass(Property property) {
+		super(getMetadataBuildingContext(property));
+	}
+	
+	private static MetadataBuildingContext getMetadataBuildingContext(Property property) {
+		PersistentClass pc = property.getPersistentClass();
+		MetadataBuildingContext result = null;
+		try {
+			Field field = PersistentClass.class.getDeclaredField("metadataBuildingContext");
+			field.setAccessible(true);
+			result = (MetadataBuildingContext)field.get(pc);
+		} catch (NoSuchFieldException | 
+				SecurityException | 
+				IllegalArgumentException | 
+				IllegalAccessException e) {
+			throw new RuntimeException("Problem while trying to retrieve MetadataBuildingContext from field", e);
+		}
+		return result;
 	}
 
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -91,7 +91,7 @@ public class PersistentClassWrapperFactory {
 			extends SpecialRootClass
 			implements PersistentClassWrapper {
 		public SpecialRootClassWrapperImpl(Property property) {
-			super(property, DummyMetadataBuildingContext.INSTANCE);
+			super(property);
 		}
 	}
 	

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/SpecialRootClassTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/SpecialRootClassTest.java
@@ -1,0 +1,34 @@
+package org.hibernate.tool.orm.jbt.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Field;
+
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.RootClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SpecialRootClassTest {
+	
+	private SpecialRootClass specialRootClass = null;
+	
+	@BeforeEach 
+	public void beforeEach() {
+		PersistentClass pc = new RootClass(DummyMetadataBuildingContext.INSTANCE);
+		Property p = new Property();
+		p.setPersistentClass(pc);
+		specialRootClass = new SpecialRootClass(p);
+	}
+	
+	@Test
+	public void testConstruction() throws Exception {
+		assertNotNull(specialRootClass);
+		Field field = PersistentClass.class.getDeclaredField("metadataBuildingContext");
+		field.setAccessible(true);
+		assertSame(DummyMetadataBuildingContext.INSTANCE, field.get(specialRootClass));
+	}
+
+}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -58,6 +58,7 @@ public class PersistentClassWrapperFactoryTest {
 		invocationHandler = Proxy.getInvocationHandler(joinedSubclassWrapper);
 		joinedSubclassTarget = (PersistentClass)wrapperField.get(invocationHandler);
 		property = new Property();
+		property.setPersistentClass(rootClassTarget);
 		specialRootClassWrapper = PersistentClassWrapperFactory.createSpecialRootClassWrapper(property);
 		invocationHandler = Proxy.getInvocationHandler(specialRootClassWrapper);
 		specialRootClassTarget = (PersistentClass)wrapperField.get(invocationHandler);


### PR DESCRIPTION
  - SpecialRootClass has the same MetadataBuildingContext as the property that is used for its construction
  - Create the constructor accordingly
  - Adapt the relevant test
