### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/type/TypeFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/type/TypeFactory.java
@@ -1,5 +1,6 @@
 package org.hibernate.tool.orm.jbt.type;
 
+import org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapper;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.Type;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -10,7 +11,6 @@ public class TypeFactory {
 	
 	private static BasicTypeRegistry TYPE_REGISTRY = new TypeConfiguration().getBasicTypeRegistry();
 	
-	public static final Type BOOLEAN_TYPE = TYPE_REGISTRY.getRegisteredType("boolean");
 	public static final Type BYTE_TYPE = TYPE_REGISTRY.getRegisteredType("byte");
 	public static final Type BIG_INTEGER_TYPE = TYPE_REGISTRY.getRegisteredType("big_integer");
 	public static final Type SHORT_TYPE = TYPE_REGISTRY.getRegisteredType("short");
@@ -37,7 +37,7 @@ public class TypeFactory {
 	private TypeFactory() {}
 
 	public Type getBooleanType() {
-		return BOOLEAN_TYPE;
+		return TypeFactoryWrapper.INSTANCE.getBooleanType();
 	}
 
 	public Type getByteType() {

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeFactoryWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeFactoryWrapper.java
@@ -1,18 +1,162 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
-import org.hibernate.tool.orm.jbt.type.TypeFactory;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeWrapper;
+import org.hibernate.type.BasicTypeRegistry;
+import org.hibernate.type.Type;
+import org.hibernate.type.spi.TypeConfiguration;
 
 public class TypeFactoryWrapper {
 
 	public static final TypeFactoryWrapper INSTANCE = new TypeFactoryWrapper();
-	
-	static final TypeWrapper BOOLEAN_TYPE = TypeWrapperFactory.createTypeWrapper(TypeFactory.BOOLEAN_TYPE);
+
+	private static Map<String, TypeWrapper> TYPE_REGISTRY = null;	
+	private static final BasicTypeRegistry BASIC_TYPE_REGISTRY = new TypeConfiguration().getBasicTypeRegistry();
 	
 	private TypeFactoryWrapper() {}
 
 	public TypeWrapper getBooleanType() {
-		return BOOLEAN_TYPE;
+		return typeRegistry().get("boolean");
+	}
+	
+	public TypeWrapper getByteType() {
+		return typeRegistry().get("byte");
+	}
+	
+	public TypeWrapper getBigIntegerType() {
+		return typeRegistry().get("big_integer");
 	}
 
+	public TypeWrapper getShortType() {
+		return typeRegistry().get("short");
+	}
+
+	public TypeWrapper getCalendarType() {
+		return typeRegistry().get("calendar");
+	}
+
+	public TypeWrapper getCalendarDateType() {
+		return typeRegistry().get("calendar_date");
+	}
+
+	public TypeWrapper getIntegerType() {
+		return typeRegistry().get("integer");
+	}
+
+	public TypeWrapper getBigDecimalType() {
+		return typeRegistry().get("big_decimal");
+	}
+
+	public TypeWrapper getCharacterType() {
+		return typeRegistry().get("character");
+	}
+
+	public TypeWrapper getClassType() {
+		return typeRegistry().get("class");
+	}
+
+	public TypeWrapper getCurrencyType() {
+		return typeRegistry().get("currency");
+	}
+
+	public TypeWrapper getDateType() {
+		return typeRegistry().get("date");
+	}
+
+	public TypeWrapper getDoubleType() {
+		return typeRegistry().get("double");
+	}
+
+	public TypeWrapper getFloatType() {
+		return typeRegistry().get("float");
+	}
+
+	public TypeWrapper getLocaleType() {
+		return typeRegistry().get("locale");
+	}
+
+	public TypeWrapper getLongType() {
+		return typeRegistry().get("long");
+	}
+
+	public TypeWrapper getStringType() {
+		return typeRegistry().get("string");
+	}
+
+	public TypeWrapper getTextType() {
+		return typeRegistry().get("text");
+	}
+
+	public TypeWrapper getTimeType() {
+		return typeRegistry().get("time");
+	}
+
+	public TypeWrapper getTimestampType() {
+		return typeRegistry().get("timestamp");
+	}
+
+	public TypeWrapper getTimezoneType() {
+		return typeRegistry().get("timezone");
+	}
+
+	public TypeWrapper getTrueFalseType() {
+		return typeRegistry().get("true_false");
+	}
+
+	public TypeWrapper getYesNoType() {
+		return typeRegistry().get("yes_no");
+	}
+	
+	public TypeWrapper getNamedType(String name) {
+		if (!typeRegistry().containsKey(name)) {
+			Type basicType = BASIC_TYPE_REGISTRY.getRegisteredType(name);
+			if (basicType != null) {
+				typeRegistry().put(name, TypeWrapperFactory.createTypeWrapper(basicType));
+			} else {
+				typeRegistry().put(name, null);
+			}
+		}
+		return typeRegistry().get(name);
+	}
+
+	public TypeWrapper getBasicType(String name) {
+		return getNamedType(name);
+	}
+	
+	private static Map<String, TypeWrapper> typeRegistry() {
+		if (TYPE_REGISTRY == null) {
+			createTypeRegistry();
+		}
+		return TYPE_REGISTRY;
+	}
+	
+	private static void createTypeRegistry() {
+		TYPE_REGISTRY = new HashMap<String, TypeWrapper>();
+		TYPE_REGISTRY.put("boolean", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("boolean")));
+		TYPE_REGISTRY.put("byte", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("byte")));
+		TYPE_REGISTRY.put("big_integer", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("big_integer")));
+		TYPE_REGISTRY.put("short", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("short")));
+		TYPE_REGISTRY.put("calendar", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("calendar")));
+		TYPE_REGISTRY.put("calendar_date", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("calendar_date")));
+		TYPE_REGISTRY.put("integer", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("integer")));
+		TYPE_REGISTRY.put("big_decimal", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("big_decimal")));
+		TYPE_REGISTRY.put("character", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("character")));
+		TYPE_REGISTRY.put("class", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("class")));
+		TYPE_REGISTRY.put("currency", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("currency")));
+		TYPE_REGISTRY.put("date", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("date")));
+		TYPE_REGISTRY.put("double", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("double")));
+		TYPE_REGISTRY.put("float", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("float")));
+		TYPE_REGISTRY.put("locale", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("locale")));
+		TYPE_REGISTRY.put("long", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("long")));
+		TYPE_REGISTRY.put("string", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("string")));
+		TYPE_REGISTRY.put("text", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("text")));
+		TYPE_REGISTRY.put("time", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("time")));
+		TYPE_REGISTRY.put("timestamp", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("timestamp")));
+		TYPE_REGISTRY.put("timezone", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("timezone")));
+		TYPE_REGISTRY.put("true_false", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("true_false")));
+		TYPE_REGISTRY.put("yes_no", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("yes_no")));
+	}
+	
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -28,7 +28,6 @@ import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
-import org.hibernate.tool.orm.jbt.type.TypeFactory;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
@@ -224,7 +223,7 @@ public class WrapperFactory {
 	}
 
 	public static Object createTypeFactoryWrapper() {
-		return TypeFactory.INSTANCE;
+		return TypeFactoryWrapper.INSTANCE;
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/type/TypeFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/type/TypeFactoryTest.java
@@ -13,11 +13,6 @@ public class TypeFactoryTest {
 	}
 
 	@Test
-	public void testGetBooleanType() {
-		assertSame(TypeFactory.BOOLEAN_TYPE, TypeFactory.INSTANCE.getBooleanType());
-	}
-	
-	@Test
 	public void testGetByteType() {
 		assertSame(TypeFactory.BYTE_TYPE, TypeFactory.INSTANCE.getByteType());
 	}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeFactoryWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeFactoryWrapperTest.java
@@ -1,14 +1,14 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.hibernate.tool.orm.jbt.type.TypeFactory;
 import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeWrapper;
+import org.hibernate.type.Type;
 import org.junit.jupiter.api.Test;
 
 public class TypeFactoryWrapperTest {
-
+	
 	@Test
 	public void testConstruction() {
 		assertNotNull(TypeFactoryWrapper.INSTANCE);
@@ -17,7 +17,151 @@ public class TypeFactoryWrapperTest {
 	@Test
 	public void testGetBooleanType() {
 		TypeWrapper booleanTypeWrapper = TypeFactoryWrapper.INSTANCE.getBooleanType();
-		assertSame(booleanTypeWrapper.getWrappedObject(), TypeFactory.BOOLEAN_TYPE);
+		assertEquals("boolean", ((Type)booleanTypeWrapper.getWrappedObject()).getName());
+	}
+
+	@Test
+	public void testGetByteType() {
+		TypeWrapper byteTypeWrapper = TypeFactoryWrapper.INSTANCE.getByteType();
+		assertEquals("byte", ((Type)byteTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetBigIntegerType() {
+		TypeWrapper bigIntegerTypeWrapper = TypeFactoryWrapper.INSTANCE.getBigIntegerType();
+		assertEquals("big_integer", ((Type)bigIntegerTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetShortType() {
+		TypeWrapper shortTypeWrapper = TypeFactoryWrapper.INSTANCE.getShortType();
+		assertEquals("short", ((Type)shortTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetCalendarType() {
+		TypeWrapper calendarTypeWrapper = TypeFactoryWrapper.INSTANCE.getCalendarType();
+		assertEquals("calendar", ((Type)calendarTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetCalendarDateType() {
+		TypeWrapper calendarDateTypeWrapper = TypeFactoryWrapper.INSTANCE.getCalendarDateType();
+		assertEquals("calendar_date", ((Type)calendarDateTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetIntegerType() {
+		TypeWrapper integerTypeWrapper = TypeFactoryWrapper.INSTANCE.getIntegerType();
+		assertEquals("integer", ((Type)integerTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetBigDecimalType() {
+		TypeWrapper bigDecimalTypeWrapper = TypeFactoryWrapper.INSTANCE.getBigDecimalType();
+		assertEquals("big_decimal", ((Type)bigDecimalTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetCharacterType() {
+		TypeWrapper characterTypeWrapper = TypeFactoryWrapper.INSTANCE.getCharacterType();
+		assertEquals("character", ((Type)characterTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetClassType() {
+		TypeWrapper classTypeWrapper = TypeFactoryWrapper.INSTANCE.getClassType();
+		assertEquals("class", ((Type)classTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetCurrencyType() {
+		TypeWrapper currencyTypeWrapper = TypeFactoryWrapper.INSTANCE.getCurrencyType();
+		assertEquals("currency", ((Type)currencyTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetDateType() {
+		TypeWrapper dateTypeWrapper = TypeFactoryWrapper.INSTANCE.getDateType();
+		assertEquals("date", ((Type)dateTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetDoubleType() {
+		TypeWrapper doubleTypeWrapper = TypeFactoryWrapper.INSTANCE.getDoubleType();
+		assertEquals("double", ((Type)doubleTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetFloatType() {
+		TypeWrapper floatTypeWrapper = TypeFactoryWrapper.INSTANCE.getFloatType();
+		assertEquals("float", ((Type)floatTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetLocaleType() {
+		TypeWrapper localeTypeWrapper = TypeFactoryWrapper.INSTANCE.getLocaleType();
+		assertEquals("locale", ((Type)localeTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetLongType() {
+		TypeWrapper longTypeWrapper = TypeFactoryWrapper.INSTANCE.getLongType();
+		assertEquals("long", ((Type)longTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetStringType() {
+		TypeWrapper stringTypeWrapper = TypeFactoryWrapper.INSTANCE.getStringType();
+		assertEquals("string", ((Type)stringTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetTextType() {
+		TypeWrapper textTypeWrapper = TypeFactoryWrapper.INSTANCE.getTextType();
+		assertEquals("text", ((Type)textTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetTimeType() {
+		TypeWrapper timeTypeWrapper = TypeFactoryWrapper.INSTANCE.getTimeType();
+		assertEquals("time", ((Type)timeTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetTimestampType() {
+		TypeWrapper timestampTypeWrapper = TypeFactoryWrapper.INSTANCE.getTimestampType();
+		assertEquals("timestamp", ((Type)timestampTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetTimezoneType() {
+		TypeWrapper timezoneTypeWrapper = TypeFactoryWrapper.INSTANCE.getTimezoneType();
+		assertEquals("timezone", ((Type)timezoneTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetTrueFalseType() {
+		TypeWrapper trueFalselTypeWrapper = TypeFactoryWrapper.INSTANCE.getTrueFalseType();
+		assertEquals("true_false", ((Type)trueFalselTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetYesNoType() {
+		TypeWrapper yesNoTypeWrapper = TypeFactoryWrapper.INSTANCE.getYesNoType();
+		assertEquals("yes_no", ((Type)yesNoTypeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test 
+	public void testGetNamedType() {
+		TypeWrapper typeWrapper = TypeFactoryWrapper.INSTANCE.getNamedType(String.class.getName());
+		assertEquals("string", ((Type)typeWrapper.getWrappedObject()).getName());
+	}
+	
+	@Test
+	public void testGetBasicType() {
+		TypeWrapper typeWrapper = TypeFactoryWrapper.INSTANCE.getBasicType(String.class.getName());
+		assertEquals("string", ((Type)typeWrapper.getWrappedObject()).getName());
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -44,7 +44,6 @@ import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
-import org.hibernate.tool.orm.jbt.type.TypeFactory;
 import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
@@ -397,7 +396,7 @@ public class WrapperFactoryTest {
 	@Test
 	public void testCreateTypeFactoryWrapper() {
 		Object typeFactoryWrapper = WrapperFactory.createTypeFactoryWrapper();
-		assertSame(TypeFactory.INSTANCE, typeFactoryWrapper);
+		assertSame(TypeFactoryWrapper.INSTANCE, typeFactoryWrapper);
 	}
 	
 	@SuppressWarnings("serial")


### PR DESCRIPTION
  - Move functionality from class 'org.hibernate.tool.orm.jbt.util.TypeFactory' to class 'org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapper'
  - Adapt the test class 'org.hibernate.tool.orm.jbt.wrp.TypeFactoryTest' to cover the functionality of 'org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapper'
  - Make 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createTypeFactoryWrapper()' return 'TypeFactoryWrapper.INSTANCE'
  - Adapt the test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateTypeFactoryWrapper()'
