### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -48,5 +48,6 @@ public interface PersistentClassWrapper extends Wrapper {
 	default void setKey(KeyValue value) { setIdentifier(value); }
 	default boolean isInstanceOfSpecialRootClass() { return SpecialRootClass.class.isAssignableFrom(getWrappedObject().getClass()); }
 	default Property getParentProperty() { throw new RuntimeException("getParentProperty() is only allowed on SpecialRootClass"); }
+	default void setIdentifierProperty(Property property) { throw new RuntimeException("setIdentifierProperty is only allowed on RootClass instances"); }
 	
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -647,6 +647,28 @@ public class PersistentClassWrapperFactoryTest {
 		assertEquals("foo", parentProperty.getName());
 	}
 	
+	@Test
+	public void testSetIdentifierProperty() {
+		Property property = new Property();
+		assertNull(rootClassTarget.getIdentifierProperty());
+		rootClassWrapper.setIdentifierProperty(property);
+		assertSame(property, rootClassTarget.getIdentifierProperty());
+		assertNull(specialRootClassTarget.getIdentifierProperty());
+		specialRootClassWrapper.setIdentifierProperty(property);
+		assertSame(property, specialRootClassTarget.getIdentifierProperty());
+		try {
+			singleTableSubclassWrapper.setIdentifierProperty(property);
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals("setIdentifierProperty is only allowed on RootClass instances", e.getMessage());
+		}
+		try {
+			joinedSubclassWrapper.setIdentifierProperty(property);
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals("setIdentifierProperty is only allowed on RootClass instances", e.getMessage());
+		}
+	}
 	private KeyValue createValue() {
 		return (KeyValue)Proxy.newProxyInstance(
 				getClass().getClassLoader(), 


### PR DESCRIPTION
  - Add method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setIdentifierProperty(Property)' which defaults to throwing a RuntimeException
  - Implement new test method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testSetIdentifierProperty()'
