### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -22,6 +22,7 @@ import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
+import org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapper;
 import org.junit.jupiter.api.Test;
 
 public class ValueWrapperFactoryTest {
@@ -30,9 +31,10 @@ public class ValueWrapperFactoryTest {
 	public void testCreateArrayWrapper() {
 		PersistentClassWrapper persistentClassWrapper = PersistentClassWrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = persistentClassWrapper.getWrappedObject();
-		Value arrayWrapper = ValueWrapperFactory.createArrayWrapper(persistentClassWrapper);
-		assertTrue(arrayWrapper instanceof Array);
-		assertSame(((Array)arrayWrapper).getOwner(), persistentClassTarget);
+		ValueWrapper arrayWrapper = ValueWrapperFactory.createArrayWrapper(persistentClassWrapper);
+		Value wrappedArray = arrayWrapper.getWrappedObject();
+		assertTrue(wrappedArray instanceof Array);
+		assertSame(((Array)wrappedArray).getOwner(), persistentClassTarget);
 	}
 
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -46,6 +46,7 @@ import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 import org.hibernate.tool.orm.jbt.wrp.DatabaseReaderWrapperFactory.DatabaseReaderWrapper;
 import org.hibernate.tool.orm.jbt.wrp.HqlCompletionProposalWrapperFactory.HqlCompletionProposalWrapper;
+import org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -228,8 +229,9 @@ public class WrapperFactoryTest {
 		Object persistentClassWrapper = wrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = (PersistentClass)((Wrapper)persistentClassWrapper).getWrappedObject();
 		Object arrayWrapper = wrapperFactory.createArrayWrapper(persistentClassWrapper);
-		assertTrue(arrayWrapper instanceof Array);
-		assertSame(((Array)arrayWrapper).getOwner(), persistentClassTarget);
+		Value wrappedArray = ((ValueWrapper)arrayWrapper).getWrappedObject();
+		assertTrue(wrappedArray instanceof Array);
+		assertSame(((Array)wrappedArray).getOwner(), persistentClassTarget);
 	}
 
 	@Test


### PR DESCRIPTION
  - Merge 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueExtensionImpl' into 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapperInvocationHandler'
  - Override 'getElement()' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapperInvocationHandler' so that it redirects to the target value when appropriate
  - Unwrap the InvocationTargetException in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapperInvocationHandler#invokde(...)'
  - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createArrayWrapper(PersistentClassWrapper)'
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreateArrayWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateArrayWrapper()
