### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/PersistentClassWrapperFactory.java
@@ -150,6 +150,21 @@ public class PersistentClassWrapperFactory {
 				
 			};
 		}
+		@Override 
+		public Iterator<Property> getPropertyClosureIterator() {
+			final Iterator<Property> iterator = getPropertyClosure().iterator();
+			return new Iterator<Property>() {
+				@Override
+				public boolean hasNext() {
+					return iterator.hasNext();
+				}
+				@Override
+				public Property next() {
+					return wrapPropertyIfNeeded(iterator.next());
+				}
+				
+			};
+		}
 
 	}
 	


### PR DESCRIPTION
  - Override method 'getPropertyClosureIterator()' in class 'org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapperFactory.SpecialRootClassWrapperImpl'
