### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -103,7 +103,7 @@ public class WrapperFactory {
 	}
 
 	public static Object createPropertyWrapper() {
-		return new Property();
+		return new PropertyWrapper();
 	}
 
 	public static Object createHqlCompletionProposalWrapper(Object hqlCompletionProposalTarget) {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -216,7 +216,7 @@ public class WrapperFactoryTest {
 	public void testCreatePropertyWrapper() {
 		Object propertyWrapper = WrapperFactory.createPropertyWrapper();
 		assertNotNull(propertyWrapper);
-		assertTrue(propertyWrapper instanceof Property);
+		assertTrue(propertyWrapper instanceof PropertyWrapper);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Modify test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreatePropertyWrapper()' to verify that the propertyWrapper is an instance of 'org.hibernate.tool.orm.jbt.wrp.PropertyWrapper'
  - Change the implementation of 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createPropertyWrapper()' to return an instance of 'org.hibernate.tool.orm.jbt.wrp.PropertyWrapper'
