### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactory.java
@@ -44,6 +44,8 @@ public class EntityPersisterWrapperFactory {
 				return method.invoke(this, args);
 			} else if ("getPropertyTypes".equals(method.getName())) {
 				return getPropertyTypes();
+			} else if ("getIdentifierType".equals(method.getName())) {
+				return TypeWrapperFactory.createTypeWrapper(delegate.getIdentifierType());
 			} else {
 				return method.invoke(delegate, args);
 			}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactoryTest.java
@@ -26,6 +26,7 @@ import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeExtension;
 import org.hibernate.tuple.entity.EntityMetamodel;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.Type;
+import org.hibernate.type.internal.NamedBasicTypeImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -124,6 +125,17 @@ public class EntityPersisterWrapperFactoryTest {
 	@Test
 	public void testGetMappedClass() {
 		assertSame(Foo.class, entityPersisterWrapper.getMappedClass());
+	}
+	
+	@Test
+	public void testGetIdentifierType() {
+		Type typeWrapper = entityPersisterWrapper.getIdentifierType();
+		assertNotNull(typeWrapper);
+		assertTrue(typeWrapper instanceof Wrapper);
+		Object wrappedType = ((Wrapper)typeWrapper).getWrappedObject();
+		assertNotNull(wrappedType);
+		assertTrue(wrappedType instanceof NamedBasicTypeImpl);
+		assertSame("string", ((NamedBasicTypeImpl<?>)wrappedType).getName());
 	}
 	
 


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.wrp.EntityPersisterWrapperFactoryTest#testGetIdentifierType()'
  - Handle the 'getIdentifierType' case separately in 'org.hibernate.tool.orm.jbt.wrp.EntityPersisterWrapperFactory.EntityPersisterInvocationHandler#invoke(...)' to wrap the result Type
