### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapper.java
@@ -34,13 +34,13 @@ public interface PersistentClassWrapper extends Wrapper {
 	default Iterator<Property> getPropertyIterator() { return getProperties().iterator(); }
 	default Iterator<Join> getJoinIterator() { return getJoins().iterator(); }
 	default Iterator<Subclass> getSubclassIterator() { return getSubclasses().iterator(); }
+	default Iterator<Property> getPropertyClosureIterator() { return getPropertyClosure().iterator(); }
 
 	String getEntityName();
 	String getClassName();
 	Property getIdentifierProperty();
 	boolean hasIdentifierProperty();
 	PersistentClass getRootClass();
-	Iterator<Property> getPropertyClosureIterator();
 	PersistentClass getSuperclass();
 	Property getProperty(String name);
 	Table getTable();
@@ -82,5 +82,6 @@ public interface PersistentClassWrapper extends Wrapper {
 	List<Property> getProperties();
 	List<Join> getJoins();
 	List<Subclass> getSubclasses();
+	List<Property> getPropertyClosure();
 	
 }


### PR DESCRIPTION
  - Add new method 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#getPropertyClosure()'
  - Add default implementation for 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper#getPropertyClosureIterator()'
