### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -25,7 +25,6 @@ import org.hibernate.mapping.Set;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.ide.completion.HQLCodeAssist;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
@@ -140,7 +139,7 @@ public class WrapperFactory {
 	}
 
 	public static Object createTableWrapper(String name) {
-		Table result = new Table("Hibernate Tools", name);
+		TableWrapper result = new TableWrapper(name);
 		result.setPrimaryKey(new PrimaryKey(result));
 		return result;
 	}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -274,8 +274,8 @@ public class WrapperFactoryTest {
 	public void testCreateTableWrapper() {
 		Object tableWrapper = WrapperFactory.createTableWrapper("foo");
 		assertNotNull(tableWrapper);
-		assertTrue(tableWrapper instanceof Table);
-		Table table = (Table)tableWrapper;
+		assertTrue(tableWrapper instanceof TableWrapper);
+		Table table = (Table)((TableWrapper)tableWrapper).getWrappedObject();
 		assertEquals("foo", table.getName());
 		PrimaryKey pk = table.getPrimaryKey();
 		assertSame(table, pk.getTable());


### PR DESCRIPTION
  - Modify test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateTableWrapper() to verify that the tableWrapper is an instance of 'org.hibernate.tool.orm.jbt.wrp.TableWrapper'
  - Change the implementation of 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createTableWrapper(String)' to return an instance of 'org.hibernate.tool.orm.jbt.wrp.TableWrapper'
