### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Properties;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.api.export.ArtifactCollector;
@@ -43,23 +44,24 @@ public class ExporterWrapperFactory {
 			if (CfgExporter.class.isAssignableFrom(getWrappedObject().getClass())) {
 				((CfgExporter)getWrappedObject()).setCustomProperties(configuration.getProperties());
 			}
-			getWrappedObject().getProperties().put(
+			getProperties().put(
 					ExporterConstants.METADATA_DESCRIPTOR, 
 					new ConfigurationMetadataDescriptor(configuration));
 		}
 		default void setArtifactCollector(ArtifactCollector artifactCollector) {
-			getWrappedObject().getProperties().put(
-					ExporterConstants.ARTIFACT_COLLECTOR,
-					artifactCollector);
+			getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
 		}
 		default void setOutputDirectory(File dir) {
-			getWrappedObject().getProperties().put(ExporterConstants.DESTINATION_FOLDER, dir);
+			getProperties().put(ExporterConstants.DESTINATION_FOLDER, dir);
 		}
 		default void setTemplatePath(String[] templatePath) {
-			getWrappedObject().getProperties().put(ExporterConstants.TEMPLATE_PATH, templatePath);
+			getProperties().put(ExporterConstants.TEMPLATE_PATH, templatePath);
 		}
 		default void start() {
 			getWrappedObject().start();
+		}
+		default Properties getProperties() {
+			return getWrappedObject().getProperties();
 		}
 	}
 	

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
@@ -97,6 +97,17 @@ public class ExporterWrapperFactoryTest {
 		assertTrue(((TestExporter)exporterWrapper.getWrappedObject()).started);
 	}
 	
+	@Test
+	public void testGetProperties() throws Exception {
+		Field propertiesField = AbstractExporter.class.getDeclaredField("properties");
+		propertiesField.setAccessible(true);
+		Properties properties = new Properties();
+		assertNotNull(exporterWrapper.getProperties());
+		assertNotSame(properties, exporterWrapper.getProperties());
+		propertiesField.set(exporterWrapper.getWrappedObject(), properties);
+		assertSame(properties, exporterWrapper.getProperties());
+	}
+	
 	public static class TestExporter extends AbstractExporter {
 		private boolean started = false;
 		@Override protected void doStart() {}


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactoryTest#testGetProperties()'
  - Add new default interface method 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory.ExporterWrapper#getProperties()'
  - Refactor default methods of interface 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory.ExporterWrapper' to use above method
