### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/HbmExporterExt.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/HbmExporterExt.java
@@ -7,6 +7,8 @@ import org.hibernate.tool.internal.export.hbm.HbmExporter;
 
 public class HbmExporterExt extends HbmExporter {
 	
+	private Object delegateExporter;
+
 	public HbmExporterExt(Configuration cfg, File file) {
 		getProperties().put(
 				METADATA_DESCRIPTOR, 
@@ -16,4 +18,8 @@ public class HbmExporterExt extends HbmExporter {
 		}
 	}
 	
+	public void setDelegate(Object delegate) {
+		delegateExporter = delegate;
+	}
+
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/HbmExporterExtTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/HbmExporterExtTest.java
@@ -2,6 +2,7 @@ package org.hibernate.tool.orm.jbt.util;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -41,6 +42,16 @@ public class HbmExporterExtTest {
 		Field configurationField = ConfigurationMetadataDescriptor.class.getDeclaredField("configuration");
 		configurationField.setAccessible(true);
 		assertSame(cfg, configurationField.get(descriptor));
+	}
+	
+	@Test
+	public void testSetDelegate() throws Exception {
+		Object delegate = new Object();
+		Field delegateField = HbmExporterExt.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		assertNull(delegateField.get(hbmExporterExt));
+		hbmExporterExt.setDelegate(delegate);
+		assertSame(delegate, delegateField.get(hbmExporterExt));
 	}
 
 }


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.util.HbmExporterExtTest#testSetDelegate()'
  - Add new implementation method 'org.hibernate.tool.orm.jbt.util.HbmExporterExt#setDelegate(Object)'
