### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/entities/summary.ftl
+++ b/orm/src/main/resources/doc/entities/summary.ftl
@@ -31,13 +31,13 @@
 				</tr>
 			</thead>
 			<tbody>
-				<#foreach package in packageList>
+				<#list packageList as package>
 				<tr>
 					<td>
 						<a href="${docFileManager.getRef(docFile, docFileManager.getPackageSummaryDocFile(package))}" target="generalFrame">${package}</a>
 					</td>
 				</tr>
-				</#foreach>
+				</#list>
 			</tbody>
 		</table>
 


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/entities/summary.ftl'
