### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/composite-element.hbm.ftl
+++ b/orm/src/main/resources/hbm/composite-element.hbm.ftl
@@ -1,12 +1,12 @@
 <composite-element class="${elementValue.componentClassName}">
 	<#assign metaattributable=property>
 	<#include "meta.hbm.ftl">
-	<#foreach property in elementValue.getPropertyIterator()>
+	<#list elementValue.properties as property>
 		<#assign tag=c2h.getTag(property)>
 		<#if tag="component">
 			<#assign tag="nested-composite-element">
 			<#assign elementValue = property.value>
 		</#if>
 		<#include "${tag}.hbm.ftl"/>
-	</#foreach>
+	</#list>
 </composite-element>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/composite-element.hbm.ftl'
