### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
@@ -4,33 +4,44 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.orm.jbt.util.ReflectUtil;
 
 public class ExporterWrapperFactory {
 	
 	public static ExporterWrapper create(String className) {
-		Object delegate = ReflectUtil.createInstance(className);
 		return (ExporterWrapper)Proxy.newProxyInstance( 
 				ExporterWrapperFactory.class.getClassLoader(), 
 				new Class[] { ExporterWrapper.class }, 
-				new ExporterInvocationHandler(delegate));
+				new ExporterInvocationHandler(className));
 	}
 	
 	private static class ExporterInvocationHandler implements InvocationHandler {
 		
-		private Object delegate = null;
+		private ExporterWrapper exporterWrapper = null;
 		
-		private ExporterInvocationHandler(Object delegate) {
-			this.delegate = delegate;
+		private ExporterInvocationHandler(String className) {
+			this.exporterWrapper = new ExporterWrapperImpl(className);
 		}
 
 		@Override
 		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-			return method.invoke(delegate, args);
+			return method.invoke(exporterWrapper, args);
 		}
 		
 	}
 	
-	static interface ExporterWrapper {}
+	static interface ExporterWrapper extends Wrapper {}
+	
+	static class ExporterWrapperImpl implements ExporterWrapper {
+		private Exporter delegateExporter = null;
+		private ExporterWrapperImpl(String className) {
+			delegateExporter = (Exporter)ReflectUtil.createInstance(className);
+		}
+		@Override 
+		public Exporter getWrappedObject() {
+			return delegateExporter;
+		}
+	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
@@ -1,6 +1,7 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory.ExporterWrapper;
@@ -12,6 +13,8 @@ public class ExporterWrapperFactoryTest {
 	public void testCreate() {
 		ExporterWrapper exporterWrapper = ExporterWrapperFactory.create(DdlExporter.class.getName());
 		assertNotNull(exporterWrapper);
+		Object wrappedExporter = exporterWrapper.getWrappedObject();
+		assertTrue(wrappedExporter instanceof DdlExporter);
 	}
 
 }


### PR DESCRIPTION
  - Refactor class 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory' so that implementation of 'Wrapper#getWrappedObject()' returns the exporter delegate
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactoryTest#testCreate()'
