### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -137,7 +137,7 @@ public class PersistentClassWrapperFactory {
 		}
 		@Override 
 		public Iterator<Property> getPropertyIterator() {
-			final Iterator<Property> iterator = super.getPropertyIterator();
+			final Iterator<Property> iterator = getProperties().iterator();
 			return new Iterator<Property>() {
 				@Override
 				public boolean hasNext() {


### PR DESCRIPTION
  - Replace reference to deprecated method 'PersistentClass#getPropertyIterator()'
