### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
@@ -155,7 +155,7 @@ public class DelegatingPersistentClassWrapperImpl extends RootClass implements P
 
 	@Override 
 	public Iterator<Subclass> getSubclassIterator() {
-		return delegate.getSubclassIterator();
+		return delegate.getSubclasses().iterator();
 	}
 
 	@Override 


### PR DESCRIPTION
  - Replace reference to deprecated method 'PersistentClass#getSubclassIterator()' in class 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl'
