### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/tables/schema-list.ftl
+++ b/orm/src/main/resources/doc/tables/schema-list.ftl
@@ -16,9 +16,9 @@
 		</p>
 
 		<p>
-			<#foreach schema in schemaList>
+			<#list schemaList as schema>
 				<a href="${docFileManager.getRef(docFile, docFileManager.getSchemaTableListDocFile(schema))}" target="tablesFrame">${schema}</a><br/>
-			</#foreach>
+			</#list>
 		</p>
 
 	</body>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/tables/schema-list.ftl'
