### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/EnvironmentWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/EnvironmentWrapper.java
@@ -2,6 +2,8 @@ package org.hibernate.tool.orm.jbt.wrp;
 
 public class EnvironmentWrapper {
 	
+	public static EnvironmentWrapper INSTANCE = new EnvironmentWrapper();
 	
+	private EnvironmentWrapper() {}
 
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -226,4 +226,8 @@ public class WrapperFactory {
 		return TypeFactoryWrapper.INSTANCE;
 	}
 
+	public static Object createEnvironmentWrapper() {
+		return EnvironmentWrapper.INSTANCE;
+	}
+
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/EnvironmentWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/EnvironmentWrapperTest.java
@@ -11,7 +11,7 @@ public class EnvironmentWrapperTest {
 	
 	@BeforeEach
 	public void beforeEach() {
-		environmentWrapper = new EnvironmentWrapper();
+		environmentWrapper = EnvironmentWrapper.INSTANCE;
 	}
 	
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -399,6 +399,13 @@ public class WrapperFactoryTest {
 		assertSame(TypeFactoryWrapper.INSTANCE, typeFactoryWrapper);
 	}
 	
+	@Test
+	public void testCreateEnvironmentWrapper() {
+		Object environmentWrapper = WrapperFactory.createEnvironmentWrapper();
+		assertNotNull(environmentWrapper);
+		assertSame(environmentWrapper, EnvironmentWrapper.INSTANCE);
+	}
+		
 	@SuppressWarnings("serial")
 	public static class TestNamingStrategy extends DefaultNamingStrategy {}
 	


### PR DESCRIPTION
  - Make class 'org.hibernate.tool.orm.jbt.wrp.EnvironmentWrapper' a singleton
  - Test class 'org.hibernate.tool.orm.jbt.wrp.EnvironmentWrapperTest' uses the singleton instance of 'org.hibernate.tool.orm.jbt.wrp.EnvironmentWrapper'
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateEnvironmentWrapper()'
  - Implement new method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createEnvironmentWrapper()'
