### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -47,7 +47,10 @@ public class ValueWrapperFactory {
 	}
 
 	public static ValueWrapper createManyToOneWrapper(Table table) {
-		return new ManyToOneWrapperImpl(table);
+		return createValueWrapper(
+				new ManyToOne(
+						DummyMetadataBuildingContext.INSTANCE, 
+						table));
 	}
 
 	public static ValueWrapper createMapWrapper(PersistentClassWrapper persistentClassWrapper) {
@@ -114,12 +117,6 @@ public class ValueWrapperFactory {
 	static interface ValueWrapper extends Value, ValueExtension {}
 	
 	
-	private static class ManyToOneWrapperImpl extends ManyToOne implements ValueWrapper {
-		protected ManyToOneWrapperImpl(Table table) {
-			super(DummyMetadataBuildingContext.INSTANCE, table);
-		}		
-	}
-
 	private static class MapWrapperImpl extends Map implements ValueWrapper {
 		protected MapWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
 			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -114,7 +114,7 @@ public class WrapperFactory {
 		return result;
 	}
 
-	public Value createManyToOneWrapper(Object table) {
+	public Object createManyToOneWrapper(Object table) {
 		return ValueWrapperFactory.createManyToOneWrapper((Table)table);
 	}
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -60,9 +60,10 @@ public class ValueWrapperFactoryTest {
 	@Test
 	public void testCreateManyToOneWrapper() {
 		Table table = new Table("", "foo");
-		Value manyToOneWrapper = ValueWrapperFactory.createManyToOneWrapper(table);
-		assertTrue(manyToOneWrapper instanceof ManyToOne);
-		assertSame(table, manyToOneWrapper.getTable());
+		ValueWrapper manyToOneWrapper = ValueWrapperFactory.createManyToOneWrapper(table);
+		Value wrappedManyToOne = manyToOneWrapper.getWrappedObject();
+		assertTrue(wrappedManyToOne instanceof ManyToOne);
+		assertSame(table, wrappedManyToOne.getTable());
 	}
 
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -279,9 +279,10 @@ public class WrapperFactoryTest {
 	@Test
 	public void testCreateManyToOneWrapper() {
 		Table table = new Table("", "foo");
-		Value manyToOneWrapper = wrapperFactory.createManyToOneWrapper(table);
-		assertTrue(manyToOneWrapper instanceof ManyToOne);
-		assertSame(table, manyToOneWrapper.getTable());
+		Object manyToOneWrapper = wrapperFactory.createManyToOneWrapper(table);
+		Value wrappedManyToOne = ((ValueWrapper)manyToOneWrapper).getWrappedObject();
+		assertTrue(wrappedManyToOne instanceof ManyToOne);
+		assertSame(table, wrappedManyToOne.getTable());
 	}
 
 	@Test


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createManyToOneWrapper(Table)'
  - Method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createManyToOneWrapper(Object)' returns an Object instance instead of Value
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreateManyToOneWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateManyToOneWrapper()
