### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/entities/perPackageEntity-list.ftl
+++ b/orm/src/main/resources/doc/entities/perPackageEntity-list.ftl
@@ -14,9 +14,9 @@
 		<#if (classList.size() > 0)>
 			<p>
 				Entities<br/>
-				<#foreach class in classList>
+				<#list classList as class>
 					<a href="${docFileManager.getRef(docFile, docFileManager.getEntityDocFile(class))}" target="generalFrame">${class.declarationName}</a><br/>
-				</#foreach>
+				</#list>
 			</p>
 		</#if>
 


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/entities/perPackageEntity-list.ftl'
