### PR TITLE
HBX-2390: Create a JBoss Tools adaptation layer in Hibernate Tools

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ColumnWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ColumnWrapper.java
@@ -1,81 +1,26 @@
 package org.hibernate.tool.orm.jbt.wrp;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.hibernate.boot.Metadata;
-import org.hibernate.boot.internal.MetadataImpl;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Value;
-import org.hibernate.tool.orm.jbt.util.MetadataHelper;
-import org.hibernate.type.spi.TypeConfiguration;
 
-public class ColumnWrapper extends Column {
-	
-	private static final int DEFAULT_LENGTH = 255;
-	private static final int DEFAULT_PRECISION = 19;
-	private static final int DEFAULT_SCALE = 2;
-	
-	public ColumnWrapper(String name) {
-		super(name);
-	}
-	
-	public String getSqlType(Configuration configuration) {
-		Metadata metadata = MetadataHelper.getMetadata(configuration);
-		TypeConfiguration tc = ((MetadataImpl)metadata).getTypeConfiguration();
-		return super.getSqlType(tc, buildDialect(configuration), metadata);
-	}
-	
-	public Long getLength() {
-		Long length = super.getLength();
-		return length == null ? Integer.MIN_VALUE : length.longValue();
-	}
-	
-	public int getDefaultLength() {
-		return DEFAULT_LENGTH;
-	}
-	
-	public Integer getPrecision() {
-		Integer precision = super.getPrecision();
-		return precision == null ? Integer.MIN_VALUE : precision.intValue();
-	}
 
-	public int getDefaultPrecision() {
-		return DEFAULT_PRECISION;
-	}
+public interface ColumnWrapper extends Wrapper {
 
-	public Integer getScale() {
-		Integer scale = super.getScale();
-		return scale == null ? Integer.MIN_VALUE : scale.intValue();
-	}
-
-	public int getDefaultScale() {
-		return DEFAULT_SCALE;
-	}
-	
-	@Override
-	public Value getValue() {
-		Value val = super.getValue();
-		if (val != null) {
-			val = ValueWrapperFactory.createValueWrapper(val);
-		}
-		return val;
-	}
-
-	private Dialect buildDialect(Configuration configuration) {
-		Map<String, Object> dialectPropertyMap = new HashMap<String, Object>();
-		dialectPropertyMap.put(
-				AvailableSettings.DIALECT, 
-				configuration.getProperty(AvailableSettings.DIALECT));
-		DialectFactory df = configuration
-				.getStandardServiceRegistryBuilder()
-				.build()
-				.getService(DialectFactory.class);
-		return df.buildDialect(dialectPropertyMap, null);
-	}
+	@Override Column getWrappedObject();
+	String getName();
+	Integer getSqlTypeCode();
+	String getSqlType();
+	Long getLength();
+	int getDefaultLength();
+	Integer getPrecision();
+	int getDefaultPrecision();
+	Integer getScale();
+	int getDefaultScale();
+	boolean isNullable();
+	Value getValue();
+	boolean isUnique();
+	String getSqlType(Configuration configuration);
+	void setSqlType(String sqlType);
 
 }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingColumnWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingColumnWrapperImpl.java
@@ -1,0 +1,136 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.internal.MetadataImpl;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Value;
+import org.hibernate.tool.orm.jbt.util.MetadataHelper;
+import org.hibernate.type.spi.TypeConfiguration;
+
+public class DelegatingColumnWrapperImpl extends Column implements ColumnWrapper {
+	
+	private static final int DEFAULT_LENGTH = 255;
+	private static final int DEFAULT_PRECISION = 19;
+	private static final int DEFAULT_SCALE = 2;
+	
+	private Column delegate = null;
+	
+	public DelegatingColumnWrapperImpl(Column c) {
+		delegate = c;
+	}
+	
+	@Override
+	public Column getWrappedObject() {
+		return delegate;
+	}
+	
+	@Override
+	public String getSqlType(Configuration configuration) {
+		Metadata metadata = MetadataHelper.getMetadata(configuration);
+		TypeConfiguration tc = ((MetadataImpl)metadata).getTypeConfiguration();
+		return delegate.getSqlType(tc, buildDialect(configuration), metadata);
+	}
+	
+	@Override
+	public Long getLength() {
+		Long length = delegate.getLength();
+		return length == null ? Integer.MIN_VALUE : length.longValue();
+	}
+	
+	@Override
+	public int getDefaultLength() {
+		return DEFAULT_LENGTH;
+	}
+	
+	@Override
+	public Integer getPrecision() {
+		Integer precision = delegate.getPrecision();
+		return precision == null ? Integer.MIN_VALUE : precision.intValue();
+	}
+
+	@Override
+	public int getDefaultPrecision() {
+		return DEFAULT_PRECISION;
+	}
+
+	@Override
+	public Integer getScale() {
+		Integer scale = delegate.getScale();
+		return scale == null ? Integer.MIN_VALUE : scale.intValue();
+	}
+
+	@Override
+	public int getDefaultScale() {
+		return DEFAULT_SCALE;
+	}
+	
+	@Override
+	public Value getValue() {
+		Value val = delegate.getValue();
+		if (val != null) {
+			val = ValueWrapperFactory.createValueWrapper(val);
+		}
+		return val;
+	}
+
+	@Override
+	public String getName() {
+		return delegate.getName();
+	}
+	
+	@Override
+	public Integer getSqlTypeCode() {
+		return delegate.getSqlTypeCode();
+	}
+	
+	@Override
+	public String getSqlType() {
+		return delegate.getSqlType();
+	}
+	
+	@Override
+	public boolean isNullable() {
+		return delegate.isNullable();
+	}
+	
+	@Override
+	public boolean isUnique() {
+		return delegate.isUnique();
+	}
+	
+	@Override
+	public void setSqlType(String sqlType) {
+		delegate.setSqlType(sqlType);
+	}
+	
+	@Override 
+	public boolean equals(Object o) {
+		if (!(o instanceof DelegatingColumnWrapperImpl)) {
+			return false;
+		} else {
+			return ((DelegatingColumnWrapperImpl)o).getWrappedObject().equals(delegate);
+		}
+	}
+	
+	
+	private Dialect buildDialect(Configuration configuration) {
+		Map<String, Object> dialectPropertyMap = new HashMap<String, Object>();
+		dialectPropertyMap.put(
+				AvailableSettings.DIALECT, 
+				configuration.getProperty(AvailableSettings.DIALECT));
+		DialectFactory df = configuration
+				.getStandardServiceRegistryBuilder()
+				.build()
+				.getService(DialectFactory.class);
+		return df.buildDialect(dialectPropertyMap, null);
+	}
+
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingForeignKeyWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingForeignKeyWrapperImpl.java
@@ -1,0 +1,48 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.Table;
+
+public class DelegatingForeignKeyWrapperImpl extends ForeignKey implements ForeignKeyWrapper {
+	
+	private ForeignKey delegate = null;
+	
+	public DelegatingForeignKeyWrapperImpl(ForeignKey fk) {
+		delegate = fk;
+	}
+
+	@Override
+	public ForeignKey getWrappedObject() {
+		return delegate;
+	}
+
+	@Override
+	public Iterator<Column> columnIterator() {
+		return delegate.getColumns().iterator();
+	}
+
+	@Override
+	public Table getReferencedTable() {
+		Table result = delegate.getReferencedTable();
+		return result == null ? null : new DelegatingTableWrapperImpl(result);
+	}
+	
+	@Override
+	public boolean isReferenceToPrimaryKey() {
+		return delegate.isReferenceToPrimaryKey();
+	}
+	
+	@Override
+	public List<Column> getReferencedColumns() {
+		return delegate.getReferencedColumns();
+	}
+	
+	@Override
+	public boolean containsColumn(Column column) {
+		return delegate.containsColumn(column);
+	}
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPrimaryKeyWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPrimaryKeyWrapperImpl.java
@@ -1,0 +1,27 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import java.util.Iterator;
+
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.PrimaryKey;
+
+public class DelegatingPrimaryKeyWrapperImpl extends PrimaryKey implements PrimaryKeyWrapper {
+	
+	private PrimaryKey delegate = null;
+	
+	public DelegatingPrimaryKeyWrapperImpl(PrimaryKey pk) {
+		super(pk.getTable());
+		delegate = pk;
+	}
+
+	@Override
+	public PrimaryKey getWrappedObject() {
+		return delegate;
+	}
+
+	@Override
+	public Iterator<Column> columnIterator() {
+		return delegate.getColumns().iterator();
+	}
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingTableWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingTableWrapperImpl.java
@@ -49,12 +49,23 @@ public class DelegatingTableWrapperImpl extends Table implements TableWrapper{
 	
 	@Override
 	public PrimaryKey getPrimaryKey() {
-		return delegate.getPrimaryKey();
+		PrimaryKey result = delegate.getPrimaryKey();
+		return result == null ? null : new DelegatingPrimaryKeyWrapperImpl(result);
 	}
 	
 	@Override
 	public Iterator<Column> getColumnIterator() {
-		return delegate.getColumnIterator();
+		final Iterator<Column> iterator = delegate.getColumnIterator();
+		return new Iterator<Column>() {
+			@Override
+			public boolean hasNext() {
+				return iterator.hasNext();
+			}
+			@Override
+			public Column next() {
+				return new DelegatingColumnWrapperImpl(iterator.next());
+			}			
+		};
 	}
 	
 	@Override
@@ -67,7 +78,7 @@ public class DelegatingTableWrapperImpl extends Table implements TableWrapper{
 			}
 			@Override
 			public ForeignKey next() {
-				return (ForeignKey)ForeignKeyWrapperFactory.createForeinKeyWrapper(iterator.next());
+				return new DelegatingForeignKeyWrapperImpl(iterator.next());
 			}		
 		};
 	}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ForeignKeyWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ForeignKeyWrapper.java
@@ -1,0 +1,19 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.Table;
+
+public interface ForeignKeyWrapper extends Wrapper {
+	
+	@Override ForeignKey getWrappedObject();	
+	Table getReferencedTable();
+	Iterator<Column> columnIterator();
+	boolean isReferenceToPrimaryKey();
+	List<Column> getReferencedColumns();
+	boolean containsColumn(Column column);
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PrimaryKeyWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PrimaryKeyWrapper.java
@@ -1,0 +1,22 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.PrimaryKey;
+import org.hibernate.mapping.Table;
+
+public interface PrimaryKeyWrapper extends Wrapper {
+
+	@Override PrimaryKey getWrappedObject();
+	void addColumn(Column column);
+	int getColumnSpan();
+	List<Column> getColumns();
+	Column getColumn(int i);
+	Table getTable();
+	boolean containsColumn(Column column);
+	Iterator<Column> columnIterator();
+	String getName();
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
@@ -62,10 +62,7 @@ public class TypeWrapperFactory {
 			return returnedClass == null ? null : returnedClass.getName();
 		}
 		default String getAssociatedEntityName() {
-			throw new UnsupportedOperationException(
-					"Class '" + 
-					getWrappedObject().getClass().getName() + 
-					"' does not support 'getAssociatedEntityName()'." ); 
+			return null; 
 		}
 		default boolean isIntegerType() {
 			return IntegerType.class.isAssignableFrom(getWrappedObject().getClass());

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -30,6 +30,7 @@ import org.hibernate.mapping.Set;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
+import org.hibernate.type.Type;
 
 public class ValueWrapperFactory {
 	
@@ -126,6 +127,8 @@ public class ValueWrapperFactory {
 						result = createWrappedPropertyIterator((Iterator<?>)result);
 					} else if (result != null && "getAssociatedClass".equals(valueClassMethod.getName())) {
 						result = new DelegatingPersistentClassWrapperImpl((PersistentClass)result);
+					} else if (result != null && "getType".equals(method.getName())) {
+						result = TypeWrapperFactory.createTypeWrapper((Type)result);
 					}
 				} else {
 					result = method.invoke(this, args);

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -9,6 +9,7 @@ import org.hibernate.mapping.Any;
 import org.hibernate.mapping.Array;
 import org.hibernate.mapping.Bag;
 import org.hibernate.mapping.BasicValue;
+import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.DependantValue;
 import org.hibernate.mapping.IdentifierBag;
@@ -79,7 +80,7 @@ public class WrapperFactory {
 	}
 
 	public static Object createColumnWrapper(String name) {
-		return new ColumnWrapper(name);
+		return new DelegatingColumnWrapperImpl(new Column(name));
 	}
 
 	public static Object createRootClassWrapper() {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/DelegatingColumnWrapperImplTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/DelegatingColumnWrapperImplTest.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Proxy;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.orm.jbt.type.IntegerType;
 import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
@@ -21,13 +22,13 @@ import org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ColumnWrapperTest {
+public class DelegatingColumnWrapperImplTest {
 	
-	private ColumnWrapper columnWrapper = null;
+	private DelegatingColumnWrapperImpl columnWrapper = null;
 	
 	@BeforeEach
 	public void beforeEach() {
-		columnWrapper = new ColumnWrapper(null);
+		columnWrapper = new DelegatingColumnWrapperImpl(new Column());
 	}
 	
 	@Test
@@ -35,24 +36,24 @@ public class ColumnWrapperTest {
 		assertNull(columnWrapper.getSqlType());
 		columnWrapper.setSqlType("foobar");
 		assertEquals("foobar", columnWrapper.getSqlType());
-		columnWrapper = new ColumnWrapper(null);
+		columnWrapper = new DelegatingColumnWrapperImpl(new Column());
 		Configuration cfg = new Configuration();
 		cfg.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
 		cfg.setProperty(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
-		columnWrapper.setValue(createValue());
+		columnWrapper.getWrappedObject().setValue(createValue());
 		assertEquals("integer", columnWrapper.getSqlType(cfg));
 	}
 	
 	@Test
 	public void testGetLength() {
 		assertEquals(Integer.MIN_VALUE, columnWrapper.getLength());
-		columnWrapper.setLength(Integer.MAX_VALUE);
+		columnWrapper.getWrappedObject().setLength(Integer.MAX_VALUE);
 		assertEquals(Integer.MAX_VALUE, columnWrapper.getLength());
 	}
 	
 	@Test
 	public void testGetDefaultLength() throws Exception {
-		Field defaultLengthField = ColumnWrapper.class.getDeclaredField("DEFAULT_LENGTH");
+		Field defaultLengthField = DelegatingColumnWrapperImpl.class.getDeclaredField("DEFAULT_LENGTH");
 		defaultLengthField.setAccessible(true);
 		assertEquals(defaultLengthField.get(null), columnWrapper.getDefaultLength());
 	}
@@ -60,13 +61,13 @@ public class ColumnWrapperTest {
 	@Test
 	public void testGetPrecision() {
 		assertEquals(Integer.MIN_VALUE, columnWrapper.getPrecision());
-		columnWrapper.setPrecision(Integer.MAX_VALUE);
+		columnWrapper.getWrappedObject().setPrecision(Integer.MAX_VALUE);
 		assertEquals(Integer.MAX_VALUE, columnWrapper.getPrecision());
 	}
 	
 	@Test
 	public void testGetDefaultPrecision() throws Exception {
-		Field defaultPrecisionField = ColumnWrapper.class.getDeclaredField("DEFAULT_PRECISION");
+		Field defaultPrecisionField = DelegatingColumnWrapperImpl.class.getDeclaredField("DEFAULT_PRECISION");
 		defaultPrecisionField.setAccessible(true);
 		assertEquals(defaultPrecisionField.get(null), columnWrapper.getDefaultPrecision());
 	}
@@ -74,13 +75,13 @@ public class ColumnWrapperTest {
 	@Test
 	public void testGetScale() {
 		assertEquals(Integer.MIN_VALUE, columnWrapper.getScale());
-		columnWrapper.setScale(Integer.MAX_VALUE);
+		columnWrapper.getWrappedObject().setScale(Integer.MAX_VALUE);
 		assertEquals(Integer.MAX_VALUE, columnWrapper.getScale());
 	}
 	
 	@Test
 	public void testGetDefaultScale() throws Exception {
-		Field defaultScaleField = ColumnWrapper.class.getDeclaredField("DEFAULT_SCALE");
+		Field defaultScaleField = DelegatingColumnWrapperImpl.class.getDeclaredField("DEFAULT_SCALE");
 		defaultScaleField.setAccessible(true);
 		assertEquals(defaultScaleField.get(null), columnWrapper.getDefaultScale());
 	}
@@ -89,7 +90,7 @@ public class ColumnWrapperTest {
 	public void testGetValue() {
 		Value v = createValue();
 		assertNull(columnWrapper.getValue());
-		columnWrapper.setValue(v);
+		columnWrapper.getWrappedObject().setValue(v);
 		Value valueWrapper = columnWrapper.getValue();
 		assertNotNull(valueWrapper);
 		assertTrue(valueWrapper instanceof ValueWrapper);

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperTest.java
@@ -2,6 +2,7 @@ package org.hibernate.tool.orm.jbt.wrp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -169,13 +170,8 @@ public class TypeWrapperTest {
 	@Test
 	public void testGetAssociatedEntityName() {
 		// first try a class type
-		try {
-			TypeWrapper classTypeWrapper = TypeWrapperFactory.createTypeWrapper(new ClassType());
-			classTypeWrapper.getAssociatedEntityName();
-			fail();
-		} catch (UnsupportedOperationException e) {
-			assertTrue(e.getMessage().contains("does not support 'getAssociatedEntityName()'"));
-		}
+		TypeWrapper classTypeWrapper = TypeWrapperFactory.createTypeWrapper(new ClassType());
+		assertNull(classTypeWrapper.getAssociatedEntityName());
 		// next try a many to one type 
 		TypeWrapper manyToOneTypeWrapper = TypeWrapperFactory.createTypeWrapper(
 				new ManyToOneType((TypeConfiguration)null, "foo"));

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -161,7 +161,7 @@ public class WrapperFactoryTest {
 	public void testCreateColumnWrapper() {
 		Object columnWrapper = WrapperFactory.createColumnWrapper(null);
 		assertNotNull(columnWrapper);
-		assertTrue(columnWrapper instanceof ColumnWrapper);
+		assertTrue(columnWrapper instanceof DelegatingColumnWrapperImpl);
 	}
 	
 	@Test


### PR DESCRIPTION
- Create interface 'org.hibernate.tool.orm.jbt.wrp.ColumnWrapper'
  - Change class 'org.hibernate.tool.orm.jbt.wrp.ColumnWrapper' into 'org.hibernate.tool.orm.jbt.wrp.DelegatingColumnWrapperImpl' that extends Column and implemnts ColumnWrapper
  - Modify method 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl# getPrimaryKey()' to wrap the resulting PrimaryKey value
  - Modify method 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl#getColumnIterator()' to wrap the resulting columns
  - Modify 'next()' method in return value of 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl#getForeignKeyIterator()' and wrap the resulting ForeignKey instance
  - Modify interface method 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeWrapper#getAssociatedEntityName()'
  - Handle 'getType' case in 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapperInvocationHandler#invoke(...)'
  - Modify method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createColumnWrapper(String)'
  - Modify test cases in class 'org.hibernate.tool.orm.jbt.wrp.ColumnWrapperTest'
  - Modify test case 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperTest#testGetAssociatedEntityName()'
  - Modify test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateColumnWrapper()'

