### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/HbmExporterWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/HbmExporterWrapper.java
@@ -2,6 +2,7 @@ package org.hibernate.tool.orm.jbt.wrp;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
 
 import org.hibernate.cfg.Configuration;
@@ -29,6 +30,11 @@ public class HbmExporterWrapper extends HbmExporter {
 	public void superExportPOJO(Map<String, Object> map, POJOClass pojoClass) {
 		super.exportPOJO(map, pojoClass);
 	}
+	
+	@Override
+	public File getOutputDirectory() {
+		return super.getOutputDirectory();
+	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
@@ -48,10 +54,11 @@ public class HbmExporterWrapper extends HbmExporter {
 			POJOClass pojoClass, 
 			String qualifiedDeclarationName) {
 		try {
-			delegateExporter
-				.getClass()
-				.getMethod("exportPojo", Map.class, Object.class, String.class)
-				.invoke(delegateExporter, map, pojoClass, qualifiedDeclarationName);
+			Method method = delegateExporter
+					.getClass()
+					.getDeclaredMethod("exportPojo", Map.class, Object.class, String.class);
+			method.setAccessible(true);
+			method.invoke(delegateExporter, map, pojoClass, qualifiedDeclarationName);
 		} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/HbmExporterWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/HbmExporterWrapperTest.java
@@ -96,7 +96,7 @@ public class HbmExporterWrapperTest {
 		templateProcessed = false;
 		Object delegateExporter = new Object() {
 			@SuppressWarnings("unused")
-			public void exportPojo(Map<Object, Object> map, Object object, String string) {
+			private void exportPojo(Map<Object, Object> map, Object object, String string) {
 				assertSame(map, context);
 				assertSame(object, pojoClass);
 				assertEquals(string, pojoClass.getQualifiedDeclarationName());
@@ -152,4 +152,12 @@ public class HbmExporterWrapperTest {
 		assertFalse(delegateHasExported);
 	}
 
+	@Test
+	public void testGetOutputDirectory() {
+		assertNull(hbmExporterWrapper.getOutputDirectory());
+		File file = new File("testGetOutputDirectory");
+		hbmExporterWrapper.getProperties().put(ExporterConstants.DESTINATION_FOLDER, file);
+		assertSame(file, hbmExporterWrapper.getOutputDirectory());
+	}
+	
 }


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.HbmExporterWrapperTest#testGetOutputDirectory()'
  - Inherit method 'org.hibernate.tool.orm.jbt.wrp.HbmExporterWrapper.getOutputDirectory()' and change visibility to public
