### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactory.java
@@ -5,6 +5,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeWrapper;
+import org.hibernate.type.Type;
 
 public class EntityPersisterWrapperFactory {
 	
@@ -40,6 +42,8 @@ public class EntityPersisterWrapperFactory {
 		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 			if (isEntityPersisterExtensionMethod(method)) {
 				return method.invoke(this, args);
+			} else if ("getPropertyTypes".equals(method.getName())) {
+				return getPropertyTypes();
 			} else {
 				return method.invoke(delegate, args);
 			}
@@ -50,6 +54,17 @@ public class EntityPersisterWrapperFactory {
 			return delegate;
 		}
 
+		private TypeWrapper[] getPropertyTypes() {
+			Type[] types = getWrappedObject().getPropertyTypes();
+			if (types != null) {
+				TypeWrapper[] result = new TypeWrapper[types.length];
+				for (int i = 0; i < types.length; i++) {
+					result[i] = TypeWrapperFactory.createTypeWrapper(types[i]);
+				}
+				return result;
+			}
+			return null;
+		}
 	}
 	
     private static boolean isEntityPersisterExtensionMethod(Method m) {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactoryTest.java
@@ -22,7 +22,10 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.orm.jbt.wrp.EntityPersisterWrapperFactory.EntityPersisterExtension;
+import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeExtension;
 import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.type.CollectionType;
+import org.hibernate.type.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -103,7 +106,22 @@ public class EntityPersisterWrapperFactoryTest {
  		assertEquals("bars", propertyNames[0]);
 	}
 	
+	@Test
+	public void testGetPropertyTypes() {
+		Type[] propertyTypeWrappers = entityPersisterWrapper.getPropertyTypes();
+		assertEquals(1, propertyTypeWrappers.length);
+		Type propertyTypeWrapper = propertyTypeWrappers[0];
+		assertTrue(propertyTypeWrapper instanceof Wrapper);
+		assertTrue(propertyTypeWrapper instanceof TypeExtension);
+		Object wrappedPropertyType = ((Wrapper)propertyTypeWrapper).getWrappedObject();
+		assertTrue(wrappedPropertyType instanceof CollectionType);
+		assertTrue(propertyTypeWrapper.isCollectionType());
+		assertEquals(
+				"org.hibernate.tool.orm.jbt.wrp.EntityPersisterWrapperFactoryTest$Foo.bars",
+				((TypeExtension)propertyTypeWrapper).getRole());
+ 	}
 	
+
 
 	
 	


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.EntityPersisterWrapperFactoryTest#testGetPropertyTypes()'
  - Handle the 'getPropertyType()' case separately in 'rg.hibernate.tool.orm.jbt.wrp.EntityPersisterWrapperFactory.EntityPersisterInvocationHandler#invoke(...)' to wrap the result array
