### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/HqlCodeAssistWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/HqlCodeAssistWrapper.java
@@ -1,12 +1,62 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
+import java.lang.reflect.Method;
+
 import org.hibernate.boot.Metadata;
 import org.hibernate.tool.ide.completion.HQLCodeAssist;
+import org.hibernate.tool.ide.completion.HQLCompletionProposal;
+import org.hibernate.tool.ide.completion.IHQLCompletionRequestor;
 
 public class HqlCodeAssistWrapper extends HQLCodeAssist {
 
 	public HqlCodeAssistWrapper(Metadata metadata) {
 		super(metadata);
+	}
+	
+	public void codeComplete(String query, int position, Object handler) {
+		super.codeComplete(query, position, new HqlCompletionRequestorAdapter(handler));;
+	}
+	
+	private static class HqlCompletionRequestorAdapter implements IHQLCompletionRequestor {
+		
+		private Object handler = null;
+		private Method acceptMethod = null;
+		private Method completionFailureMethod = null;
+		
+		private HqlCompletionRequestorAdapter(Object handler) {
+			this.handler = handler;
+			acceptMethod = lookupMethod("accept", Object.class);
+			completionFailureMethod = lookupMethod("completionFailure", String.class);
+		}
+		
+		@Override
+		public boolean accept(HQLCompletionProposal proposal) {
+			try {
+				return (boolean)acceptMethod.invoke(handler, proposal);
+			} catch (Throwable t) {
+				throw new RuntimeException(t);
+			}
+		}
+
+		@Override
+		public void completionFailure(String errorMessage) {
+			try {
+				completionFailureMethod.invoke(handler, errorMessage);
+			} catch (Throwable t) {
+				throw new RuntimeException(t);
+			}
+		}
+		
+		private Method lookupMethod(String name, Class<?> argumentClass) {
+			Method result = null;
+			try {
+				result = handler.getClass().getMethod(name, new Class[] { argumentClass });
+			} catch (Throwable t) {
+				throw new RuntimeException(t);
+			}
+			return result;
+		}
+		
 	}
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/HqlCodeAssistWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/HqlCodeAssistWrapperTest.java
@@ -1,0 +1,53 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.tool.orm.jbt.util.MetadataHelper;
+import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HqlCodeAssistWrapperTest {
+	
+	private HqlCodeAssistWrapper hqlCodeAssistWrapper = null;
+	
+	@BeforeEach
+	public void beforeEach() {
+		Configuration configuration = new NativeConfiguration();
+		configuration.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
+		Metadata metadata = MetadataHelper.getMetadata(configuration);
+		hqlCodeAssistWrapper = new HqlCodeAssistWrapper(metadata);
+	}
+	
+	@Test
+	public void testCodeComplete() {
+		// First test the handler's 'accept' method
+		TestCodeCompletionHandler completionHandler = new TestCodeCompletionHandler();
+		assertEquals(0, completionHandler.acceptCount);
+		hqlCodeAssistWrapper.codeComplete("", 0, completionHandler);
+		assertNotEquals(0, completionHandler.acceptCount);
+		// Now try to invoke the handler's 'completionFailure' method
+		hqlCodeAssistWrapper = new HqlCodeAssistWrapper(null);
+		assertNull(completionHandler.errorMessage);
+		hqlCodeAssistWrapper.codeComplete("FROM ", 5, completionHandler);
+		assertNotNull(completionHandler.errorMessage);
+	}
+	
+	static class TestCodeCompletionHandler {
+		int acceptCount = 0;
+		String errorMessage = null;
+		public boolean accept(Object o) {
+			acceptCount++;
+			return false;
+		}
+		public void completionFailure(String errorMessage) {
+			this.errorMessage = errorMessage;
+		}
+	}
+
+}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -13,7 +13,6 @@ import java.lang.reflect.Field;
 import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.NamingStrategy;
@@ -54,7 +53,6 @@ import org.hibernate.tool.internal.reveng.strategy.TableFilter;
 import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.MetadataHelper;
-import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
@@ -455,7 +453,7 @@ public class WrapperFactoryTest {
 	@Test
 	public void testCreateHqlCodeAssistWrapper() throws Exception {
 		Configuration configuration = new NativeConfiguration();
-		configuration.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
+		configuration.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
 		Metadata metadata = MetadataHelper.getMetadata(configuration);
 		Object hqlCodeAssistWrapper = WrapperFactory.createHqlCodeAssistWrapper(configuration);
 		assertTrue(hqlCodeAssistWrapper instanceof HqlCodeAssistWrapper);


### PR DESCRIPTION
  - Add new test class 'org.hibernate.tool.orm.jbt.wrp.HqlCodeAssistWrapperTest'
  - Implement method 'org.hibernate.tool.orm.jbt.wrp.HqlCodeAssistWrapper#codeComplete(String,int,Object)' that adapts the handler argument to an instance of 'org.hibernate.tool.ide.completion.IHQLCompletionRequestor' before delegating to the superclass
  - Some cleanup of test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateHqlCodeAssistWrapper()'
