### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Index/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/Index/TestCase.java
@@ -97,7 +97,7 @@ public class TestCase {
 				JdbcUtil.toIdentifier(this, index.getName()));	
 		assertEquals(2, index.getColumnSpan() );	
 		assertSame(index.getTable(), table);
-		Iterator<Column> cols = index.getColumnIterator();
+		Iterator<Column> cols = index.getColumns().iterator();
 		Column col1 = cols.next();
 		Column col2 = cols.next();	
 		assertEquals(


### PR DESCRIPTION
  - Replace reference to deprecated method 'Index#getColumnIterator()' in test class 'org.hibernate.tool.jdbc2cfg.Index.TestCase'
