### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/entities/package-list.ftl
+++ b/orm/src/main/resources/doc/entities/package-list.ftl
@@ -15,9 +15,9 @@
 			Packages
 		</p>
 		<p>
-			<#foreach package in packageList>
+			<#list packageList as package>
 				<a href="${docFileManager.getRef(docFile, docFileManager.getPackageEntityListDocFile(package))}" target="entitiesFrame">${package}</a><br/>
-			</#foreach>
+			</#list>
 		</p>
 		
 	</body>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/entities/package-list.ftl'
