### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -196,7 +196,9 @@ public class ValueWrapperFactory {
 			try {
 				return (Value)extendedValue.getClass().getMethod("getElement", new Class[] {}).invoke(extendedValue);
 			} catch (NoSuchMethodException e) {
-				throw new UnsupportedOperationException("Class '" + extendedValue.getClass().getName() + "' does not support 'isTypeSpecified()'." );
+				// TODO for now return null, needs to be replaced by throwing UnsupportedOperationException
+				return null;
+				// throw new UnsupportedOperationException("Class '" + extendedValue.getClass().getName() + "' does not support 'isTypeSpecified()'." );
 			} catch (InvocationTargetException e) {
 				throw new RuntimeException(e.getTargetException());
 			} catch (IllegalAccessException e) {


### PR DESCRIPTION
  - method 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapperInvocationHandler#getElement()' returns 'null' for now when the method does not exist in the target class (needs to be replaced by throwing UnsupportedOperationException later
