### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -33,7 +33,10 @@ public class ValueWrapperFactory {
 	}
 
 	public static ValueWrapper createBagWrapper(PersistentClassWrapper persistentClassWrapper) {
-		return new BagWrapperImpl(persistentClassWrapper);
+		return createValueWrapper(
+				new Bag(
+						DummyMetadataBuildingContext.INSTANCE, 
+						persistentClassWrapper.getWrappedObject()));
 	}
 
 	public static ValueWrapper createListWrapper(PersistentClassWrapper persistentClassWrapper) {
@@ -108,12 +111,6 @@ public class ValueWrapperFactory {
 	static interface ValueWrapper extends Value, ValueExtension {}
 	
 	
-	private static class BagWrapperImpl extends Bag implements ValueWrapper {
-		protected BagWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
-			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());
-		}		
-	}
-
 	private static class ListWrapperImpl extends List implements ValueWrapper {
 		protected ListWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
 			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -41,9 +41,10 @@ public class ValueWrapperFactoryTest {
 	public void testCreateBagWrapper() {
 		PersistentClassWrapper persistentClassWrapper = PersistentClassWrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = persistentClassWrapper.getWrappedObject();
-		Value bagWrapper = ValueWrapperFactory.createBagWrapper(persistentClassWrapper);
-		assertTrue(bagWrapper instanceof Bag);
-		assertSame(((Bag)bagWrapper).getOwner(), persistentClassTarget);
+		ValueWrapper bagWrapper = ValueWrapperFactory.createBagWrapper(persistentClassWrapper);
+		Value wrappedBag = bagWrapper.getWrappedObject();
+		assertTrue(wrappedBag instanceof Bag);
+		assertSame(((Bag)wrappedBag).getOwner(), persistentClassTarget);
 	}
 
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -239,8 +239,9 @@ public class WrapperFactoryTest {
 		Object persistentClassWrapper = wrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = (PersistentClass)((Wrapper)persistentClassWrapper).getWrappedObject();
 		Object bagWrapper = wrapperFactory.createBagWrapper(persistentClassWrapper);
-		assertTrue(bagWrapper instanceof Bag);
-		assertSame(((Bag)bagWrapper).getOwner(), persistentClassTarget);
+		Value wrappedBag = ((ValueWrapper)bagWrapper).getWrappedObject();
+		assertTrue(wrappedBag instanceof Bag);
+		assertSame(((Bag)wrappedBag).getOwner(), persistentClassTarget);
 	}
 
 	@Test


### PR DESCRIPTION
   - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createBagWrapper(PersistentClassWrapper)'
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreateBagWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateBagWrapper()
