### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
@@ -58,6 +58,9 @@ public class ExporterWrapperFactory {
 		default void setTemplatePath(String[] templatePath) {
 			getWrappedObject().getProperties().put(ExporterConstants.TEMPLATE_PATH, templatePath);
 		}
+		default void start() {
+			getWrappedObject().start();
+		}
 	}
 	
 	static class ExporterWrapperImpl implements ExporterWrapper {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
@@ -1,7 +1,9 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,48 +15,59 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.api.export.ArtifactCollector;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory.ExporterWrapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ExporterWrapperFactoryTest {
 	
 	private ExporterWrapper exporterWrapper = null;
 	
+	@BeforeEach
+	public void beforeEach() {
+		exporterWrapper = ExporterWrapperFactory.create(TestExporter.class.getName());
+	}
+	
 	@Test
 	public void testCreate() {
-		exporterWrapper = ExporterWrapperFactory.create(DdlExporter.class.getName());
 		assertNotNull(exporterWrapper);
 		Object wrappedExporter = exporterWrapper.getWrappedObject();
-		assertTrue(wrappedExporter instanceof DdlExporter);
+		assertTrue(wrappedExporter instanceof TestExporter);
 	}
 
 	@Test
 	public void testSetConfiguration() throws Exception {
-		exporterWrapper = ExporterWrapperFactory.create(CfgExporter.class.getName());
+		Object metadataDescriptor = null;
 		Properties properties = new Properties();
 		Configuration configuration = new Configuration();
 		configuration.setProperties(properties);
-		exporterWrapper.setConfiguration(configuration);	
-		assertSame(properties, ((CfgExporter)exporterWrapper.getWrappedObject()).getCustomProperties());
-		Object object = exporterWrapper.getWrappedObject().getProperties().get(
-				ExporterConstants.METADATA_DESCRIPTOR);
-		assertNotNull(object);
-		assertTrue(object instanceof ConfigurationMetadataDescriptor);
-		ConfigurationMetadataDescriptor configurationMetadataDescriptor = (ConfigurationMetadataDescriptor)object;
 		Field field = ConfigurationMetadataDescriptor.class.getDeclaredField("configuration");
 		field.setAccessible(true);
-		object = field.get(configurationMetadataDescriptor);
-		assertNotNull(object);
-		assertTrue(object instanceof Configuration);
-		assertSame(object, configuration);
+		// First use the TestExporter 
+		assertNull(exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.METADATA_DESCRIPTOR));
+		exporterWrapper.setConfiguration(configuration);	
+		metadataDescriptor = exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.METADATA_DESCRIPTOR);
+		assertNotNull(metadataDescriptor);
+		assertTrue(metadataDescriptor instanceof ConfigurationMetadataDescriptor);
+		assertSame(configuration, field.get(metadataDescriptor));
+		// Now test with a CfgExporter
+		exporterWrapper = ExporterWrapperFactory.create(CfgExporter.class.getName());
+		assertNotSame(properties, ((CfgExporter)exporterWrapper.getWrappedObject()).getCustomProperties());
+		assertNull(exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.METADATA_DESCRIPTOR));
+		exporterWrapper.setConfiguration(configuration);	
+		assertSame(properties, ((CfgExporter)exporterWrapper.getWrappedObject()).getCustomProperties());
+		metadataDescriptor = exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.METADATA_DESCRIPTOR);
+		assertNotNull(metadataDescriptor);
+		assertTrue(metadataDescriptor instanceof ConfigurationMetadataDescriptor);
+		assertSame(configuration, field.get(metadataDescriptor));
 	}
 	
 	@Test
 	public void testSetArtifactCollector() {
-		exporterWrapper = ExporterWrapperFactory.create(DdlExporter.class.getName());
 		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
 		assertNotSame(artifactCollector, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
 		exporterWrapper.setArtifactCollector(artifactCollector);
@@ -64,7 +77,6 @@ public class ExporterWrapperFactoryTest {
 	@Test
 	public void testSetOutputDirectory() {
 		File file = new File("");
-		exporterWrapper = ExporterWrapperFactory.create(DdlExporter.class.getName());
 		assertNotSame(file, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.DESTINATION_FOLDER));		
 		exporterWrapper.setOutputDirectory(file);
 		assertSame(file, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.DESTINATION_FOLDER));		
@@ -73,10 +85,22 @@ public class ExporterWrapperFactoryTest {
 	@Test
 	public void testSetTemplatePath() {
 		String[] templatePath = new String[] {};
-		exporterWrapper = ExporterWrapperFactory.create(DdlExporter.class.getName());
 		assertNotSame(templatePath, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.TEMPLATE_PATH));		
 		exporterWrapper.setTemplatePath(templatePath);
 		assertSame(templatePath, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.TEMPLATE_PATH));		
+	}
+	
+	@Test
+	public void testStart() throws Exception {
+		assertFalse(((TestExporter)exporterWrapper.getWrappedObject()).started);
+		exporterWrapper.start();
+		assertTrue(((TestExporter)exporterWrapper.getWrappedObject()).started);
+	}
+	
+	public static class TestExporter extends AbstractExporter {
+		private boolean started = false;
+		@Override protected void doStart() {}
+		@Override public void start() { started = true; }		
 	}
 	
 }


### PR DESCRIPTION
  - Refactor tests in class 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactoryTest' to use new inner class 'TestExporter'
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactoryTest#testStart()'
  - Add new default interface method 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory.ExporterWrapper#start()'
