### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -94,7 +94,10 @@ public class ValueWrapperFactory {
 	}
 	
 	public static ValueWrapper createComponentWrapper(PersistentClassWrapper persistentClassWrapper) {
-		return new ComponentWrapperImpl(persistentClassWrapper);
+		return createValueWrapper(
+				new Component(
+						DummyMetadataBuildingContext.INSTANCE, 
+						persistentClassWrapper.getWrappedObject()));
 	}
 	
 	public static ValueWrapper createValueWrapper(Value wrappedValue) {
@@ -132,12 +135,6 @@ public class ValueWrapperFactory {
 	
 	static interface ValueWrapper extends Value, ValueExtension {}
 	
-	
-	private static class ComponentWrapperImpl extends Component implements ValueWrapper {
-		protected ComponentWrapperImpl(PersistentClassWrapper persistentClassWrapper) {
-			super(DummyMetadataBuildingContext.INSTANCE, persistentClassWrapper.getWrappedObject());
-		}		
-	}
 	
 	private static class ValueWrapperInvocationHandler implements ValueExtension, InvocationHandler {
 		

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactoryTest.java
@@ -134,9 +134,10 @@ public class ValueWrapperFactoryTest {
 	public void testCreateComponentValue() {
 		PersistentClassWrapper persistentClassWrapper = PersistentClassWrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = persistentClassWrapper.getWrappedObject();
-		Value componentWrapper = ValueWrapperFactory.createComponentWrapper(persistentClassWrapper);
-		assertTrue(componentWrapper instanceof Component);
-		assertSame(((Component)componentWrapper).getOwner(), persistentClassTarget);
+		ValueWrapper componentWrapper = ValueWrapperFactory.createComponentWrapper(persistentClassWrapper);
+		Value wrappedComponent = componentWrapper.getWrappedObject();
+		assertTrue(wrappedComponent instanceof Component);
+		assertSame(((Component)wrappedComponent).getOwner(), persistentClassTarget);
 	}
 	
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -353,8 +353,9 @@ public class WrapperFactoryTest {
 		Object persistentClassWrapper = wrapperFactory.createRootClassWrapper();
 		PersistentClass persistentClassTarget = (PersistentClass)((Wrapper)persistentClassWrapper).getWrappedObject();
 		Object componentWrapper = wrapperFactory.createComponentWrapper(persistentClassWrapper);
-		assertTrue(componentWrapper instanceof Component);
-		assertSame(((Component)componentWrapper).getOwner(), persistentClassTarget);
+		Value wrappedComponent = ((ValueWrapper)componentWrapper).getWrappedObject();
+		assertTrue(wrappedComponent instanceof Component);
+		assertSame(((Component)wrappedComponent).getOwner(), persistentClassTarget);
 	}
 	
 	@SuppressWarnings("serial")


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createValueWrapper(...)' in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.createComponentWrapper()'
  - Adapt the following test cases to the above change:
    * org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactoryTest#testCreateComponentWrapper()
    * org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateComponentWrapper()
