### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -45,9 +45,9 @@ public interface PersistentClassWrapper extends Wrapper {
 	void addProperty(Property p);
 	void setTable(Table table);
 	void setIdentifier(KeyValue value);
-	default void setKey(KeyValue value) { setIdentifier(value); }
+	default void setKey(KeyValue value) { throw new RuntimeException("setKey(KeyValue) is only allowed on JoinedSubclass"); }
 	default boolean isInstanceOfSpecialRootClass() { return SpecialRootClass.class.isAssignableFrom(getWrappedObject().getClass()); }
 	default Property getParentProperty() { throw new RuntimeException("getParentProperty() is only allowed on SpecialRootClass"); }
-	default void setIdentifierProperty(Property property) { throw new RuntimeException("setIdentifierProperty is only allowed on RootClass instances"); }
+	default void setIdentifierProperty(Property property) { throw new RuntimeException("setIdentifierProperty(Property) is only allowed on RootClass instances"); }
 	
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -5,12 +5,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.mapping.JoinedSubclass;
 import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SingleTableSubclass;
+import org.hibernate.mapping.Subclass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -595,15 +595,28 @@ public class PersistentClassWrapperFactoryTest {
 		KeyValue valueTarget = createValue();
 		assertNull(rootClassTarget.getKey());
 		assertNull(singleTableSubclassTarget.getKey());
-		rootClassWrapper.setKey(valueTarget);
-		assertSame(valueTarget, rootClassTarget.getKey());
-		assertSame(valueTarget, singleTableSubclassTarget.getKey());
 		assertNull(joinedSubclassTarget.getKey());
+		assertNull(specialRootClassTarget.getKey());
+		try {
+			rootClassWrapper.setKey(valueTarget);
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+		}
+		try {
+			singleTableSubclassWrapper.setKey(valueTarget);
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+		}
 		joinedSubclassWrapper.setKey(valueTarget);
 		assertSame(valueTarget, joinedSubclassTarget.getKey());
-		assertNull(specialRootClassTarget.getKey());
-		specialRootClassWrapper.setKey(valueTarget);
-		assertSame(valueTarget, specialRootClassTarget.getKey());
+		try {
+			specialRootClassWrapper.setKey(valueTarget);
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+		}
 	}
 	
 	@Test
@@ -660,13 +673,13 @@ public class PersistentClassWrapperFactoryTest {
 			singleTableSubclassWrapper.setIdentifierProperty(property);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("setIdentifierProperty is only allowed on RootClass instances", e.getMessage());
+			assertEquals("setIdentifierProperty(Property) is only allowed on RootClass instances", e.getMessage());
 		}
 		try {
 			joinedSubclassWrapper.setIdentifierProperty(property);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("setIdentifierProperty is only allowed on RootClass instances", e.getMessage());
+			assertEquals("setIdentifierProperty(Property) is only allowed on RootClass instances", e.getMessage());
 		}
 	}
 	private KeyValue createValue() {


### PR DESCRIPTION
  - Change the default implementation of 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setKey(KeyValue)' to throw a RuntimeException (it should only be called on instances of JoinedSubclass)
  - Slight change in the exception message on 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setIdentifierProperty(Property)'
  - Adapt the test cases 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testSetKey() and 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testSetIdentifierProperty()' to account for the above changes
