### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/filter-def.hbm.ftl
+++ b/orm/src/main/resources/hbm/filter-def.hbm.ftl
@@ -1,8 +1,8 @@
-<#foreach filterKey in md.filterDefinitions.keySet()>
+<#list md.filterDefinitions.keySet() as filterKey>
 <#assign filterDef = md.filterDefinitions.get(filterKey)>
     <filter-def name="filterKey">
-<#foreach filterParaName in filterDef.parameterNames>
-	<filter-param name="${filterParaName}" type="${filterDef.getParameterType(filterParaName).name}" />
-</#foreach>
+    <#foreach filterParaName in filterDef.parameterNames>
+	    <filter-param name="${filterParaName}" type="${filterDef.getParameterType(filterParaName).name}" />
+    </#foreach>
     </filter-def>    
-</#foreach>
+</#list>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/filter-def.hbm.ftl'
