### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/doc/tables/summary.ftl
+++ b/orm/src/main/resources/doc/tables/summary.ftl
@@ -31,7 +31,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				<#foreach schema in dochelper.tablesBySchema.keySet()>
+				<#list dochelper.tablesBySchema.keySet() as schema>
 					<tr>
 						<td>
 							<a href="${docFileManager.getRef(docFile, docFileManager.getSchemaSummaryDocFile(schema))}" target="generalFrame">
@@ -39,7 +39,7 @@
 							</a>
 						</td>
 					</tr>
-				</#foreach>
+				</#list>
 			</tbody>
 		</table>
 		


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/doc/tables/summary.ftl'
