### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Index/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Index/TestCase.java
@@ -83,7 +83,7 @@ public class TestCase {
 				JdbcUtil.toIdentifier(this, "WITH_INDEX"), 
 				JdbcUtil.toIdentifier(this, table.getName()));	
 		assertNull(table.getPrimaryKey(), "there should be no pk" );
-		Iterator<Index> iterator = table.getIndexIterator();
+		Iterator<Index> iterator = table.getIndexes().values().iterator();
 		int cnt=0;
 		while(iterator.hasNext() ) {
 			iterator.next();


### PR DESCRIPTION
  - Replace reference to deprecated method 'Table#getIndexIterator()' in test class 'org.hibernate.tool.jdbc2cfg.Index.TestCase'

