### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/element-element.hbm.ftl
+++ b/orm/src/main/resources/hbm/element-element.hbm.ftl
@@ -1,5 +1,5 @@
 <element type="${elementValue.getTypeName()}">
- <#foreach column in elementValue.columnIterator>
+  <#list elementValue.columns as column>
         <#include "column.hbm.ftl">
-  </#foreach>
+  </#list>
 </element>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/element-element.hbm.ftl'
