### PR TITLE
HBX-2548: Make changes to the JBT bridge so that the Wrapper interface does not leak into the JBT code

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingColumnWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingColumnWrapperImpl.java
@@ -23,6 +23,7 @@ public class DelegatingColumnWrapperImpl extends Column implements ColumnWrapper
 	private Column delegate = null;
 	
 	public DelegatingColumnWrapperImpl(Column c) {
+		super(c.getName());
 		delegate = c;
 	}
 	


### PR DESCRIPTION
  - Call constructor of super class in 'org.hibernate.tool.orm.jbt.wrp.DelegatingColumnWrapperImpl'
