### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
 import org.hibernate.mapping.JoinedSubclass;
+import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
@@ -74,6 +75,10 @@ public class PersistentClassWrapperFactory {
 		public Value getDiscriminator() {
 			return wrapValueIfNeeded(super.getDiscriminator());
 		}
+		@Override
+		public KeyValue getIdentifier() {
+			return (KeyValue)wrapValueIfNeeded(super.getIdentifier());
+		}
 	}
 	
 	static class SingleTableSubclassWrapperImpl 
@@ -82,10 +87,6 @@ public class PersistentClassWrapperFactory {
 		public SingleTableSubclassWrapperImpl(PersistentClass superclass) {
 			super(superclass, DummyMetadataBuildingContext.INSTANCE);
 		}
-		@Override
-		public Value getDiscriminator() {
-			return wrapValueIfNeeded(super.getDiscriminator());
-		}
 	}
 	
 	static class JoinedSubclassWrapperImpl
@@ -93,10 +94,6 @@ public class PersistentClassWrapperFactory {
 			implements PersistentClassWrapper {
 		public JoinedSubclassWrapperImpl(PersistentClass superclass) {
 			super(superclass, DummyMetadataBuildingContext.INSTANCE);
-		}
-		@Override
-		public Value getDiscriminator() {
-			return wrapValueIfNeeded(super.getDiscriminator());
 		}
 	}
 	
@@ -109,6 +106,10 @@ public class PersistentClassWrapperFactory {
 		@Override
 		public Value getDiscriminator() {
 			return wrapValueIfNeeded(super.getDiscriminator());
+		}
+		@Override
+		public KeyValue getIdentifier() {
+			return (KeyValue)wrapValueIfNeeded(super.getIdentifier());
 		}
 	}
 	

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -36,7 +36,7 @@ public class ValueWrapperFactory {
 	public static ValueWrapper createValueWrapper(Value wrappedValue) {
 		return (ValueWrapper)Proxy.newProxyInstance(
 				ValueWrapperFactory.class.getClassLoader(), 
-				new Class[] { ValueWrapper.class }, 
+				new Class[] { ValueWrapper.class, KeyValue.class }, 
 				new ValueWrapperInvocationHandler(wrappedValue));
 	}
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -394,13 +394,13 @@ public class PersistentClassWrapperFactoryTest {
 		assertNull(singleTableSubclassWrapper.getIdentifier());
 		assertNull(joinedSubclassWrapper.getIdentifier());
 		assertNull(specialRootClassWrapper.getIdentifier());
-		KeyValue value = createValue();
+		KeyValue value = new BasicValue(DummyMetadataBuildingContext.INSTANCE);
 		((RootClass)rootClassTarget).setIdentifier(value);
-		assertSame(value, rootClassWrapper.getIdentifier());
-		assertSame(value, singleTableSubclassWrapper.getIdentifier());
-		assertSame(value, joinedSubclassWrapper.getIdentifier());
+		assertSame(value, ((Wrapper)rootClassWrapper.getIdentifier()).getWrappedObject());
+		assertSame(value, ((Wrapper)singleTableSubclassWrapper.getIdentifier()).getWrappedObject());
+		assertSame(value, ((Wrapper)joinedSubclassWrapper.getIdentifier()).getWrappedObject());
 		((RootClass)specialRootClassTarget).setIdentifier(value);
-		assertSame(value, specialRootClassWrapper.getIdentifier());
+		assertSame(value, ((Wrapper)specialRootClassWrapper.getIdentifier()).getWrappedObject());
 	}
 	
 	@Test


### PR DESCRIPTION
  - Modify test case 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest#testGetIdentifier()' to make sure the returned value is wrapped
  - Adapt the implementation of 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory' to override the 'getIdentifier()' methods and wrap the returned value
  - Make sure factory method 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory#createValueWrapper(Value)' returns a value that also implements 'org.hibernate.mapping.KeyValue'
