### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -76,7 +76,10 @@ public class ValueWrapperFactory {
 	}
 
 	public static ValueWrapper createPrimitiveArrayWrapper(PersistentClassWrapper persistentClassWrapper) {
-		return new PrimitiveArrayWrapperImpl(persistentClassWrapper);
+		return createValueWrapper(
+				new PrimitiveArray(
+						DummyMetadataBuildingContext.INSTANCE, 
+						persistentClassWrapper.getWrappedObject()));
 	}
 
 	public static ValueWrapper createSetWrapper(PersistentClassWrapper persistentClassWrapper) {
@@ -127,12 +130,6 @@ public class ValueWrapperFactory {
 	static interface ValueWrapper extends Value, ValueExtension {}
 	
 	
-	private static class PrimitiveArrayWrapperImpl extends PrimitiveArray implements ValueWrapper {
-		protected PrimitiveArrayWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
-			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());
-		}		
-	}
-
 	private static class SetWrapperImpl extends Set implements ValueWrapper {
 		protected SetWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
 			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -106,9 +106,10 @@ public class ValueWrapperFactoryTest {
 	public void testCreatePrimitiveArray() {
 		PersistentClassWrapper persistentClassWrapper = PersistentClassWrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = persistentClassWrapper.getWrappedObject();
-		Value primitiveArrayWrapper = ValueWrapperFactory.createPrimitiveArrayWrapper(persistentClassWrapper);
-		assertTrue(primitiveArrayWrapper instanceof PrimitiveArray);
-		assertSame(((PrimitiveArray)primitiveArrayWrapper).getOwner(), persistentClassTarget);
+		ValueWrapper primitiveArrayWrapper = ValueWrapperFactory.createPrimitiveArrayWrapper(persistentClassWrapper);
+		Value wrappedPrimitiveArray = primitiveArrayWrapper.getWrappedObject();
+		assertTrue(wrappedPrimitiveArray instanceof PrimitiveArray);
+		assertSame(((PrimitiveArray)wrappedPrimitiveArray).getOwner(), persistentClassTarget);
 	}
 	
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -326,8 +326,9 @@ public class WrapperFactoryTest {
 		Object persistentClassWrapper = wrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = (PersistentClass)((Wrapper)persistentClassWrapper).getWrappedObject();
 		Object primitiveArrayWrapper = wrapperFactory.createPrimitiveArrayWrapper(persistentClassWrapper);
-		assertTrue(primitiveArrayWrapper instanceof PrimitiveArray);
-		assertSame(((PrimitiveArray)primitiveArrayWrapper).getOwner(), persistentClassTarget);
+		Value wrappedPrimitiveArray = ((ValueWrapper)primitiveArrayWrapper).getWrappedObject();
+		assertTrue(wrappedPrimitiveArray instanceof PrimitiveArray);
+		assertSame(((PrimitiveArray)wrappedPrimitiveArray).getOwner(), persistentClassTarget);
 	}
 
 	@Test


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createPrimitiveArrayWrapper(PersistentClassWrapper)'
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreatePrimitiveArrayWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreatePrimitiveArrayWrapper()
