### PR TITLE
HBX-2548: Make changes to the JBT bridge so that the Wrapper interface does not leak into the JBT code

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/Cfg2HbmToolWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/Cfg2HbmToolWrapperFactory.java
@@ -1,0 +1,74 @@
+package org.hibernate.tool.orm.jbt.wrp;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.SimpleValue;
+import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
+import org.hibernate.tool.internal.export.hbm.HBMTagForValueVisitor;
+
+public class Cfg2HbmToolWrapperFactory {
+	
+	public static Cfg2HbmToolWrapper createCfg2HbmToolWrapper() {
+		return (Cfg2HbmToolWrapper)Proxy.newProxyInstance(
+				Cfg2HbmToolWrapperFactory.class.getClassLoader(), 
+				new Class[] { Cfg2HbmToolWrapper.class }, 
+				new Cfg2HbmToolInvocationHandler(new Cfg2HbmTool()));
+	}
+	
+	static interface Cfg2HbmToolWrapper extends Wrapper {
+		@Override Cfg2HbmTool getWrappedObject();
+		default String getTag(PersistentClass pc) {
+			return getWrappedObject().getTag(pc);
+		}
+		default String getTag(Property p) {
+			if (p instanceof Wrapper) {
+				p = (Property)((Wrapper)p).getWrappedObject();
+			}
+			PersistentClass persistentClass = p.getPersistentClass();
+			if(persistentClass!=null) {
+				Property v = persistentClass.getVersion();
+				if (v instanceof Wrapper) {
+					v = (Property)((Wrapper)v).getWrappedObject();
+				}
+				if(v==p) {
+					String typeName = ((SimpleValue)p.getValue()).getTypeName();
+					if("timestamp".equals(typeName) || "dbtimestamp".equals(typeName)) {
+						return "timestamp";
+					} else {
+						return "version";
+					}
+				}
+			}
+			String toolTag = (String) p.getValue().accept(HBMTagForValueVisitor.INSTANCE);
+			if ("component".equals(toolTag) && "embedded".equals(p.getPropertyAccessorName())){
+				toolTag = "properties";
+			}
+			return toolTag;
+		}
+	}
+	
+	private static class Cfg2HbmToolInvocationHandler implements InvocationHandler, Cfg2HbmToolWrapper {
+		
+		private Cfg2HbmTool delegate = null;
+		
+		public Cfg2HbmToolInvocationHandler(Cfg2HbmTool cfg2HbmTool) {
+			delegate = cfg2HbmTool;
+		}
+
+		@Override
+		public Cfg2HbmTool getWrappedObject() {
+			return delegate;
+		}
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			return method.invoke(this, args);
+		}
+		
+	}
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -28,7 +28,6 @@ import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
-import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
@@ -47,7 +46,7 @@ public class WrapperFactory {
 	}
 	
 	public static Object createCfg2HbmWrapper() {
-		return new Cfg2HbmTool();
+		return Cfg2HbmToolWrapperFactory.createCfg2HbmToolWrapper();
 	}
 
 	public static Object createNamingStrategyWrapper(String namingStrategyClassName) {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -76,7 +76,9 @@ public class WrapperFactoryTest {
 	public void testCreateCfg2HbmWrapper() {
 		Object cfg2HbmWrapper = WrapperFactory.createCfg2HbmWrapper();
 		assertNotNull(cfg2HbmWrapper);
-		assertTrue(cfg2HbmWrapper instanceof Cfg2HbmTool);
+		assertTrue(cfg2HbmWrapper instanceof Wrapper);
+		Object cfg2HbmTool = ((Wrapper)cfg2HbmWrapper).getWrappedObject();
+		assertTrue(cfg2HbmTool instanceof Cfg2HbmTool);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Create new class 'org.hibernate.tool.orm.jbt.wrp.Cfg2HbmToolWrapperFactory' that can create a wrapper for the Cfg2HbmTool class'
  - Adapt factory method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createCfg2HbmWrapper()' to return an instance of the above class
  - Adapt test case 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateCfg2HbmWrapper()' accordingly
