### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -54,7 +54,10 @@ public class ValueWrapperFactory {
 	}
 
 	public static ValueWrapper createMapWrapper(PersistentClassWrapper persistentClassWrapper) {
-		return new MapWrapperImpl(persistentClassWrapper);
+		return createValueWrapper(
+				new Map(
+						DummyMetadataBuildingContext.INSTANCE, 
+						persistentClassWrapper.getWrappedObject()));
 	}
 
 	public static ValueWrapper createOneToManyWrapper(PersistentClassWrapper persistentClassWrapper) {
@@ -117,12 +120,6 @@ public class ValueWrapperFactory {
 	static interface ValueWrapper extends Value, ValueExtension {}
 	
 	
-	private static class MapWrapperImpl extends Map implements ValueWrapper {
-		protected MapWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
-			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());
-		}		
-	}
-
 	private static class OneToManyWrapperImpl extends OneToMany implements ValueWrapper {
 		protected OneToManyWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
 			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -70,9 +70,10 @@ public class ValueWrapperFactoryTest {
 	public void testCreateMapWrapper() {
 		PersistentClassWrapper persistentClassWrapper = PersistentClassWrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = persistentClassWrapper.getWrappedObject();
-		Value mapWrapper = ValueWrapperFactory.createMapWrapper(persistentClassWrapper);
-		assertTrue(mapWrapper instanceof Map);
-		assertSame(((Map)mapWrapper).getOwner(), persistentClassTarget);
+		ValueWrapper mapWrapper = ValueWrapperFactory.createMapWrapper(persistentClassWrapper);
+		Value wrappedMap = mapWrapper.getWrappedObject();
+		assertTrue(wrappedMap instanceof Map);
+		assertSame(((Map)wrappedMap).getOwner(), persistentClassTarget);
 	}
 	
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -290,8 +290,9 @@ public class WrapperFactoryTest {
 		Object persistentClassWrapper = wrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = (PersistentClass)((Wrapper)persistentClassWrapper).getWrappedObject();
 		Object mapWrapper = wrapperFactory.createMapWrapper(persistentClassWrapper);
-		assertTrue(mapWrapper instanceof Map);
-		assertSame(((Map)mapWrapper).getOwner(), persistentClassTarget);
+		Value wrappedMap = ((ValueWrapper)mapWrapper).getWrappedObject();
+		assertTrue(wrappedMap instanceof Map);
+		assertSame(((Map)wrappedMap).getOwner(), persistentClassTarget);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createMapWrapper(PersistentClassWrapper)'
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreateMapWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateMapWrapper()
