### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SchemaExportWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SchemaExportWrapper.java
@@ -1,7 +1,14 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
+import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 
 public class SchemaExportWrapper extends SchemaExport {
+	
+	private Configuration configuration = null;
+	
+	public SchemaExportWrapper(Configuration configuration) {
+		this.configuration = configuration;
+	}
 
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.orm.jbt.wrp;
 import java.util.Map;
 import java.util.Properties;
 
+import org.hibernate.cfg.Configuration;
 import org.hibernate.mapping.Any;
 import org.hibernate.mapping.Array;
 import org.hibernate.mapping.Bag;
@@ -230,8 +231,8 @@ public class WrapperFactory {
 		return EnvironmentWrapper.INSTANCE;
 	}
 
-	public static Object createSchemaExport() {
-		return new SchemaExportWrapper();
+	public static Object createSchemaExport(Object configuration) {
+		return new SchemaExportWrapper((Configuration)configuration);
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SchemaExportWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SchemaExportWrapperTest.java
@@ -1,22 +1,31 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.lang.reflect.Field;
+
+import org.hibernate.cfg.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SchemaExportWrapperTest {
 	
 	private SchemaExportWrapper schemaExportWrapper = null;
+	private Configuration configuration = null;
 	
 	@BeforeEach
 	public void beforeEach() {
-		schemaExportWrapper = new SchemaExportWrapper();
+		configuration = new Configuration();
+		schemaExportWrapper = new SchemaExportWrapper(configuration);
 	}
 	
 	@Test
-	public void testConstruction() {
+	public void testConstruction() throws Exception {
 		assertNotNull(schemaExportWrapper);
+		Field configurationField = SchemaExportWrapper.class.getDeclaredField("configuration");
+		configurationField.setAccessible(true);
+		assertSame(configuration, configurationField.get(schemaExportWrapper));
 	}
-
+	
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.lang.reflect.Field;
 import java.util.Properties;
 
+import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.NamingStrategy;
 import org.hibernate.mapping.Any;
@@ -37,7 +38,6 @@ import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
@@ -408,10 +408,14 @@ public class WrapperFactoryTest {
 	}
 	
 	@Test
-	public void testCreateSchemaExport() {
-		Object schemaExport = WrapperFactory.createSchemaExport();
+	public void testCreateSchemaExport() throws Exception {
+		Configuration configuration = new Configuration();
+		Object schemaExport = WrapperFactory.createSchemaExport(configuration);
 		assertNotNull(schemaExport);
 		assertTrue(schemaExport instanceof SchemaExportWrapper);
+		Field configurationField = SchemaExportWrapper.class.getDeclaredField("configuration");
+		configurationField.setAccessible(true);
+		assertSame(configuration, configurationField.get(schemaExport));
 	}
 		
 	@SuppressWarnings("serial")


### PR DESCRIPTION
  - Constructor 'org.hibernate.tool.orm.jbt.wrp.SchemaExportWrapper' takes a 'org.hibernate.cfg.Configuration' argument
  - Adapt the test class 'org.hibernate.tool.orm.jbt.wrp.SchemaExportWrapper'
  - Adapt implementation method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createSchemaExport(Object)' to accept a ('org.hibernate.cfg.Configuration') argument
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateSchemaExport()'
