### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -83,7 +83,10 @@ public class ValueWrapperFactory {
 	}
 
 	public static ValueWrapper createSetWrapper(PersistentClassWrapper persistentClassWrapper) {
-		return new SetWrapperImpl(persistentClassWrapper);
+		return createValueWrapper(
+				new Set(
+						DummyMetadataBuildingContext.INSTANCE, 
+						persistentClassWrapper.getWrappedObject()));
 	}
 
 	public static ValueWrapper createSimpleValueWrapper() {
@@ -130,12 +133,6 @@ public class ValueWrapperFactory {
 	static interface ValueWrapper extends Value, ValueExtension {}
 	
 	
-	private static class SetWrapperImpl extends Set implements ValueWrapper {
-		protected SetWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
-			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());
-		}		
-	}
-
 	private static class SimpleValueWrapperImpl extends BasicValue implements ValueWrapper {
 		protected SimpleValueWrapperImpl() {
 			super(DummyMetadataBuildingContext.INSTANCE);

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -116,9 +116,10 @@ public class ValueWrapperFactoryTest {
 	public void testCreateSetWrapper() {
 		PersistentClassWrapper persistentClassWrapper = PersistentClassWrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = persistentClassWrapper.getWrappedObject();
-		Value setWrapper = ValueWrapperFactory.createSetWrapper(persistentClassWrapper);
-		assertTrue(setWrapper instanceof Set);
-		assertSame(((Set)setWrapper).getOwner(), persistentClassTarget);
+		ValueWrapper setWrapper = ValueWrapperFactory.createSetWrapper(persistentClassWrapper);
+		Value wrappedSet = setWrapper.getWrappedObject();
+		assertTrue(wrappedSet instanceof Set);
+		assertSame(((Set)wrappedSet).getOwner(), persistentClassTarget);
 	}
 	
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -336,8 +336,9 @@ public class WrapperFactoryTest {
 		Object persistentClassWrapper = wrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = (PersistentClass)((Wrapper)persistentClassWrapper).getWrappedObject();
 		Object setWrapper = wrapperFactory.createSetWrapper(persistentClassWrapper);
-		assertTrue(setWrapper instanceof Set);
-		assertSame(((Set)setWrapper).getOwner(), persistentClassTarget);
+		Value wrappedSet = ((ValueWrapper)setWrapper).getWrappedObject();
+		assertTrue(wrappedSet instanceof Set);
+		assertSame(((Set)wrappedSet).getOwner(), persistentClassTarget);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createSetWrapper(PersistentClassWrapper)'
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreateSetWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateSetWrapper()
