### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
@@ -13,10 +13,12 @@ import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
+import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.util.ReflectUtil;
 import org.hibernate.tool.orm.jbt.wrp.DdlExporterWrapperFactory.DdlExporterWrapper;
 import org.hibernate.tool.orm.jbt.wrp.GenericExporterWrapperFactory.GenericExporterWrapper;
+import org.hibernate.tool.orm.jbt.wrp.QueryExporterWrapperFactory.QueryExporterWrapper;
 
 public class ExporterWrapperFactory {
 	
@@ -77,6 +79,13 @@ public class ExporterWrapperFactory {
 		default DdlExporterWrapper getHbm2DDLExporter() {
 			if (getWrappedObject() instanceof DdlExporter) {
 				return DdlExporterWrapperFactory.create((DdlExporter)getWrappedObject());
+			} else {
+				return null;
+			}
+		}
+		default QueryExporterWrapper getQueryExporter() {
+			if (getWrappedObject() instanceof QueryExporter) {
+				return QueryExporterWrapperFactory.create((QueryExporter)getWrappedObject());
 			} else {
 				return null;
 			}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
@@ -19,10 +19,12 @@ import org.hibernate.tool.internal.export.common.AbstractExporter;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
+import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.wrp.DdlExporterWrapperFactory.DdlExporterWrapper;
 import org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory.ExporterWrapper;
 import org.hibernate.tool.orm.jbt.wrp.GenericExporterWrapperFactory.GenericExporterWrapper;
+import org.hibernate.tool.orm.jbt.wrp.QueryExporterWrapperFactory.QueryExporterWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -128,13 +130,26 @@ public class ExporterWrapperFactoryTest {
 	public void testGetHbm2DDlExporter() {
 		// TestExporter should not return a GenericExporterFacade instance
 		assertNull(exporterWrapper.getHbm2DDLExporter());
-		// try now with a GenericExporter
+		// try now with a DdlExporter
 		exporterWrapper = ExporterWrapperFactory.create(DdlExporter.class.getName());
 		DdlExporterWrapper ddlExporterWrapper = exporterWrapper.getHbm2DDLExporter();
 		assertNotNull(ddlExporterWrapper);
 		Object exporterTarget = ((Wrapper)exporterWrapper).getWrappedObject();
 		Object ddlExporterTarget = ((Wrapper)ddlExporterWrapper).getWrappedObject();
 		assertSame(exporterTarget, ddlExporterTarget);
+	}
+	
+	@Test
+	public void testGetQueryExporter() {
+		// TestExporter should not return a GenericExporterFacade instance
+		assertNull(exporterWrapper.getQueryExporter());
+		// try now with a QueryExporter
+		exporterWrapper = ExporterWrapperFactory.create(QueryExporter.class.getName());
+		QueryExporterWrapper queryExporterWrapper = exporterWrapper.getQueryExporter();
+		assertNotNull(queryExporterWrapper);
+		Object exporterTarget = ((Wrapper)exporterWrapper).getWrappedObject();
+		Object queryExporterTarget = ((Wrapper)queryExporterWrapper).getWrappedObject();
+		assertSame(exporterTarget, queryExporterTarget);
 	}
 	
 	public static class TestExporter extends AbstractExporter {


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactoryTest#testGetQueryExporter()'
  - Add new default interface method 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory.ExporterWrapper#getQueryExporter()'
