### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 
 import org.hibernate.mapping.Join;
 import org.hibernate.mapping.JoinedSubclass;
+import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
@@ -42,5 +43,7 @@ public interface PersistentClassWrapper extends Wrapper {
 	void setAbstract(Boolean b);
 	void addProperty(Property p);
 	void setTable(Table table);
+	void setIdentifier(KeyValue value);
+	default void setKey(KeyValue value) { setIdentifier(value); }
 	
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
 import org.hibernate.mapping.JoinedSubclass;
+import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
@@ -81,6 +82,9 @@ public class PersistentClassWrapperFactory {
 		public void setTable(Table table) {
 			throw new RuntimeException("Method 'setTable' cannot be called for SingleTableSubclass");
 		}
+		public void setIdentifier(KeyValue value) {
+			throw new RuntimeException("Method 'setIdentifier' cannot be called for SingleTableSubclass");
+		}
 	}
 	
 	static class JoinedSubclassWrapperImpl
@@ -88,6 +92,9 @@ public class PersistentClassWrapperFactory {
 			implements PersistentClassWrapper {
 		public JoinedSubclassWrapperImpl(PersistentClass superclass) {
 			super(superclass, DummyMetadataBuildingContext.INSTANCE);
+		}
+		public void setIdentifier(KeyValue value) {
+			super.setKey(value);
 		}
 	}
 	

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -588,6 +588,22 @@ public class PersistentClassWrapperFactoryTest {
 		assertSame(table, specialRootClassTarget.getTable());
 	}	
 	
+	@Test
+	public void testSetKey() {
+		KeyValue valueTarget = createValue();
+		assertNull(rootClassTarget.getKey());
+		assertNull(singleTableSubclassTarget.getKey());
+		rootClassWrapper.setKey(valueTarget);
+		assertSame(valueTarget, rootClassTarget.getKey());
+		assertSame(valueTarget, singleTableSubclassTarget.getKey());
+		assertNull(joinedSubclassTarget.getKey());
+		joinedSubclassWrapper.setKey(valueTarget);
+		assertSame(valueTarget, joinedSubclassTarget.getKey());
+		assertNull(specialRootClassTarget.getKey());
+		specialRootClassWrapper.setKey(valueTarget);
+		assertSame(valueTarget, specialRootClassTarget.getKey());
+	}
+	
 	private KeyValue createValue() {
 		return (KeyValue)Proxy.newProxyInstance(
 				getClass().getClassLoader(), 


### PR DESCRIPTION
  - Add method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setIdentifier(KeyValue)'
  - Add method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setKey(KeyValue)' that defaults to 'setIdentifier(KeyValue)'
  - Implement method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.SingleTableSubclassWrapperImpl#setIdentifier(KeyValue) to throw an exception as this is not supported
  - Implement method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.JoinedSubclassWrapperImpl#setIdentifier(KeyValue) to throw an exception as this is not supported
  - Implement new test method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testSetKey()'
