### PR TITLE
HBX-2548: Make changes to the JBT bridge so that the Wrapper interface does not leak into the JBT code

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -4,7 +4,6 @@ import java.util.Iterator;
 
 import org.hibernate.mapping.Join;
 import org.hibernate.mapping.JoinedSubclass;
-import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
@@ -24,8 +23,8 @@ public interface PersistentClassWrapper extends Wrapper {
 	default boolean isInstanceOfJoinedSubclass() { return JoinedSubclass.class.isAssignableFrom(getWrappedObject().getClass()); }
 	default Property getProperty() { throw new RuntimeException("getProperty() is only allowed on SpecialRootClass"); }
 	default void setTable(Table table) { throw new RuntimeException("Method 'setTable(Table)' is not supported."); }
-	default void setIdentifier(KeyValue value) { throw new RuntimeException("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances"); }
-	default void setKey(KeyValue value) { throw new RuntimeException("setKey(KeyValue) is only allowed on JoinedSubclass"); }
+	default void setIdentifier(Value value) { throw new RuntimeException("Method 'setIdentifier(Value)' can only be called on RootClass instances"); }
+	default void setKey(Value value) { throw new RuntimeException("setKey(Value) is only allowed on JoinedSubclass"); }
 	default boolean isInstanceOfSpecialRootClass() { return SpecialRootClass.class.isAssignableFrom(getWrappedObject().getClass()); }
 	default Property getParentProperty() { throw new RuntimeException("getParentProperty() is only allowed on SpecialRootClass"); }
 	default void setIdentifierProperty(Property property) { throw new RuntimeException("setIdentifierProperty(Property) is only allowed on RootClass instances"); }

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -15,7 +15,6 @@ import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
-import org.hibernate.tool.orm.jbt.wrp.PropertyWrapperFactory.DelegatingPropertyWrapperImpl;
 import org.hibernate.tool.orm.jbt.wrp.PropertyWrapperFactory.PropertyWrapper;
 
 public class PersistentClassWrapperFactory {
@@ -75,6 +74,13 @@ public class PersistentClassWrapperFactory {
 		public KeyValue getIdentifier() {
 			return (KeyValue)wrapValueIfNeeded(super.getIdentifier());
 		}
+		@Override
+		public void setIdentifier(Value v) {
+			if (v instanceof Wrapper) {
+				v = (Value)((Wrapper)v).getWrappedObject();
+			} 
+			super.setIdentifier(((KeyValue)v));
+		}
 	}
 	
 	static class SingleTableSubclassWrapperImpl 
@@ -91,6 +97,13 @@ public class PersistentClassWrapperFactory {
 		public JoinedSubclassWrapperImpl(PersistentClass superclass) {
 			super(superclass, DummyMetadataBuildingContext.INSTANCE);
 		}
+		@Override
+		public void setKey(Value v) {
+			if (v instanceof Wrapper) {
+				v = (Value)((Wrapper)v).getWrappedObject();
+			} 
+			super.setKey(((KeyValue)v));
+		}
 	}
 	
 	static class SpecialRootClassWrapperImpl 
@@ -106,6 +119,13 @@ public class PersistentClassWrapperFactory {
 		@Override
 		public KeyValue getIdentifier() {
 			return (KeyValue)wrapValueIfNeeded(super.getIdentifier());
+		}
+		@Override
+		public void setIdentifier(Value v) {
+			if (v instanceof Wrapper) {
+				v = (Value)((Wrapper)v).getWrappedObject();
+			} 
+			super.setIdentifier(((KeyValue)v));
 		}
 		@Override
 		public Property getProperty() {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactoryTest.java
@@ -9,9 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.Iterator;
 
 import org.hibernate.MappingException;
@@ -598,7 +595,7 @@ public class PersistentClassWrapperFactoryTest {
 	
 	@Test
 	public void testSetKey() {
-		KeyValue valueTarget = createValue();
+		Value valueTarget = new BasicValue(DummyMetadataBuildingContext.INSTANCE);
 		assertNull(rootClassTarget.getKey());
 		assertNull(singleTableSubclassTarget.getKey());
 		assertNull(joinedSubclassTarget.getKey());
@@ -607,13 +604,13 @@ public class PersistentClassWrapperFactoryTest {
 			rootClassWrapper.setKey(valueTarget);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+			assertEquals("setKey(Value) is only allowed on JoinedSubclass", e.getMessage());
 		}
 		try {
 			singleTableSubclassWrapper.setKey(valueTarget);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+			assertEquals("setKey(Value) is only allowed on JoinedSubclass", e.getMessage());
 		}
 		joinedSubclassWrapper.setKey(valueTarget);
 		assertSame(valueTarget, joinedSubclassTarget.getKey());
@@ -621,7 +618,7 @@ public class PersistentClassWrapperFactoryTest {
 			specialRootClassWrapper.setKey(valueTarget);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+			assertEquals("setKey(Value) is only allowed on JoinedSubclass", e.getMessage());
 		}
 	}
 	
@@ -691,42 +688,42 @@ public class PersistentClassWrapperFactoryTest {
 
 	@Test
 	public void testSetIdentifier() {
-		KeyValue valueTarget = createValue();
+		KeyValue valueTarget = new BasicValue(DummyMetadataBuildingContext.INSTANCE);
 		assertNull(rootClassTarget.getIdentifier());
 		assertNull(singleTableSubclassTarget.getIdentifier());
 		assertNull(joinedSubclassTarget.getIdentifier());
 		rootClassWrapper.setIdentifier(valueTarget);
-		assertSame(valueTarget, rootClassTarget.getIdentifier());
-		assertSame(valueTarget, singleTableSubclassTarget.getIdentifier());
-		assertSame(valueTarget, joinedSubclassTarget.getIdentifier());
+		assertSame(valueTarget, ((Wrapper)rootClassTarget.getIdentifier()).getWrappedObject());
+		assertSame(valueTarget, ((Wrapper)singleTableSubclassTarget.getIdentifier()).getWrappedObject());
+		assertSame(valueTarget, ((Wrapper)joinedSubclassTarget.getIdentifier()).getWrappedObject());
 		try {
 			singleTableSubclassWrapper.setIdentifier(valueTarget);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances", e.getMessage());
+			assertEquals("Method 'setIdentifier(Value)' can only be called on RootClass instances", e.getMessage());
 		}
 		try {
 			joinedSubclassWrapper.setIdentifier(valueTarget);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances", e.getMessage());
+			assertEquals("Method 'setIdentifier(Value)' can only be called on RootClass instances", e.getMessage());
 		}
 		assertNull(specialRootClassTarget.getIdentifier());
 		specialRootClassWrapper.setIdentifier(valueTarget);
-		assertSame(valueTarget, specialRootClassTarget.getIdentifier());
+		assertSame(valueTarget, ((Wrapper)specialRootClassTarget.getIdentifier()).getWrappedObject());
 	}
 	
 	@Test
 	public void testSetDiscriminator() throws Exception {
-		Value valueTarget = createValue();
+		KeyValue valueTarget = new BasicValue(DummyMetadataBuildingContext.INSTANCE);
 		assertNull(rootClassTarget.getDiscriminator());
 		assertNull(singleTableSubclassTarget.getDiscriminator());
 		assertNull(joinedSubclassTarget.getDiscriminator());
 		assertNull(specialRootClassTarget.getDiscriminator());
 		rootClassWrapper.setDiscriminator(valueTarget);
-		assertSame(valueTarget, rootClassTarget.getDiscriminator());
-		assertSame(valueTarget, singleTableSubclassTarget.getDiscriminator());
-		assertSame(valueTarget, joinedSubclassTarget.getDiscriminator());
+		assertSame(valueTarget, ((Wrapper)rootClassTarget.getDiscriminator()).getWrappedObject());
+		assertSame(valueTarget, ((Wrapper)singleTableSubclassTarget.getDiscriminator()).getWrappedObject());
+		assertSame(valueTarget, ((Wrapper)joinedSubclassTarget.getDiscriminator()).getWrappedObject());
 		try {
 			singleTableSubclassWrapper.setDiscriminator(valueTarget);
 			fail();
@@ -741,7 +738,7 @@ public class PersistentClassWrapperFactoryTest {
 		}
 		assertNull(specialRootClassTarget.getDiscriminator());
 		specialRootClassWrapper.setDiscriminator(valueTarget);
-		assertSame(valueTarget, specialRootClassTarget.getDiscriminator());
+		assertSame(valueTarget, ((Wrapper)specialRootClassTarget.getDiscriminator()).getWrappedObject());
 	}
 	
 	@Test
@@ -1214,15 +1211,4 @@ public class PersistentClassWrapperFactoryTest {
 		assertSame(tableTarget, specialRootClassWrapper.getRootTable());
 	}
 	
-	private KeyValue createValue() {
-		return (KeyValue)Proxy.newProxyInstance(
-				getClass().getClassLoader(), 
-				new Class[] { KeyValue.class, ValueWrapper.class }, 
-				new InvocationHandler() {	
-					@Override
-					public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-						return null;
-					}
-		});
-	}
 }


### PR DESCRIPTION
  - Change the argument type of methods 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#setIdentifier(...)' and 'org.hibernate.tool.orm.jbt.wrp.Persiste ntClassWrapper#setKey(...)' from 'KeyValue' to 'Value'
  - Override the default 'setIdentifier(Value)' in 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.RootClassWrapperImpl' and in 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.SpecialRootClassWrapperImpl'
  - Override the default 'setKey(Value)' in 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.JoinedSubclassWrapperImpl'
  - Adapt test class ''org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactoryTest' to reflect the above changes'
