### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -40,7 +40,10 @@ public class ValueWrapperFactory {
 	}
 
 	public static ValueWrapper createListWrapper(PersistentClassWrapper persistentClassWrapper) {
-		return new ListWrapperImpl(persistentClassWrapper);
+		return createValueWrapper(
+				new List(
+						DummyMetadataBuildingContext.INSTANCE, 
+						persistentClassWrapper.getWrappedObject()));
 	}
 
 	public static ValueWrapper createManyToOneWrapper(Table table) {
@@ -111,12 +114,6 @@ public class ValueWrapperFactory {
 	static interface ValueWrapper extends Value, ValueExtension {}
 	
 	
-	private static class ListWrapperImpl extends List implements ValueWrapper {
-		protected ListWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
-			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());
-		}		
-	}
-
 	private static class ManyToOneWrapperImpl extends ManyToOne implements ValueWrapper {
 		protected ManyToOneWrapperImpl(Table table) {
 			super(DummyMetadataBuildingContext.INSTANCE, table);

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -51,9 +51,10 @@ public class ValueWrapperFactoryTest {
 	public void testCreateListWrapper() {
 		PersistentClassWrapper persistentClassWrapper = PersistentClassWrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = persistentClassWrapper.getWrappedObject();
-		Value listWrapper = ValueWrapperFactory.createListWrapper(persistentClassWrapper);
-		assertTrue(listWrapper instanceof List);
-		assertSame(((List)listWrapper).getOwner(), persistentClassTarget);
+		ValueWrapper listWrapper = ValueWrapperFactory.createListWrapper(persistentClassWrapper);
+		Value wrappedList = listWrapper.getWrappedObject();
+		assertTrue(wrappedList instanceof List);
+		assertSame(((List)wrappedList).getOwner(), persistentClassTarget);
 	}
 	
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -249,8 +249,9 @@ public class WrapperFactoryTest {
 		Object persistentClassWrapper = wrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = (PersistentClass)((Wrapper)persistentClassWrapper).getWrappedObject();
 		Object listWrapper = wrapperFactory.createListWrapper(persistentClassWrapper);
-		assertTrue(listWrapper instanceof List);
-		assertSame(((List)listWrapper).getOwner(), persistentClassTarget);
+		Value wrappedList = ((ValueWrapper)listWrapper).getWrappedObject();
+		assertTrue(wrappedList instanceof List);
+		assertSame(((List)wrappedList).getOwner(), persistentClassTarget);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createListWrapper(PersistentClassWrapper)'
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreateListWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateListWrapper()
