### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapper.java
@@ -31,7 +31,12 @@ public class SessionFactoryWrapper extends SessionFactoryDelegatingImpl {
 	}
 
 	public Map<String, CollectionPersister> getAllCollectionMetadata() {
-		return getMetamodel().collectionPersisters();
+		Map<String, CollectionPersister> origin = getMetamodel().collectionPersisters();
+		Map<String, CollectionPersister> result = new HashMap<String, CollectionPersister>(origin.size());
+		for (String key : origin.keySet()) {
+			result.put(key, (CollectionPersister)CollectionPersisterWrapperFactory.create(origin.get(key)));
+		}
+		return result;
 	}
 
 	public EntityPersister getClassMetadata(String string) {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/EntityPersisterWrapperFactoryTest.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -162,12 +161,6 @@ public class EntityPersisterWrapperFactoryTest {
 		Object identifier = entityPersisterWrapper.getIdentifier(foo, sessionFacade);
 		assertSame("bar", identifier);
 	}
-	
-
-
-	
-	
-	
 	
 	@Test
 	public void testIsInstanceOfAbstractEntityPersister() throws Exception {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/SessionFactoryWrapperTest.java
@@ -103,7 +103,9 @@ public class SessionFactoryWrapperTest {
 	public void testGetAllCollectionMetadata() throws Exception {
 		Map<String, CollectionPersister> allCollectionMetadata = sessionFactoryWrapper.getAllCollectionMetadata();
 		assertEquals(1, allCollectionMetadata.size());
-		assertNotNull(allCollectionMetadata.get(Foo.class.getName() + ".bars"));
+		CollectionPersister barsPersister = allCollectionMetadata.get(Foo.class.getName() + ".bars");
+		assertNotNull(barsPersister);
+		assertTrue(barsPersister instanceof Wrapper);
 	}
 	
 
@@ -122,7 +124,9 @@ public class SessionFactoryWrapperTest {
 	@Test
 	public void testGetCollectionMetadata() throws Exception {
 		assertNull(sessionFactoryWrapper.getCollectionMetadata("bars"));
-		assertNotNull(sessionFactoryWrapper.getCollectionMetadata(Foo.class.getName() + ".bars"));
+		CollectionPersister barsPersister = sessionFactoryWrapper.getCollectionMetadata(Foo.class.getName() + ".bars");
+		assertNotNull(barsPersister);
+		assertTrue(barsPersister instanceof Wrapper);
 	}	
 	
 }


### PR DESCRIPTION
  - Refactor method 'org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapper#getAllCollectionMetadata()' to return a map of wrapped collection persisters
  - Adapt test cases 'org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapperTest#testGetAllCollectionMetadata()' and 'org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapperTest#testGetCollectionMetadata()' to the above change
