### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DdlExporterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DdlExporterWrapperFactory.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.orm.jbt.wrp;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Properties;
 
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
@@ -35,6 +36,9 @@ public class DdlExporterWrapperFactory {
 		@Override DdlExporter getWrappedObject();
 		default void setExport(boolean b) {
 			getWrappedObject().getProperties().put(ExporterConstants.EXPORT_TO_DATABASE, b);
+		}
+		default Properties getProperties() {
+			return getWrappedObject().getProperties();
 		}
 		
 	}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/DdlExporterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/DdlExporterWrapperFactoryTest.java
@@ -2,11 +2,16 @@ package org.hibernate.tool.orm.jbt.wrp;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
+import java.util.Properties;
+
 import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +40,16 @@ public class DdlExporterWrapperFactoryTest {
 		assertFalse((Boolean)wrappedDdlExporter.getProperties().get(ExporterConstants.EXPORT_TO_DATABASE));
 		ddlExporterWrapper.setExport(true);
 		assertTrue((Boolean)wrappedDdlExporter.getProperties().get(ExporterConstants.EXPORT_TO_DATABASE));
+	}
+
+	@Test
+	public void testGetProperties() throws Exception {
+		Field propertiesField = AbstractExporter.class.getDeclaredField("properties");
+		propertiesField.setAccessible(true);
+		Properties properties = new Properties();
+		assertNotSame(properties, ddlExporterWrapper.getProperties());
+		propertiesField.set(wrappedDdlExporter, properties);
+		assertSame(properties, ddlExporterWrapper.getProperties());
 	}
 
 }


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.DdlExporterWrapperFactoryTest#testGetProperties()'
  - Add new default interface method 'org.hibernate.tool.orm.jbt.wrp.DdlExporterWrapperFactory.DdlExporterWrapper#getProperties()'
