### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
@@ -110,7 +110,7 @@ public class DelegatingPersistentClassWrapperImpl extends RootClass implements P
 
 	@Override 
 	public Iterator<Join> getJoinIterator() {
-		return delegate.getJoinIterator();
+		return delegate.getJoins().iterator();
 	}
 
 	@Override 


### PR DESCRIPTION
  - Replace reference to deprecated method 'PersistentClass#getJoinIterator()' in class 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl'
