### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/any.hbm.ftl
+++ b/orm/src/main/resources/hbm/any.hbm.ftl
@@ -11,12 +11,12 @@
 	    	<#assign metaattributable=property>
 		<#include "meta.hbm.ftl">
 		<#if value.metaValues?exists>
-		 <#foreach entry in value.metaValues.entrySet()>
+		    <#list value.metaValues.entrySet() as entry>
               		<meta-value value="${entry.key}" class="${entry.value}"/>
-           	</#foreach>
-           	</#if>
-           	<#foreach column in property.columnIterator>
-              		<#include "column.hbm.ftl">
-          	 </#foreach>
+           	</#list>
+        </#if>
+        <#list property.columnIterator as column>
+            <#include "column.hbm.ftl">
+        </#list>
 	</any>
 	


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/any.hbm.ftl'
