### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/array.hbm.ftl
+++ b/orm/src/main/resources/hbm/array.hbm.ftl
@@ -18,9 +18,9 @@
  	<#include "meta.hbm.ftl">
     <#include "key.hbm.ftl">
     <list-index>
-    <#foreach column in indexValue.columnIterator>
+    <#list indexValue.columns as column>
     	<#include "column.hbm.ftl">
-    </#foreach>  
+    </#list>  
     </list-index>
     <#include "${elementTag}-element.hbm.ftl">
 </array>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/array.hbm.ftl'
