### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -41,6 +41,6 @@ public interface PersistentClassWrapper extends Wrapper {
 	void setDiscriminatorValue(String str);
 	void setAbstract(Boolean b);
 	void addProperty(Property p);
-	
+	void setTable(Table table);
 	
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -10,6 +10,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SingleTableSubclass;
+import org.hibernate.mapping.Table;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 
@@ -76,6 +77,9 @@ public class PersistentClassWrapperFactory {
 			implements PersistentClassWrapper {
 		public SingleTableSubclassWrapperImpl(PersistentClass superclass) {
 			super(superclass, DummyMetadataBuildingContext.INSTANCE);
+		}
+		public void setTable(Table table) {
+			throw new RuntimeException("Method 'setTable' cannot be called for SingleTableSubclass");
 		}
 	}
 	

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -566,6 +566,28 @@ public class PersistentClassWrapperFactoryTest {
 		assertFalse(specialRootClassWrapper.isInstanceOfJoinedSubclass());
 	}
 	
+	@Test
+	public void testSetTable() {
+		Table table = new Table("");
+		assertNull(rootClassTarget.getTable());
+		assertNull(singleTableSubclassTarget.getTable());
+		rootClassWrapper.setTable(table);
+		assertSame(table, rootClassTarget.getTable());
+		assertSame(table, singleTableSubclassTarget.getTable());
+		try {
+			singleTableSubclassWrapper.setTable(new Table(""));
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals(e.getMessage(), "Method 'setTable' cannot be called for SingleTableSubclass");
+		}
+		assertNull(joinedSubclassTarget.getTable());
+		joinedSubclassWrapper.setTable(table);
+		assertSame(table, joinedSubclassTarget.getTable());
+		assertNull(specialRootClassTarget.getTable());
+		specialRootClassWrapper.setTable(table);
+		assertSame(table, specialRootClassTarget.getTable());
+	}	
+	
 	private KeyValue createValue() {
 		return (KeyValue)Proxy.newProxyInstance(
 				getClass().getClassLoader(), 


### PR DESCRIPTION
  - Add method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setTable(Table)'
  - Override default in method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.SingleTableSubclassWrapperImpl#setTable(Table)' as setting the table is not allowed in this case
  - Provide new test method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testSetTable()'
