### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
@@ -48,7 +48,12 @@ public class DelegatingPersistentClassWrapperImpl extends RootClass implements P
 
 	@Override 
 	public RootClass getRootClass() {
-		return delegate.getRootClass();
+		RootClass result = delegate.getRootClass();
+		if (result == delegate) {
+			return this;
+		} else {
+			return result == null ? null : new DelegatingPersistentClassWrapperImpl(result);
+		}
 	}
 
 	@Override 
@@ -84,7 +89,8 @@ public class DelegatingPersistentClassWrapperImpl extends RootClass implements P
 
 	@Override 
 	public Table getTable() {
-		return delegate.getTable();
+		Table result = delegate.getTable();
+		return result == null ? null : new DelegatingTableWrapperImpl(result);
 	}
 
 	@Override 

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingTableWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingTableWrapperImpl.java
@@ -1,0 +1,110 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import java.util.Iterator;
+
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.KeyValue;
+import org.hibernate.mapping.PrimaryKey;
+import org.hibernate.mapping.Table;
+
+public class DelegatingTableWrapperImpl extends Table implements TableWrapper{
+	
+	private Table delegate = null;
+	
+	public DelegatingTableWrapperImpl(Table t) {
+		delegate = t;
+	}
+	
+	@Override
+	public Table getWrappedObject() {
+		return delegate;
+	}
+
+	@Override
+	public KeyValue getIdentifierValue() {
+		KeyValue result = delegate.getIdentifierValue();
+		return result == null ? null : (KeyValue)ValueWrapperFactory.createValueWrapper(result);
+	}
+	
+	@Override 
+	public String getName() {
+		return delegate.getName();
+	}
+	
+	@Override
+	public void addColumn(Column column) {
+		delegate.addColumn(column);
+	}
+	
+	@Override 
+	public String getCatalog() {
+		return delegate.getCatalog();
+	}
+	
+	@Override 
+	public String getSchema() {
+		return delegate.getSchema();
+	}
+	
+	@Override
+	public PrimaryKey getPrimaryKey() {
+		return delegate.getPrimaryKey();
+	}
+	
+	@Override
+	public Iterator<Column> getColumnIterator() {
+		return delegate.getColumnIterator();
+	}
+	
+	@Override
+	public Iterator<ForeignKey> getForeignKeyIterator() {
+		Iterator<ForeignKey> iterator = delegate.getForeignKeyIterator();
+		return new Iterator<ForeignKey>() {
+			@Override
+			public boolean hasNext() {
+				return iterator.hasNext();
+			}
+			@Override
+			public ForeignKey next() {
+				return (ForeignKey)ForeignKeyWrapperFactory.createForeinKeyWrapper(iterator.next());
+			}		
+		};
+	}
+	
+	@Override
+	public String getComment() {
+		return delegate.getComment();
+	}
+	
+	@Override
+	public String getRowId() {
+		return delegate.getRowId();
+	}
+	
+	@Override
+	public String getSubselect() {
+		return delegate.getSubselect();
+	}
+	
+	@Override
+	public boolean hasDenormalizedTables() {
+		return delegate.hasDenormalizedTables();
+	}
+	
+	@Override 
+	public boolean isAbstract() {
+		return delegate.isAbstract();
+	}
+	
+	@Override
+	public boolean isAbstractUnionTable() {
+		return delegate.isAbstractUnionTable();
+	}
+	
+	@Override
+	public boolean isPhysicalTable() {
+		return delegate.isPhysicalTable();
+	}
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TableWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TableWrapper.java
@@ -1,18 +1,28 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
-import org.hibernate.mapping.KeyValue;
-import org.hibernate.mapping.Table;
+import java.util.Iterator;
 
-public class TableWrapper extends Table implements Wrapper {
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.PrimaryKey;
+import org.hibernate.mapping.Value;
+
+public interface TableWrapper extends Wrapper {
 	
-	public TableWrapper(String name) {
-		super("HibernateTools", name);
-	}
-	
-	@Override
-	public KeyValue getIdentifierValue() {
-		KeyValue result = super.getIdentifierValue();
-		return result == null ? null : (KeyValue)ValueWrapperFactory.createValueWrapper(result);
-	}
+	String getName();
+	void addColumn(Column column);
+	String getCatalog();
+	String getSchema();
+	PrimaryKey getPrimaryKey();
+	Iterator<Column> getColumnIterator();
+	Iterator<ForeignKey> getForeignKeyIterator();
+	String getComment();
+	String getRowId();
+	String getSubselect();
+	boolean hasDenormalizedTables();
+	boolean isAbstract();
+	boolean isAbstractUnionTable();
+	boolean isPhysicalTable();
+	Value getIdentifierValue();
 
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -124,6 +124,8 @@ public class ValueWrapperFactory {
 						result = ValueWrapperFactory.createValueWrapper((Value)result);
 					} else if ("getPropertyIterator".equals(valueClassMethod.getName())) {
 						result = createWrappedPropertyIterator((Iterator<?>)result);
+					} else if (result != null && "getAssociatedClass".equals(valueClassMethod.getName())) {
+						result = new DelegatingPersistentClassWrapperImpl((PersistentClass)result);
 					}
 				} else {
 					result = method.invoke(this, args);

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -139,8 +139,9 @@ public class WrapperFactory {
 	}
 
 	public static Object createTableWrapper(String name) {
-		TableWrapper result = new TableWrapper(name);
-		result.setPrimaryKey(new PrimaryKey(result));
+		Table t = new Table("Hibernate Tools", name);
+		t.setPrimaryKey(new PrimaryKey(t));
+		DelegatingTableWrapperImpl result = new DelegatingTableWrapperImpl(t);
 		return result;
 	}
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/DelegatingTableWrapperImplTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/DelegatingTableWrapperImplTest.java
@@ -6,17 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.KeyValue;
+import org.hibernate.mapping.Table;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TableWrapperTest {
+public class DelegatingTableWrapperImplTest {
 	
-	private TableWrapper tableWrapper = null;
+	private DelegatingTableWrapperImpl tableWrapper = null;
 	
 	@BeforeEach
 	public void beforeEach() {
-		tableWrapper = new TableWrapper("foo");
+		tableWrapper = new DelegatingTableWrapperImpl(new Table("Hibernate Tools", "foo"));
 		KeyValue v = new BasicValue(DummyMetadataBuildingContext.INSTANCE);
 		tableWrapper.setIdentifierValue(v);
 	}
@@ -30,7 +31,7 @@ public class TableWrapperTest {
 	@Test
 	public void testGetIdentifierValue() {
 		KeyValue v = new BasicValue(DummyMetadataBuildingContext.INSTANCE);
-		tableWrapper.setIdentifierValue(v);
+		tableWrapper.getWrappedObject().setIdentifierValue(v);
 		assertSame(v,  ((Wrapper)tableWrapper.getIdentifierValue()).getWrappedObject());
 	}
 

--- a/orm/src/main/java/org/hibernate/tool/ide/completion/HQLCompletionProposal.java
+++ b/orm/src/main/java/org/hibernate/tool/ide/completion/HQLCompletionProposal.java
@@ -189,5 +189,12 @@ public class HQLCompletionProposal {
 	}
 	
 
+	public int aliasRefKind() { return ALIAS_REF; }
+	public int entityNameKind() { return ENTITY_NAME; }
+	public int propertyKind() { return PROPERTY; }
+	public int keywordKind() { return KEYWORD; }
+	public int functionKind() { return FUNCTION; }
+	
+	
 	
 }


### PR DESCRIPTION
  - Change class 'org.hibernate.tool.orm.jbt.wrp.TableWrapper' into an interface
  - Create new class 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl' that extends Table and implements TableWrapper
  - Modify methods in class 'org.hibernate.tool.orm.jbt.wrp.DelegatingPersistentClassWrapperImpl' to wrap the result
    * DelegatingPersistentClassWrapperImpl#getRootClass()
    * DelegatingPersistentClassWrapperImpl#getTable()
  - Handle the 'getAssociatedClass()' case in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapperInvocationHandler' to wrap the resulting PersistentClass instance
  - Modify method 'org.hibernate.tool.orm.jbt.wrp.createTableWrapper(String)' to create an instance of DelegatingTableWrapperImpl
  - Rename class 'org.hibernate.tool.orm.jbt.wrp.TableWrapperTest' into 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl' and adapt to the new implementation
  - Add some methods to class 'org.hibernate.tool.ide.completion.HQLCompletionProposal
    * aliasRefKind()
    * entityNameKind() * propertyKind() * keywordKind() * functionKind()
