### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/entities/package-summary.ftl
+++ b/orm/src/main/resources/doc/entities/package-summary.ftl
@@ -23,7 +23,7 @@
 					</tr>
 				</thead>
 				<tbody>
-					<#foreach class in classList>
+					<#list classList as class>
 						<tr>
 							<td style="width: 15%">
 								<a href="${docFileManager.getRef(docFile, docFileManager.getEntityDocFile(class))}" target="generalFrame">
@@ -34,7 +34,7 @@
 								${class.getMetaAsString("class-description")?default("&nbsp;")}
 							</td>
 						</tr>
-					</#foreach>
+					</#list>
 				</tbody>
 			</table>
 		</#if>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/entities/package-summary.ftl'
