### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PropertyWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PropertyWrapperFactory.java
@@ -1,9 +1,5 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Value;
@@ -12,48 +8,49 @@ import org.hibernate.type.Type;
 
 public class PropertyWrapperFactory {
 	
-	public static PropertyWrapper createPropertyWrapper(Property wrappedProperty) {
-		return (PropertyWrapper)Proxy.newProxyInstance(
-				ValueWrapperFactory.class.getClassLoader(), 
-				new Class[] { PropertyWrapper.class }, 
-				new PropertyWrapperInvocationHandler(wrappedProperty));
+	public static Property createPropertyWrapper(Property wrappedProperty) {
+		return new DelegatingPropertyWrapperImpl(wrappedProperty);
 	}
 
-	static interface PropertyWrapper extends Wrapper{
+	static interface PropertyWrapper extends Wrapper{		
+		@Override Property getWrappedObject();		
+		Value getValue();
+		Type getType();
+		void setName(String name);
+		void setPersistentClass(PersistentClass pc);
+		PersistentClass getPersistentClass();
+		boolean isComposite();
+		String getPropertyAccessorName();
+		String getName();
+		void setValue(Value value);
+		void setPropertyAccessorName(String name);
+		void setCascade(String c);
+		boolean isBackRef();
+		boolean isSelectable();
+		boolean isUpdateable();
+		String getCascade();
+		boolean isLazy();
+		boolean isOptional();
+		boolean isNaturalIdentifier();
+		boolean isOptimisticLocked();
+		boolean isInsertable();		
+	}
+	
+	static class DelegatingPropertyWrapperImpl extends Property implements PropertyWrapper {
 		
-		@Override Property getWrappedObject();
+		private Property delegate = null;
 		
-		default Value getValue() { 
-			Value v = getWrappedObject().getValue();
-			return v == null ? null : ValueWrapperFactory.createValueWrapper(v); 
+		public DelegatingPropertyWrapperImpl(Property p) {
+			delegate = p;
 		}
-
-		default void setName(String name) {
-			getWrappedObject().setName(name);
+		
+		@Override
+		public Property getWrappedObject() {
+			return delegate;
 		}
-
-		default void setPersistentClass(PersistentClass pc) {
-			getWrappedObject().setPersistentClass(pc);
-		}
-
-		default PersistentClassWrapper getPersistentClass() {
-			PersistentClassWrapper pc = (PersistentClassWrapper)getWrappedObject().getPersistentClass();
-			return pc == null ? null : PersistentClassWrapperFactory.createPersistentClassWrapper(pc);
-		}
-
-		default boolean isComposite() {
-			return getWrappedObject().isComposite();
-		}
-
-		default String getPropertyAccessorName() {
-			return getWrappedObject().getPropertyAccessorName();
-		}
-
-		default String getName() {
-			return getWrappedObject().getName();
-		}
-
-		default Type getType() {
+		
+		@Override
+		public Type getType() {
 			TypeWrapper result = null;
 			if (getWrappedObject().getValue() != null) {
 				Type t = getWrappedObject().getType();
@@ -62,88 +59,102 @@ public class PropertyWrapperFactory {
 			return result;
 		}
 
-		default void setValue(Value value) {
-			getWrappedObject().setValue(value);
+		@Override
+		public Value getValue() { 
+			Value v = getWrappedObject().getValue();
+			return v == null ? null : ValueWrapperFactory.createValueWrapper(v); 
 		}
 
-		default void setPropertyAccessorName(String name) {
-			getWrappedObject().setPropertyAccessorName(name);
-		}
-
-		default void setCascade(String c) {
-			getWrappedObject().setCascade(c);
-		}
-
-		default boolean isBackRef() {
-			return getWrappedObject().isBackRef();
-		}
-
-		default boolean isSelectable() {
-			return getWrappedObject().isSelectable();
-		}
-
-		default boolean isUpdateable() {
-			return getWrappedObject().isUpdateable();
-		}
-
-		default String getCascade() {
-			return getWrappedObject().getCascade();
-		}
-
-		default boolean isLazy() {
-			return getWrappedObject().isLazy();
-		}
-
-		default boolean isOptional() {
-			return getWrappedObject().isOptional();
-		}
-
-		default boolean isNaturalIdentifier() {
-			return getWrappedObject().isNaturalIdentifier();
-		}
-
-		default boolean isOptimisticLocked() {
-			return getWrappedObject().isOptimisticLocked();
-		}
-
-		default boolean isInsertable() {
-			return getWrappedObject().isInsertable();
-		}
-		
-	}
-	
-	static class PropertyWrapperInvocationHandler implements InvocationHandler, PropertyWrapper {
-		
-		private Property delegate = null;
-		
-		public PropertyWrapperInvocationHandler(Property property) {
-			delegate = property;
+		@Override 
+		public void setName(String name) {
+			getWrappedObject().setName(name);
 		}
 
 		@Override
-		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-			Method m = lookupMethodInPropertyWrapperClass(method);
-			if (m != null) {
-				return m.invoke(this, args);
-			} else {
-				return method.invoke(delegate, args);
-			}
+		public void setPersistentClass(PersistentClass pc) {
+			getWrappedObject().setPersistentClass(pc);
 		}
 		
+		@Override
+		public PersistentClass getPersistentClass() {
+			return getWrappedObject().getPersistentClass();
+		}
+
+		@Override
+		public boolean isComposite() {
+			return getWrappedObject().isComposite();
+		}
+
 		@Override 
-		public Property getWrappedObject() {
-			return delegate;
+		public String getPropertyAccessorName() {
+			return getWrappedObject().getPropertyAccessorName();
 		}
-		
-		
+
+		@Override
+		public String getName() {
+			return getWrappedObject().getName();
+		}
+
+		@Override 
+		public void setValue(Value value) {
+			getWrappedObject().setValue(value);
+		}
+
+		@Override
+		public void setPropertyAccessorName(String name) {
+			getWrappedObject().setPropertyAccessorName(name);
+		}
+
+		@Override
+		public void setCascade(String c) {
+			getWrappedObject().setCascade(c);
+		}
+
+		@Override
+		public boolean isBackRef() {
+			return getWrappedObject().isBackRef();
+		}
+
+		@Override
+		public boolean isSelectable() {
+			return getWrappedObject().isSelectable();
+		}
+
+		@Override
+		public boolean isUpdateable() {
+			return getWrappedObject().isUpdateable();
+		}
+
+		@Override
+		public String getCascade() {
+			return getWrappedObject().getCascade();
+		}
+
+		@Override
+		public boolean isLazy() {
+			return getWrappedObject().isLazy();
+		}
+
+		@Override
+		public boolean isOptional() {
+			return getWrappedObject().isOptional();
+		}
+
+		@Override 
+		public boolean isNaturalIdentifier() {
+			return getWrappedObject().isNaturalIdentifier();
+		}
+
+		@Override
+		public boolean isOptimisticLocked() {
+			return getWrappedObject().isOptimisticLocked();
+		}
+
+		@Override
+		public boolean isInsertable() {
+			return getWrappedObject().isInsertable();
+		}
+				
 	}
 	
-	private static Method lookupMethodInPropertyWrapperClass(Method method) {
-		try {
-			return PropertyWrapper.class.getMethod(method.getName(), method.getParameterTypes());
-		} catch (NoSuchMethodException e) {
-			return null;
-		}
-	}
-
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -35,7 +35,6 @@ import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
-import org.hibernate.tool.orm.jbt.wrp.PropertyWrapperFactory.PropertyWrapper;
 
 public class WrapperFactory {
 	
@@ -99,7 +98,7 @@ public class WrapperFactory {
 
 	public static Object createSpecialRootClassWrapper(Object propertyWrapper) {
 		return PersistentClassWrapperFactory
-				.createSpecialRootClassWrapper(((PropertyWrapper)propertyWrapper).getWrappedObject());
+				.createSpecialRootClassWrapper((Property)propertyWrapper);
 	}
 
 	public static Object createPropertyWrapper() {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PropertyWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PropertyWrapperFactoryTest.java
@@ -17,6 +17,7 @@ import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
+import org.hibernate.tool.orm.jbt.wrp.PropertyWrapperFactory.PropertyWrapper;
 import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,12 +25,12 @@ import org.junit.jupiter.api.Test;
 public class PropertyWrapperFactoryTest {
 	
 	private Property wrappedProperty = null;
-	private PropertyWrapperFactory.PropertyWrapper propertyWrapper = null;
+	private PropertyWrapper propertyWrapper = null;
 	
 	@BeforeEach
 	public void beforeEach() {
 		wrappedProperty = new Property();
-		propertyWrapper = PropertyWrapperFactory.createPropertyWrapper(wrappedProperty);
+		propertyWrapper = (PropertyWrapper)PropertyWrapperFactory.createPropertyWrapper(wrappedProperty);
 	}
 
 	@Test
@@ -69,7 +70,7 @@ public class PropertyWrapperFactoryTest {
 		PersistentClassWrapper persistentClass = PersistentClassWrapperFactory.createRootClassWrapper();
 		assertNull(propertyWrapper.getPersistentClass());
 		wrappedProperty.setPersistentClass(persistentClass.getWrappedObject());
-		PersistentClassWrapper persistentClassWrapper = propertyWrapper.getPersistentClass();
+		PersistentClassWrapper persistentClassWrapper = (PersistentClassWrapper)propertyWrapper.getPersistentClass();
 		assertSame(persistentClass.getWrappedObject(), persistentClassWrapper.getWrappedObject());
 	}
 	
@@ -135,7 +136,7 @@ public class PropertyWrapperFactoryTest {
 	@Test
 	public void testIsBackRef() throws Exception {
 		assertFalse(propertyWrapper.isBackRef());
-		propertyWrapper = PropertyWrapperFactory.createPropertyWrapper(new Backref());
+		propertyWrapper = (PropertyWrapper)PropertyWrapperFactory.createPropertyWrapper(new Backref());
 		assertTrue(propertyWrapper.isBackRef());
 	}
 	

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -210,7 +210,7 @@ public class WrapperFactoryTest {
 		assertTrue(persistentClass instanceof SpecialRootClass);
 		assertSame(
 				((SpecialRootClass)persistentClass).getProperty(), 
-				propertyWrapper.getWrappedObject());		
+				propertyWrapper);		
 	}
 	
 	@Test


### PR DESCRIPTION
  - Refactor class 'org.hibernate.tool.orm.jbt.wrp.PropertyWrapperFactory' * Create inner class 'DelegatingPropertyWrapperImpl' that extends 'Property' and implements 'Wrapper' * Method 'PropertyWrapperFactory#createPropertyWrapper(Property)' now uses the above inner class * The inner interface 'PropertyWrapper' has no default implementations anymore (these are now implemented in 'DelegatingPropertyWrapperImpl') * Remove inner class 'PropertyWrapperInvocationHandler' and method 'lookupMethodInPropertyWrapperClass(Method)'
  - Refactor class 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createSpecialRootClassWrapper(Object)'
  - Adapt the setup of test class 'org.hibernate.tool.orm.jbt.wrp.PropertyWrapperFactoryTest'
  - Adapt the test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateSpecialRootClassWrapper()'
