### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/GenericExporterWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/GenericExporterWrapper.java
@@ -1,0 +1,7 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import org.hibernate.tool.internal.export.common.GenericExporter;
+
+public class GenericExporterWrapper extends GenericExporter {
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -27,7 +27,6 @@ import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
-import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
@@ -242,7 +241,7 @@ public class WrapperFactory {
 	}
 
 	public static Object createGenericExporterWrapper() {
-		return new GenericExporter();
+		return new GenericExporterWrapper();
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -42,7 +42,6 @@ import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
-import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
@@ -443,7 +442,7 @@ public class WrapperFactoryTest {
 	public void testCreateGenericExporterWrapper() {
 		Object genericExporterWrapper = WrapperFactory.createGenericExporterWrapper();
 		assertNotNull(genericExporterWrapper);
-		assertTrue(genericExporterWrapper instanceof GenericExporter);
+		assertTrue(genericExporterWrapper instanceof GenericExporterWrapper);
 	}
 		
 	@SuppressWarnings("serial")


### PR DESCRIPTION
  - Create new class 'org.hibernate.tool.orm.jbt.wrp.GenericExporterWrapper' that extends 'org.hibernate.tool.internal.export.common.GenericExporter'
  - Method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createGenericExporterWrapper()' now returns an instance of 'org.hibernate.tool.orm.jbt.wrp.GenericExporterWrapper'
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateGenericExporterWrapper()'
