### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapper.java
@@ -1,5 +1,6 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.hibernate.SessionFactory;
@@ -21,11 +22,12 @@ public class SessionFactoryWrapper extends SessionFactoryDelegatingImpl {
 	}
 	
 	public Map<String, EntityPersister> getAllClassMetadata() {
-		Map<String, EntityPersister> result = getMetamodel().entityPersisters();
-		for (String key : result.keySet()) {
-			result.put(key, (EntityPersister)EntityPersisterWrapperFactory.create(result.get(key)));
+		Map<String, EntityPersister> origin = getMetamodel().entityPersisters();
+		Map<String, EntityPersister> result = new HashMap<String, EntityPersister>(origin.size());
+		for (String key : origin.keySet()) {
+			result.put(key, (EntityPersister)EntityPersisterWrapperFactory.create(origin.get(key)));
 		}
-		return getMetamodel().entityPersisters();
+		return result;
 	}
 
 	public Map<String, CollectionPersister> getAllCollectionMetadata() {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapperTest.java
@@ -94,7 +94,9 @@ public class SessionFactoryWrapperTest {
 		Map<String, EntityPersister> allClassMetadata = sessionFactoryWrapper.getAllClassMetadata();
 		assertNotNull(allClassMetadata);
 		assertEquals(1, allClassMetadata.size());
-		assertNotNull(allClassMetadata.get(Foo.class.getName()));
+		EntityPersister fooPersister = allClassMetadata.get(Foo.class.getName());
+		assertNotNull(fooPersister);
+		assertTrue(fooPersister instanceof EntityPersisterWrapperFactory.EntityPersisterExtension);
 	}
 	
 	@Test
@@ -108,9 +110,13 @@ public class SessionFactoryWrapperTest {
 	@Test
 	public void testGetClassMetadata() throws Exception {
 		assertNull(sessionFactoryWrapper.getClassMetadata("foo"));
-		assertNotNull(sessionFactoryWrapper.getClassMetadata(Foo.class.getName()));
+		EntityPersister fooPersister = sessionFactoryWrapper.getClassMetadata(Foo.class.getName());
+		assertNotNull(fooPersister);
+		assertTrue(fooPersister instanceof EntityPersisterWrapperFactory.EntityPersisterExtension);
 		assertNull(sessionFactoryWrapper.getClassMetadata(Object.class));
-		assertNotNull(sessionFactoryWrapper.getClassMetadata(Foo.class));
+		fooPersister = sessionFactoryWrapper.getClassMetadata(Foo.class);
+		assertNotNull(fooPersister);
+		assertTrue(fooPersister instanceof EntityPersisterWrapperFactory.EntityPersisterExtension);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Adapt the test cases 'org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapperTest#testGetAllClassMetadata()' and 'org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapperTest#testGetClassMetadata()' to ensure the returned 'EntityPersister' instances are also instance of 'org.hibernate.tool.orm.jbt.wrp.EntityPersisterWrapperFactory.EntityPersisterExtension'
  - Make the above tests work again by changing the implementation of method 'org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapper#getAllClassMetadata()'
