### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/RevengConfiguration.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/RevengConfiguration.java
@@ -30,14 +30,14 @@ public class RevengConfiguration extends Configuration {
 	}
 
 	public boolean preferBasicCompositeIds() {
-		String preferBasicCompositeIds = getProperty(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS);
-		return preferBasicCompositeIds == null ? true : Boolean.getBoolean(preferBasicCompositeIds);
+		Boolean preferBasicCompositeIds = (Boolean)getProperties().get(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS);
+		return preferBasicCompositeIds == null ? Boolean.TRUE : preferBasicCompositeIds;
 	}
 
 	public void setPreferBasicCompositeIds(boolean preferBasicCompositeIds) {
-		setProperty(
+		getProperties().put(
 				MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, 
-				Boolean.toString(preferBasicCompositeIds));
+				Boolean.valueOf(preferBasicCompositeIds));
 	}
 
 	public Metadata getMetadata() {
@@ -114,11 +114,11 @@ public class RevengConfiguration extends Configuration {
 	}
 		
 	public void buildMappings() {
-		throw new RuntimeException(
-				"Method 'buildMappings' should not be called on instances of " +
-				this.getClass().getName());
+		if (metadata == null) {
+			readFromJDBC();
+		}
 	}
-		
+	
 	public SessionFactory buildSessionFactory() {
 		throw new RuntimeException(
 				"Method 'buildSessionFactory' should not be called on instances of " +

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/RevengConfigurationTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/RevengConfigurationTest.java
@@ -118,7 +118,7 @@ public class RevengConfigurationTest {
 	public void testPreferBasicCompositeIds() throws Exception {
 		assertTrue(revengConfiguration.preferBasicCompositeIds());
 		((Properties)propertyField.get(revengConfiguration)).put(
-				MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, "false");		
+				MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, false);		
 		assertFalse(revengConfiguration.preferBasicCompositeIds());
 	}
 	
@@ -129,7 +129,7 @@ public class RevengConfigurationTest {
 						MetadataConstants.PREFER_BASIC_COMPOSITE_IDS));
 		revengConfiguration.setPreferBasicCompositeIds(true);
 		assertEquals(
-				"true", 
+				true, 
 				((Properties)propertyField.get(revengConfiguration)).get(
 						MetadataConstants.PREFER_BASIC_COMPOSITE_IDS));
 	}
@@ -297,15 +297,12 @@ public class RevengConfigurationTest {
 	}
 
 	@Test
-	public void testBuildMappings() {
-		try {
-			revengConfiguration.buildMappings();
-			fail();
-		} catch (RuntimeException e) {
-			assertEquals(
-					e.getMessage(),
-					"Method 'buildMappings' should not be called on instances of " + RevengConfiguration.class.getName());
-		}
+	public void testBuildMappings() throws Exception {
+		((Properties)propertyField.get(revengConfiguration)).put("hibernate.connection.url", "jdbc:h2:mem:test");
+		((Properties)propertyField.get(revengConfiguration)).put("hibernate.default_schema", "PUBLIC");
+		assertNull(revengConfiguration.metadata);
+		revengConfiguration.buildMappings();
+		assertNotNull(revengConfiguration.metadata);
 	}
 
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ConfigurationWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ConfigurationWrapperFactoryTest.java
@@ -518,14 +518,13 @@ public class ConfigurationWrapperFactoryTest {
 		nativeConfigurationWrapper.buildMappings();
 		assertNotNull(metadataField.get(wrappedNativeConfiguration));
 		// For reveng configuration
-		try {
-			revengConfigurationWrapper.buildMappings();
-			fail();
-		} catch (RuntimeException e) {
-			assertEquals(
-					e.getMessage(),
-					"Method 'buildMappings' should not be called on instances of " + RevengConfigurationWrapperImpl.class.getName());
-		}
+		metadataField = RevengConfiguration.class.getDeclaredField("metadata");
+		metadataField.setAccessible(true);
+		wrappedRevengConfiguration.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
+		wrappedRevengConfiguration.setProperty("hibernate.default_schema", "PUBLIC");
+		assertNull(metadataField.get(wrappedRevengConfiguration));
+		revengConfigurationWrapper.buildMappings();
+		assertNotNull(metadataField.get(wrappedRevengConfiguration));
 		// For jpa configuration
 		metadataField = JpaConfiguration.class.getDeclaredField("metadata");
 		metadataField.setAccessible(true);


### PR DESCRIPTION
  - Change method 'org.hibernate.tool.orm.jbt.util.RevengConfiguration#setPreferBasicCompositeIds(boolean)' because the property needs to be stored as a Boolean and not as a String
  - Change method 'org.hibernate.tool.orm.jbt.util.RevengConfiguration#preferBasicCompositeIds()' accordingly
  - Adapt test cases 'org.hibernate.tool.orm.jbt.util.RevengConfigurationTest#testPreferBasicCompositeIds()' and 'Adapt test cases 'org.hibernate.tool.orm.jbt.util.RevengConfigurationTest#testSetPreferBasicCompositeIds()' to the above changes
  - Change method 'org.hibernate.tool.orm.jbt.util.RevengConfiguration#buildMappings()' to delegate to 'readFromJDBC()' if the metadata are null
  - Adapt test case 'org.hibernate.tool.orm.jbt.util.RevengConfigurationTest#testBuildMappings()' to the above change
