### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingTableWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingTableWrapperImpl.java
@@ -55,7 +55,7 @@ public class DelegatingTableWrapperImpl extends Table implements TableWrapper{
 	
 	@Override
 	public Iterator<Column> getColumnIterator() {
-		final Iterator<Column> iterator = delegate.getColumnIterator();
+		final Iterator<Column> iterator = delegate.getColumns().iterator();
 		return new Iterator<Column>() {
 			@Override
 			public boolean hasNext() {


### PR DESCRIPTION
  - Replace reference to deprecated method 'PersistentClass#getColumnIterator()' in class 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl'
