### PR TITLE
HBX-2548: Make changes to the JBT bridge so that the Wrapper interface does not leak into the JBT code

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ValueWrapperFactory.java
@@ -82,7 +82,13 @@ public class ValueWrapperFactory {
 		default void addColumn(Column column) { throw new UnsupportedOperationException("Class '" + getWrappedObject().getClass().getName() + "' does not support 'addColumn(Column)'." ); }
 		default void setTypeParameters(Properties properties) { throw new UnsupportedOperationException("Class '" + getWrappedObject().getClass().getName() + "' does not support 'setTypeParameters(Properties)'." ); }
 		default void setElementClassName(String name) { throw new UnsupportedOperationException("Class '" + getWrappedObject().getClass().getName() + "' does not support 'setElementClassName(String)'." ); }
-		default void setKey(KeyValue key) { throw new UnsupportedOperationException("Class '" + getWrappedObject().getClass().getName() + "' does not support 'setKey(KeyValue)'." ); }
+		default void setKey(Value value) {
+			if (Collection.class.isAssignableFrom(getWrappedObject().getClass())) {
+				((Collection)getWrappedObject()).setKey((KeyValue)value);
+			} else {
+				 throw new UnsupportedOperationException("Class '" + getWrappedObject().getClass().getName() + "' does not support 'setKey(KeyValue)'." );
+			}
+		}
 		default void setFetchModeJoin() {
 			if (Fetchable.class.isAssignableFrom(getWrappedObject().getClass())) {
 				((Fetchable)getWrappedObject()).setFetchMode(FetchMode.JOIN);
@@ -103,7 +109,7 @@ public class ValueWrapperFactory {
 		default void setReferencedEntityName(String name) { throw new UnsupportedOperationException("Class '" + getWrappedObject().getClass().getName() + "' does not support 'setReferencedEntityName(String)'." ); }
 	}
 	
-	static interface ValueWrapper extends Value, ValueExtension {}
+	static interface ValueWrapper extends KeyValue, ValueExtension {}
 	
 	
 	private static class ValueWrapperInvocationHandler implements ValueExtension, InvocationHandler {


### PR DESCRIPTION
  - Replace default method 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueExtension#setKey(KeyValue)' by new default method 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueExtension#setKey(Value)'
  - Interface 'org.hibernate.tool.orm.jbt.wrp.ValueWrapperFactory.ValueWrapper' extends KeyValue
