### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeFactoryWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeFactoryWrapper.java
@@ -1,7 +1,14 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Currency;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeWrapper;
 import org.hibernate.type.BasicTypeRegistry;
@@ -15,7 +22,10 @@ public class TypeFactoryWrapper {
 	private static Map<String, TypeWrapper> TYPE_REGISTRY = null;	
 	private static final BasicTypeRegistry BASIC_TYPE_REGISTRY = new TypeConfiguration().getBasicTypeRegistry();
 	
-	private TypeFactoryWrapper() {}
+	private Map<TypeWrapper, String> typeFormats = null;
+	
+	private TypeFactoryWrapper() {
+	}
 
 	public TypeWrapper getBooleanType() {
 		return typeRegistry().get("boolean");
@@ -125,6 +135,44 @@ public class TypeFactoryWrapper {
 		return getNamedType(name);
 	}
 	
+	public Map<TypeWrapper, String> getTypeFormats() {
+		if (typeFormats == null) {
+			initializeTypeFormats();
+		}
+		return typeFormats;
+	}
+	
+	protected void initializeTypeFormats() {
+		typeFormats = new HashMap<>();
+		addTypeFormat(getBooleanType(), Boolean.TRUE);
+		addTypeFormat(getByteType(), Byte.valueOf((byte) 42));
+		addTypeFormat(getBigIntegerType(), BigInteger.valueOf(42));
+		addTypeFormat(getShortType(), Short.valueOf((short) 42));
+		addTypeFormat(getCalendarType(), new GregorianCalendar());
+		addTypeFormat(getCalendarDateType(), new GregorianCalendar());
+		addTypeFormat(getIntegerType(), Integer.valueOf(42));
+		addTypeFormat(getBigDecimalType(), new BigDecimal(42.0));
+		addTypeFormat(getCharacterType(), Character.valueOf('h'));
+		addTypeFormat(getClassType(), Class.class);
+		addTypeFormat(getCurrencyType(), Currency.getInstance(Locale.getDefault()));
+		addTypeFormat(getDateType(), new Date());
+		addTypeFormat(getDoubleType(), Double.valueOf(42.42));
+		addTypeFormat(getFloatType(), Float.valueOf((float)42.42));
+		addTypeFormat(getLocaleType(), Locale.getDefault());
+		addTypeFormat(getLongType(), Long.valueOf(42));
+		addTypeFormat(getStringType(), "a string"); //$NON-NLS-1$
+		addTypeFormat(getTextType(), "a text"); //$NON-NLS-1$
+		addTypeFormat(getTimeType(), new Date());
+		addTypeFormat(getTimestampType(), new Date());
+		addTypeFormat(getTimezoneType(), TimeZone.getDefault());
+		addTypeFormat(getTrueFalseType(), Boolean.TRUE);
+		addTypeFormat(getYesNoType(), Boolean.TRUE);
+	}
+	
+	protected void addTypeFormat(TypeWrapper type, Object value) {
+		typeFormats.put(type, type.toString(value));
+	}
+	
 	private static Map<String, TypeWrapper> typeRegistry() {
 		if (TYPE_REGISTRY == null) {
 			createTypeRegistry();
@@ -158,5 +206,5 @@ public class TypeFactoryWrapper {
 		TYPE_REGISTRY.put("true_false", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("true_false")));
 		TYPE_REGISTRY.put("yes_no", TypeWrapperFactory.createTypeWrapper(BASIC_TYPE_REGISTRY.getRegisteredType("yes_no")));
 	}
-	
+
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
@@ -4,12 +4,16 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Map;
 
 import org.hibernate.tool.orm.jbt.type.IntegerType;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.java.CalendarJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
 
 public class TypeWrapperFactory {
 	
@@ -23,7 +27,13 @@ public class TypeWrapperFactory {
 	static interface TypeExtension extends Wrapper {
 		default public String toString(Object object) { 
 			if (BasicType.class.isAssignableFrom(getWrappedObject().getClass())) {
-				return ((BasicType)getWrappedObject()).getJavaTypeDescriptor().toString(object);
+				JavaType javaType = ((BasicType<?>)getWrappedObject()).getJavaTypeDescriptor();
+				if (javaType instanceof CalendarJavaType && object instanceof Calendar) {
+					SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+					return simpleDateFormat.format(((Calendar)object).getTime());
+				} else {
+					return javaType.toString(object);
+				}
 			} else {
 				throw new UnsupportedOperationException(
 						"Class '" + 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeFactoryWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeFactoryWrapperTest.java
@@ -3,6 +3,13 @@ package org.hibernate.tool.orm.jbt.wrp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.text.SimpleDateFormat;
+import java.util.Currency;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
 import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeWrapper;
 import org.hibernate.type.Type;
 import org.junit.jupiter.api.Test;
@@ -164,4 +171,48 @@ public class TypeFactoryWrapperTest {
 		assertEquals("string", ((Type)typeWrapper.getWrappedObject()).getName());
 	}
 
+	@Test
+	public void testGetTypeFormats() {
+		Map<TypeWrapper, String> typeFormats = TypeFactoryWrapper.INSTANCE.getTypeFormats();
+		assertEquals(23, typeFormats.size());
+		assertEquals("true", typeFormats.get(TypeFactoryWrapper.INSTANCE.getBooleanType()));
+		assertEquals("42", typeFormats.get(TypeFactoryWrapper.INSTANCE.getByteType()));
+		assertEquals("42", typeFormats.get(TypeFactoryWrapper.INSTANCE.getBigIntegerType()));
+		assertEquals("42", typeFormats.get(TypeFactoryWrapper.INSTANCE.getShortType()));
+		assertEquals(
+				new SimpleDateFormat("yyyy-MM-dd").format(new Date()), 
+				typeFormats.get(TypeFactoryWrapper.INSTANCE.getCalendarType()));
+		assertEquals(
+				new SimpleDateFormat("yyyy-MM-dd").format(new Date()), 
+				typeFormats.get(TypeFactoryWrapper.INSTANCE.getCalendarDateType()));
+		assertEquals("42", typeFormats.get(TypeFactoryWrapper.INSTANCE.getIntegerType()));
+		assertEquals("42", typeFormats.get(TypeFactoryWrapper.INSTANCE.getBigDecimalType()));
+		assertEquals("h", typeFormats.get(TypeFactoryWrapper.INSTANCE.getCharacterType()));
+		assertEquals(
+				Class.class.getName(), 
+				typeFormats.get(TypeFactoryWrapper.INSTANCE.getClassType()));
+		assertEquals(
+				Currency.getInstance(Locale.getDefault()).toString(), 
+				typeFormats.get(TypeFactoryWrapper.INSTANCE.getCurrencyType()));
+		assertEquals(
+				new SimpleDateFormat("yyyy-MM-dd").format(new Date()), 
+				typeFormats.get(TypeFactoryWrapper.INSTANCE.getDateType()));
+		assertEquals("42.42", typeFormats.get(TypeFactoryWrapper.INSTANCE.getDoubleType()));
+		assertEquals("42.42", typeFormats.get(TypeFactoryWrapper.INSTANCE.getFloatType()));
+		assertEquals(
+				Locale.getDefault().toString(), 
+				typeFormats.get(TypeFactoryWrapper.INSTANCE.getLocaleType()));
+		assertEquals("42", typeFormats.get(TypeFactoryWrapper.INSTANCE.getLongType()));
+		assertEquals("a string", typeFormats.get(TypeFactoryWrapper.INSTANCE.getStringType()));
+		assertEquals("a text", typeFormats.get(TypeFactoryWrapper.INSTANCE.getTextType()));
+		assertEquals(12, typeFormats.get(TypeFactoryWrapper.INSTANCE.getTimeType()).length());
+		assertEquals(
+				new SimpleDateFormat("yyyy-MM-dd").format(new Date()), 
+				typeFormats.get(TypeFactoryWrapper.INSTANCE.getTimestampType()).substring(0, 10));
+		assertEquals(
+				TimeZone.getDefault().getID(), 
+				typeFormats.get(TypeFactoryWrapper.INSTANCE.getTimezoneType()));
+		assertEquals("true", typeFormats.get(TypeFactoryWrapper.INSTANCE.getTrueFalseType()));
+		assertEquals("true", typeFormats.get(TypeFactoryWrapper.INSTANCE.getYesNoType()));
+	}
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 public class TypeWrapperFactoryTest {
 
 	@Test
-	public void testCreateTyperapper() {
+	public void testCreateTypeWrapper() {
 		TypeWrapper typeWrapper = TypeWrapperFactory.createTypeWrapper(TypeFactoryWrapper.INSTANCE.getStringType());
 		assertNotNull(typeWrapper);
 		assertEquals("string", ((Type)((Wrapper)typeWrapper).getWrappedObject()).getName());


### PR DESCRIPTION
  - Correct type in 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactoryTest#testCreateTypeWrapper()'
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapperTest#testGetTypeFormats()'
  - Adapt 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory#toString(Object)' to properly handle calendar types
  - Implement method 'org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapper#getTypeFormats()'
