### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/JpaConfiguration.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/JpaConfiguration.java
@@ -14,6 +14,7 @@ import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.RevengStrategy;
+import org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl;
 import org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapper;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
@@ -120,10 +121,6 @@ public class JpaConfiguration extends Configuration {
 		return persistenceUnit;
 	}
 	
-	public Iterator<PersistentClass> getClassMappings() {
-		return getMetadata().getEntityBindings().iterator();
-	}
-	
 	public void setPreferBasicCompositeIds(boolean b) {
 		throw new RuntimeException(
 				"Method 'setPreferBasicCompositeIds' should not be called on instances of " +
@@ -136,8 +133,24 @@ public class JpaConfiguration extends Configuration {
 				this.getClass().getName());
 	}
 	
+	public Iterator<PersistentClass> getClassMappings() {
+		final Iterator<PersistentClass> iterator = getMetadata().getEntityBindings().iterator();
+		return new Iterator<PersistentClass>() {
+			@Override
+			public boolean hasNext() {
+				return iterator.hasNext();
+			}
+			@Override
+			public PersistentClass next() {
+				return new DelegatingPersistentClassWrapperImpl(iterator.next());
+			}
+			
+		};
+	}
+	
 	public PersistentClass getClassMapping(String name) {
-		return getMetadata().getEntityBinding(name);
+		PersistentClass pc = getMetadata().getEntityBinding(name);
+		return pc == null ? null : new DelegatingPersistentClassWrapperImpl(pc);
 	}
 	
 	public Iterator<Table> getTableMappings() {

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/NativeConfiguration.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/NativeConfiguration.java
@@ -20,6 +20,7 @@ import org.hibernate.cfg.NamingStrategy;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.RevengStrategy;
+import org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl;
 import org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapper;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
@@ -90,11 +91,23 @@ public class NativeConfiguration extends Configuration {
 	}
 	
 	public Iterator<PersistentClass> getClassMappings() {
-		return getMetadata().getEntityBindings().iterator();
+		final Iterator<PersistentClass> iterator = getMetadata().getEntityBindings().iterator();
+		return new Iterator<PersistentClass>() {
+			@Override
+			public boolean hasNext() {
+				return iterator.hasNext();
+			}
+			@Override
+			public PersistentClass next() {
+				return new DelegatingPersistentClassWrapperImpl(iterator.next());
+			}
+			
+		};
 	}
 	
 	public PersistentClass getClassMapping(String name) {
-		return getMetadata().getEntityBinding(name);
+		PersistentClass pc = getMetadata().getEntityBinding(name);
+		return pc == null ? null : new DelegatingPersistentClassWrapperImpl(pc);
 	}
 	
 	public Iterator<Table> getTableMappings() {

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/RevengConfiguration.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/RevengConfiguration.java
@@ -13,6 +13,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.RevengStrategy;
+import org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
 
@@ -52,14 +53,28 @@ public class RevengConfiguration extends Configuration {
 	
 	public Iterator<PersistentClass> getClassMappings() {
 		if (metadata != null) {
-			return metadata.getEntityBindings().iterator();
+			final Iterator<PersistentClass> iterator = metadata.getEntityBindings().iterator();
+			return new Iterator<PersistentClass>() {
+				@Override
+				public boolean hasNext() {
+					return iterator.hasNext();
+				}
+				@Override
+				public PersistentClass next() {
+					return new DelegatingPersistentClassWrapperImpl(iterator.next());
+				}
+			};
 		} else {
 			return Collections.emptyIterator();
 		}
 	}
 	
 	public PersistentClass getClassMapping(String name) {
-		return (metadata != null) ? metadata.getEntityBinding(name) : null;
+		PersistentClass pc = null;
+		if (metadata != null) {
+			pc = metadata.getEntityBinding(name);
+		}
+		return (pc != null) ? new DelegatingPersistentClassWrapperImpl(pc) : null;
 	}
 	
 	public Iterator<Table> getTableMappings() {

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
@@ -60,7 +60,7 @@ public class DelegatingPersistentClassWrapperImpl extends RootClass implements P
 	public PersistentClass getSuperclass() {
 		return delegate.getSuperclass();
 	}
-
+	
 	@Override 
 	public Iterator<Property> getPropertyIterator() {
 		final Iterator<Property> iterator = delegate.getPropertyIterator();

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/JpaConfigurationTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/JpaConfigurationTest.java
@@ -29,6 +29,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
+import org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper;
 import org.hibernate.tool.orm.jbt.wrp.SessionFactoryWrapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -174,8 +175,8 @@ public class JpaConfigurationTest {
 		Iterator<PersistentClass> classMappings = jpaConfiguration.getClassMappings();
 		assertNotNull(classMappings);
 		assertTrue(classMappings.hasNext());
-		PersistentClass pc = classMappings.next();
-		assertSame(pc.getMappedClass(), FooBar.class);
+		PersistentClassWrapper pc = (PersistentClassWrapper)classMappings.next();
+		assertSame(pc.getWrappedObject().getMappedClass(), FooBar.class);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Modify method 'org.hibernate.tool.orm.jbt.util.NativeConfiguration#getClassMappings()' to return an iterator of 'org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl'
  - Modify method 'org.hibernate.tool.orm.jbt.util.NativeConfiguration#getClassMapping(String) to wrap the result as 'org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl'
  - Modify method 'org.hibernate.tool.orm.jbt.util.JpaConfiguration#getClassMappings()' to return an iterator of 'org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl'
  - Modify method 'org.hibernate.tool.orm.jbt.util.JpaConfiguration#getClassMapping(String) to wrap the result as 'org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl'
  - Modify method 'org.hibernate.tool.orm.jbt.util.RevengConfiguration#getClassMappings()' to return an iterator of 'org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl'
  - Modify method 'org.hibernate.tool.orm.jbt.util.RevengConfiguration#getClassMapping(String) to wrap the result as 'org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl'
  - Modify test case 'org.hibernate.tool.orm.jbt.util.JpaConfigurationTest#testGetClassMappings()'
