### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/entities/allEntity-list.ftl
+++ b/orm/src/main/resources/doc/entities/allEntity-list.ftl
@@ -12,9 +12,9 @@
 		</p>
 		
 		<p>
-			<#foreach class in classList>
+			<#list classList as class>
 				<a href="${docFileManager.getRef(docFile, docFileManager.getEntityDocFile(class))}" target="generalFrame">${class.declarationName}</a><br/>
-			</#foreach>
+			</#list>
 		</p>
 
 	</body>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/entities/allEntity-list.ftl'
