### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -23,7 +23,6 @@ import org.hibernate.mapping.Set;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
@@ -232,7 +231,7 @@ public class WrapperFactory {
 	}
 
 	public static Object createSchemaExport() {
-		return new SchemaExport();
+		return new SchemaExportWrapper();
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -411,7 +411,7 @@ public class WrapperFactoryTest {
 	public void testCreateSchemaExport() {
 		Object schemaExport = WrapperFactory.createSchemaExport();
 		assertNotNull(schemaExport);
-		assertTrue(schemaExport instanceof SchemaExport);
+		assertTrue(schemaExport instanceof SchemaExportWrapper);
 	}
 		
 	@SuppressWarnings("serial")


### PR DESCRIPTION
  - Method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createSchemaExport()' now creates an instance of 'org.hibernate.tool.orm.jbt.wrp.SchemaExportWrapper'
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateSchemaExport()' accordingly
