### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/filter-def.hbm.ftl
+++ b/orm/src/main/resources/hbm/filter-def.hbm.ftl
@@ -1,8 +1,8 @@
 <#list md.filterDefinitions.keySet() as filterKey>
 <#assign filterDef = md.filterDefinitions.get(filterKey)>
     <filter-def name="filterKey">
-    <#foreach filterParaName in filterDef.parameterNames>
+    <#list filterDef.parameterNames as filterParaName>
 	    <filter-param name="${filterParaName}" type="${filterDef.getParameterType(filterParaName).name}" />
-    </#foreach>
+    </#list>
     </filter-def>    
 </#list>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/filter-def.hbm.ftl'
