### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -32,6 +32,7 @@ public interface PersistentClassWrapper extends Wrapper {
 	default void setDiscriminator(Value value) { throw new RuntimeException("Method 'setDiscriminator(Value)' can only be called on RootClass instances"); }
 	default boolean isLazyPropertiesCacheable() { throw new RuntimeException("Method 'isLazyPropertiesCacheable()' can only be called on RootClass instances"); }
 	default Iterator<Property> getPropertyIterator() { return getProperties().iterator(); }
+	default Iterator<Join> getJoinIterator() { return getJoins().iterator(); }
 
 	String getEntityName();
 	String getClassName();
@@ -45,7 +46,6 @@ public interface PersistentClassWrapper extends Wrapper {
 	Boolean isAbstract();
 	Value getDiscriminator();
 	Value getIdentifier();
-	Iterator<Join> getJoinIterator();
 	Property getVersion();
 	void setClassName(String name);
 	void setEntityName(String name);
@@ -80,5 +80,6 @@ public interface PersistentClassWrapper extends Wrapper {
 	String getWhere();
 	Table getRootTable();
 	List<Property> getProperties();
+	List<Join> getJoins();
 	
 }


### PR DESCRIPTION
  - Add new method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#getJoins()'
  - Add default implementation for 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#getJoinIterator()'
