### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/QueryExporterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/QueryExporterWrapperFactory.java
@@ -3,6 +3,7 @@ package org.hibernate.tool.orm.jbt.wrp;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.List;
 
 import org.hibernate.tool.internal.export.query.QueryExporter;
 
@@ -31,6 +32,10 @@ public class QueryExporterWrapperFactory {
 	}
 	
 	static interface QueryExporterWrapper extends Wrapper {
+		@Override QueryExporter getWrappedObject();
+		default void setQueries(List<String> queries) {
+			getWrappedObject().setQueries(queries);
+		}
 		
 	}
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/QueryExporterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/QueryExporterWrapperFactoryTest.java
@@ -1,8 +1,13 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,5 +28,13 @@ public class QueryExporterWrapperFactoryTest {
 		assertNotNull(queryExporterWrapper);
 		assertSame(wrappedQueryExporter, queryExporterWrapper.getWrappedObject());
 	}
+	
+	@Test
+	public void testSetQueries() {
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, wrappedQueryExporter.getProperties().get(ExporterConstants.QUERY_LIST));
+		queryExporterWrapper.setQueries(queries);
+		assertSame(queries, wrappedQueryExporter.getProperties().get(ExporterConstants.QUERY_LIST));
+	}	
 
 }


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.QueryExporterWrapperFactoryTest#testSetQueries()'
  - Add new default interface method 'org.hibernate.tool.orm.jbt.wrp.QueryExporterWrapperFactory#etQueries(List<String>)'
