### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SessionWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SessionWrapperFactory.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Proxy;
 import org.hibernate.engine.spi.SessionDelegatorBaseImpl;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactory.QueryWrapper;
 
 import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -72,6 +73,11 @@ public class SessionWrapperFactory {
 			Root root = criteriaQuery.from(persistentClass);
 			criteriaQuery.select(root);
 			return CriteriaWrapperFactory.createCriteriaWrapper(delegate().createQuery(criteriaQuery));
+		}
+		
+		@Override
+		public QueryWrapper<?> createQuery(String queryString) {
+			return QueryWrapperFactory.createQueryWrapper(delegate().createQuery(queryString, null));
 		}
 		
 		@Override

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SessionWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SessionWrapperFactoryTest.java
@@ -94,6 +94,7 @@ public class SessionWrapperFactoryTest {
 	public void testCreateQuery() {
 		Query<?> query = sessionWrapper.createQuery("from " + Foo.class.getName());
 		assertNotNull(query);
+		assertTrue(query instanceof QueryWrapperFactory.QueryWrapper);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Override method 'org.hibernate.tool.orm.jbt.wrp.SessionWrapperFactory.SessionWrapperImpl#createQuery(String)'
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.SessionWrapperFactoryTest#testCreateQuery()'
