### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/QueryWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/QueryWrapperFactoryTest.java
@@ -156,6 +156,13 @@ public class QueryWrapperFactoryTest {
 		assertEquals(1, binding.getBindValue());
 	}
 	
+	@Test
+	public void testGetReturnAliases() {
+		String[] aliases = simpleQueryWrapper.getReturnAliases();
+		assertNotNull(aliases);
+		assertEquals(0, aliases.length);
+	}
+	
 	private void createDatabase() throws Exception {
 		connection = DriverManager.getConnection("jdbc:h2:mem:test");
 		statement = connection.createStatement();


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactoryTest#testGetReturnAliases()'
  - Refactor class 'org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactory'
    * Create interface 'org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactory.QueryExtension<T>' with all the methods formerly in the interface 'org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactory.QueryWrapper<T>' and that extends 'org.hibernate.tool.orm.jbt.wrp.Wrapper'
    * Interface 'org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactory.QueryWrapper<T>' now extends 'org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactory.QueryExtension<T>' and 'org.hibernate.query.spi.QueryImplementor' * Invocation handler 'org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactory.QueryWrapperInvocationHandler<T>' now implements 'org.hibernate.tool.orm.jbt.wrp.QueryWrapperFactory.QueryWrapper<T>' (and 'java.lang.reflect.InvocationHandler') and dispatches the method either to itself or to the cached query
