### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -43,7 +43,7 @@ public interface PersistentClassWrapper extends Wrapper {
 	void setDiscriminatorValue(String str);
 	void setAbstract(Boolean b);
 	void addProperty(Property p);
-	void setTable(Table table);
+	default void setTable(Table table) { throw new RuntimeException("Method 'setTable(Table)' is not supported."); }
 	default void setIdentifier(KeyValue value) { throw new RuntimeException("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances"); }
 	default void setKey(KeyValue value) { throw new RuntimeException("setKey(KeyValue) is only allowed on JoinedSubclass"); }
 	default boolean isInstanceOfSpecialRootClass() { return SpecialRootClass.class.isAssignableFrom(getWrappedObject().getClass()); }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -10,7 +10,6 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SingleTableSubclass;
-import org.hibernate.mapping.Table;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 
@@ -77,9 +76,6 @@ public class PersistentClassWrapperFactory {
 			implements PersistentClassWrapper {
 		public SingleTableSubclassWrapperImpl(PersistentClass superclass) {
 			super(superclass, DummyMetadataBuildingContext.INSTANCE);
-		}
-		public void setTable(Table table) {
-			throw new RuntimeException("Method 'setTable' cannot be called for SingleTableSubclass");
 		}
 	}
 	

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -580,7 +580,7 @@ public class PersistentClassWrapperFactoryTest {
 			singleTableSubclassWrapper.setTable(new Table(""));
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals(e.getMessage(), "Method 'setTable' cannot be called for SingleTableSubclass");
+			assertEquals(e.getMessage(), "Method 'setTable(Table)' is not supported.");
 		}
 		assertNull(joinedSubclassTarget.getTable());
 		joinedSubclassWrapper.setTable(table);


### PR DESCRIPTION
  - Provide default implementation for 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setTable(Table)' that throws a runtime exception
  - Remove the unneeded implementations of 'setTable(Table)' in 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.SingleTableSubclassWrapperImpl'
  - Adapt the test case 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testSetTable()' to account for the above changes
