### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -30,6 +30,7 @@ import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
+import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
@@ -251,7 +252,7 @@ public class WrapperFactory {
 	}
 
 	public static Object createQueryExporterWrapper() {
-		return new QueryExporterWrapper();
+		return QueryExporterWrapperFactory.create(new QueryExporter());
 	}
 
 	public static Object createExporterWrapper(String exporterClassName) {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -458,7 +458,7 @@ public class WrapperFactoryTest {
 	public void testCreateQueryExporterWrapper() {
 		Object queryExporterWrapper = WrapperFactory.createQueryExporterWrapper();
 		assertNotNull(queryExporterWrapper);
-		assertTrue(queryExporterWrapper instanceof QueryExporterWrapper);
+		assertTrue(queryExporterWrapper instanceof QueryExporterWrapperFactory.QueryExporterWrapper);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.QueryExporterWrapperFactory#create(QueryExporter)' in the implementation of 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createQueryExporterWrapper()'
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactorTest#testCreateQueryExporterWrapper()'
