### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/tables/schema-summary.ftl
+++ b/orm/src/main/resources/doc/tables/schema-summary.ftl
@@ -22,7 +22,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				<#foreach table in dochelper.tablesBySchema.get(schema)>
+				<#list dochelper.tablesBySchema.get(schema) as table>
 					<tr>
 						<td>
 							<a href="${docFileManager.getRef(docFile, docFileManager.getTableDocFile(table))}" target="generalFrame">
@@ -30,7 +30,7 @@
 							</a>
 						</td>
 					</tr>
-				</#foreach>
+				</#list>
 			</tbody>
 		</table>
 


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/tables/schema-summary.ftl'
