### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -44,7 +44,7 @@ public interface PersistentClassWrapper extends Wrapper {
 	void setAbstract(Boolean b);
 	void addProperty(Property p);
 	void setTable(Table table);
-	void setIdentifier(KeyValue value);
+	default void setIdentifier(KeyValue value) { throw new RuntimeException("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances"); }
 	default void setKey(KeyValue value) { throw new RuntimeException("setKey(KeyValue) is only allowed on JoinedSubclass"); }
 	default boolean isInstanceOfSpecialRootClass() { return SpecialRootClass.class.isAssignableFrom(getWrappedObject().getClass()); }
 	default Property getParentProperty() { throw new RuntimeException("getParentProperty() is only allowed on SpecialRootClass"); }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -5,14 +5,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
-import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.mapping.JoinedSubclass;
-import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SingleTableSubclass;
-import org.hibernate.mapping.Subclass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
@@ -84,9 +81,6 @@ public class PersistentClassWrapperFactory {
 		public void setTable(Table table) {
 			throw new RuntimeException("Method 'setTable' cannot be called for SingleTableSubclass");
 		}
-		public void setIdentifier(KeyValue value) {
-			throw new RuntimeException("Method 'setIdentifier' cannot be called for SingleTableSubclass");
-		}
 	}
 	
 	static class JoinedSubclassWrapperImpl
@@ -94,9 +88,6 @@ public class PersistentClassWrapperFactory {
 			implements PersistentClassWrapper {
 		public JoinedSubclassWrapperImpl(PersistentClass superclass) {
 			super(superclass, DummyMetadataBuildingContext.INSTANCE);
-		}
-		public void setIdentifier(KeyValue value) {
-			super.setKey(value);
 		}
 	}
 	

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -682,6 +682,34 @@ public class PersistentClassWrapperFactoryTest {
 			assertEquals("setIdentifierProperty(Property) is only allowed on RootClass instances", e.getMessage());
 		}
 	}
+
+	@Test
+	public void testSetIdentifier() {
+		KeyValue valueTarget = createValue();
+		assertNull(rootClassTarget.getIdentifier());
+		assertNull(singleTableSubclassTarget.getIdentifier());
+		assertNull(joinedSubclassTarget.getIdentifier());
+		rootClassWrapper.setIdentifier(valueTarget);
+		assertSame(valueTarget, rootClassTarget.getIdentifier());
+		assertSame(valueTarget, singleTableSubclassTarget.getIdentifier());
+		assertSame(valueTarget, joinedSubclassTarget.getIdentifier());
+		try {
+			singleTableSubclassWrapper.setIdentifier(valueTarget);
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances", e.getMessage());
+		}
+		try {
+			joinedSubclassWrapper.setIdentifier(valueTarget);
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances", e.getMessage());
+		}
+		assertNull(specialRootClassTarget.getIdentifier());
+		specialRootClassWrapper.setIdentifier(valueTarget);
+		assertSame(valueTarget, specialRootClassTarget.getIdentifier());
+	}
+	
 	private KeyValue createValue() {
 		return (KeyValue)Proxy.newProxyInstance(
 				getClass().getClassLoader(), 


### PR DESCRIPTION
  - Provide default implementation for 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setIdentifier(KeyValue)' that throws a runtime exception
  - Remove the unneeded implementations of 'setIdentifier(KeyValue)' in 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.SingleTableSubclassWrapperImpl' and 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.JoinedSubclassWrapperImpl'
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testSetIdentifier()'
