### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -27,6 +27,7 @@ import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
@@ -241,7 +242,7 @@ public class WrapperFactory {
 	}
 
 	public static Object createGenericExporterWrapper() {
-		return new GenericExporterWrapper();
+		return GenericExporterWrapperFactory.create(new GenericExporter());
 	}
 
 	public static Object createDdlExporterWrapper() {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -444,7 +444,7 @@ public class WrapperFactoryTest {
 	public void testCreateGenericExporterWrapper() {
 		Object genericExporterWrapper = WrapperFactory.createGenericExporterWrapper();
 		assertNotNull(genericExporterWrapper);
-		assertTrue(genericExporterWrapper instanceof GenericExporterWrapper);
+		assertTrue(genericExporterWrapper instanceof GenericExporterWrapperFactory.GenericExporterWrapper);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.GenericExporterWrapperFactory#create(...)' in the implementation of 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createGenericExporterWrapper()'
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactorTest#testCreateGenericExporterWrapper()'
