### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/tables/schema-table-list.ftl
+++ b/orm/src/main/resources/doc/tables/schema-table-list.ftl
@@ -12,9 +12,9 @@
 		</p>
 		
 		<p>
-			<#foreach table in tableList>
+			<#list tableList as table>
 				<a href="${docFileManager.getRef(docFile, docFileManager.getTableDocFile(table))}" target="generalFrame">${table.name}</a><br/>
-			</#foreach>
+			</#list>
 		</p>
 
 	</body>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/tables/schema-table-list.ftl'
