### PR TITLE
HBX-2562: Cleanup of the JBT bridge

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperFactory.java
@@ -8,7 +8,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Map;
 
-import org.hibernate.tool.orm.jbt.type.IntegerType;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.Type;
@@ -65,7 +64,7 @@ public class TypeWrapperFactory {
 			return null; 
 		}
 		default boolean isIntegerType() {
-			return IntegerType.class.isAssignableFrom(getWrappedObject().getClass());
+			return Integer.class.isAssignableFrom(((Type)getWrappedObject()).getReturnedClass());
 		}
 		default boolean isArrayType() {
 			if (CollectionType.class.isAssignableFrom(getWrappedObject().getClass())) {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/TypeWrapperTest.java
@@ -11,7 +11,6 @@ import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.tool.orm.jbt.type.ClassType;
-import org.hibernate.tool.orm.jbt.type.IntegerType;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeWrapper;
 import org.hibernate.type.AnyType;
@@ -191,7 +190,7 @@ public class TypeWrapperTest {
 		TypeWrapper classTypeWrapper = TypeWrapperFactory.createTypeWrapper(new ClassType());
 		assertFalse(classTypeWrapper.isIntegerType());
 		// next try a integer type 
-		TypeWrapper integerTypeWrapper = TypeWrapperFactory.createTypeWrapper(new IntegerType());
+		TypeWrapper integerTypeWrapper = TypeWrapperFactory.createTypeWrapper(typeConfiguration.getBasicTypeForJavaType(Integer.class));
 		assertTrue(integerTypeWrapper.isIntegerType());
 	}
 	
@@ -218,7 +217,7 @@ public class TypeWrapperTest {
 		TypeWrapper stringTypeWrapper = TypeWrapperFactory.createTypeWrapper(typeConfiguration.getBasicTypeForJavaType(String.class));
 		assertFalse(stringTypeWrapper.isInstanceOfPrimitiveType());
 		// finally try a integer type 
-		TypeWrapper integerTypeWrapper = TypeWrapperFactory.createTypeWrapper(new IntegerType());
+		TypeWrapper integerTypeWrapper = TypeWrapperFactory.createTypeWrapper(typeConfiguration.getBasicTypeForJavaType(Integer.class));
 		assertTrue(integerTypeWrapper.isInstanceOfPrimitiveType());
 	}
 	
@@ -232,7 +231,7 @@ public class TypeWrapperTest {
 			assertTrue(e.getMessage().contains("does not support 'getPrimitiveClass()'"));
 		}
 		// next try a integer type 
-		TypeWrapper integerTypeWrapper = TypeWrapperFactory.createTypeWrapper(new IntegerType());
+		TypeWrapper integerTypeWrapper = TypeWrapperFactory.createTypeWrapper(typeConfiguration.getBasicTypeForJavaType(Integer.class));
 		assertEquals(int.class, integerTypeWrapper.getPrimitiveClass());
 	}
 


### PR DESCRIPTION
  - Change 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperFactory.TypeExtension#isIntegerType()' to remove IntegerType reference
  - Remove references to IntegerType from test class 'org.hibernate.tool.orm.jbt.wrp.TypeWrapperTest'
