### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -61,7 +61,10 @@ public class ValueWrapperFactory {
 	}
 
 	public static ValueWrapper createOneToManyWrapper(PersistentClassWrapper persistentClassWrapper) {
-		return new OneToManyWrapperImpl(persistentClassWrapper);
+		return createValueWrapper(
+				new OneToMany(
+						DummyMetadataBuildingContext.INSTANCE, 
+						persistentClassWrapper.getWrappedObject()));
 	}
 
 	public static ValueWrapper createOneToOneWrapper(PersistentClassWrapper persistentClassWrapper) {
@@ -120,12 +123,6 @@ public class ValueWrapperFactory {
 	static interface ValueWrapper extends Value, ValueExtension {}
 	
 	
-	private static class OneToManyWrapperImpl extends OneToMany implements ValueWrapper {
-		protected OneToManyWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
-			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());
-		}		
-	}
-
 	private static class OneToOneWrapperImpl extends OneToOne implements ValueWrapper {
 		protected OneToOneWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
 			super(DummyMetadataBuildingContext.INSTANCE, 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -82,9 +82,10 @@ public class ValueWrapperFactoryTest {
 		PersistentClass persistentClassTarget = persistentClassWrapper.getWrappedObject();
 		Table tableTarget = new Table("", "foo");
 		((RootClass)persistentClassTarget).setTable(tableTarget);
-		Value oneToManyWrapper = ValueWrapperFactory.createOneToManyWrapper(persistentClassWrapper);
-		assertTrue(oneToManyWrapper instanceof OneToMany);
-		assertSame(((OneToMany)oneToManyWrapper).getTable(), tableTarget);
+		ValueWrapper oneToManyWrapper = ValueWrapperFactory.createOneToManyWrapper(persistentClassWrapper);
+		Value wrappedOneToMany = oneToManyWrapper.getWrappedObject();
+		assertTrue(wrappedOneToMany instanceof OneToMany);
+		assertSame(((OneToMany)wrappedOneToMany).getTable(), tableTarget);
 	}
 	
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -302,8 +302,9 @@ public class WrapperFactoryTest {
 		Table tableWrapper = (Table)wrapperFactory.createTableWrapper("foo");
 		((RootClass)persistentClassTarget).setTable(tableWrapper);
 		Object oneToManyWrapper = wrapperFactory.createOneToManyWrapper(persistentClassWrapper);
-		assertTrue(oneToManyWrapper instanceof OneToMany);
-		assertSame(((OneToMany)oneToManyWrapper).getTable(), tableWrapper);
+		Value wrappedOneToMany = ((ValueWrapper)oneToManyWrapper).getWrappedObject();
+		assertTrue(wrappedOneToMany instanceof OneToMany);
+		assertSame(((OneToMany)wrappedOneToMany).getTable(), tableWrapper);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createOneToManyWrapper(PersistentClassWrapper)'
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreateOneToManyWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateOneToManyWrapper()
