### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/DelegatingPersistentClassWrapperImpl.java
@@ -68,7 +68,7 @@ public class DelegatingPersistentClassWrapperImpl extends RootClass implements P
 	
 	@Override 
 	public Iterator<Property> getPropertyIterator() {
-		final Iterator<Property> iterator = delegate.getPropertyIterator();
+		final Iterator<Property> iterator = delegate.getProperties().iterator();
 		return new Iterator<Property>() {
 			@Override
 			public boolean hasNext() {


### PR DESCRIPTION
  - Replace reference to deprecated method 'PersistentClass#getPropertyIterator()' in class 'org.hibernate.tool.orm.jbt.wrp.DelegatingTableWrapperImpl'

