### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
@@ -88,6 +88,12 @@ public class TypeWrapperFactory {
 				}
 			}
 		}
+		default String getRole() { 
+			throw new UnsupportedOperationException(
+					"Class '" + 
+					getWrappedObject().getClass().getName() + 
+					"' does not support 'getRole()'.");
+		}
 	}
 	
 	static interface TypeWrapper extends Type, TypeExtension {}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperTest.java
@@ -233,6 +233,21 @@ public class TypeWrapperTest {
 		assertEquals(int.class, integerTypeWrapper.getPrimitiveClass());
 	}
 
+	@Test
+	public void testGetRole() {
+		// first try a class type
+		try {
+			TypeWrapper classTypeWrapper = TypeWrapperFactory.createTypeWrapper(new ClassType());
+			classTypeWrapper.getRole();
+		} catch (UnsupportedOperationException e) {
+			assertTrue(e.getMessage().contains("does not support 'getRole()'"));
+		}
+		// finally try a array type
+		TypeWrapper arrayTypeWrapper = 
+				TypeWrapperFactory.createTypeWrapper(new ArrayType("foo", "bar", String.class));
+		assertEquals("foo", arrayTypeWrapper.getRole());
+	}
+	
 	public static class OrgFooBar {}
 	
 }


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperTest#testGetRole()'
  - Add new interface method 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeExtension#getRole()'
