### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/HqlCodeAssistWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/HqlCodeAssistWrapper.java
@@ -1,0 +1,12 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.ide.completion.HQLCodeAssist;
+
+public class HqlCodeAssistWrapper extends HQLCodeAssist {
+
+	public HqlCodeAssistWrapper(Metadata metadata) {
+		super(metadata);
+	}
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -247,7 +247,7 @@ public class WrapperFactory {
 	}
 	
 	public static Object createHqlCodeAssistWrapper(Object configuration) {
-		return new HQLCodeAssist(MetadataHelper.getMetadata((Configuration)configuration));
+		return new HqlCodeAssistWrapper(MetadataHelper.getMetadata((Configuration)configuration));
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -458,6 +458,7 @@ public class WrapperFactoryTest {
 		configuration.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
 		Metadata metadata = MetadataHelper.getMetadata(configuration);
 		Object hqlCodeAssistWrapper = WrapperFactory.createHqlCodeAssistWrapper(configuration);
+		assertTrue(hqlCodeAssistWrapper instanceof HqlCodeAssistWrapper);
 		Field metadataField = HQLCodeAssist.class.getDeclaredField("metadata");
 		metadataField.setAccessible(true);
 		assertSame(metadata, metadataField.get(hqlCodeAssistWrapper));


### PR DESCRIPTION
  - Add new class 'org.hibernate.tool.orm.jbt.wrp.HqlCodeAssistWrapper'
  - Adapt method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createHqlCodeAssistWrapper(Object)' to return an instance of above class
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#testCreateHqlCodeAssistWrapper()' to the above changes
