### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
@@ -48,6 +48,12 @@ public class TypeWrapperFactory {
 			Class<?> returnedClass = ((Type)getWrappedObject()).getReturnedClass();
 			return returnedClass == null ? null : returnedClass.getName();
 		}
+		default String getAssociatedEntityName() {
+			throw new UnsupportedOperationException(
+					"Class '" + 
+					getWrappedObject().getClass().getName() + 
+					"' does not support 'getAssociatedEntityName()'." ); 
+		}
 	}
 	
 	static interface TypeWrapper extends Type, TypeExtension {}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperTest.java
@@ -163,6 +163,22 @@ public class TypeWrapperTest {
 		assertEquals(OrgFooBar.class.getName(), manyToOneTypeWrapper.getReturnedClassName());
 	}
 	
+	@Test
+	public void testGetAssociatedEntityName() {
+		// first try a class type
+		try {
+			TypeWrapper classTypeWrapper = TypeWrapperFactory.createTypeWrapper(new ClassType());
+			classTypeWrapper.getAssociatedEntityName();
+			fail();
+		} catch (UnsupportedOperationException e) {
+			assertTrue(e.getMessage().contains("does not support 'getAssociatedEntityName()'"));
+		}
+		// next try a many to one type 
+		TypeWrapper manyToOneTypeWrapper = TypeWrapperFactory.createTypeWrapper(
+				new ManyToOneType((TypeConfiguration)null, "foo"));
+		assertEquals("foo", manyToOneTypeWrapper.getAssociatedEntityName());
+	}
+	
 	public static class OrgFooBar {}
 	
 }


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperTest#testGetAssociatedEntityName()'
  - Add new interface method 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeExtension#getAssociatedEntityName()' with a default implementation
