### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/idbag.hbm.ftl
+++ b/orm/src/main/resources/hbm/idbag.hbm.ftl
@@ -20,9 +20,9 @@
 	 		<generator class="${value.identifier.identifierGeneratorStrategy}"/>
 	 	</collection-id>
  		<key> 
-        	<#foreach column in keyValue.columnIterator>
+        	<#list keyValue.columns as column>
           		<#include "column.hbm.ftl">
-        	</#foreach>
+        	</#list>
         	</key>
 		<#include "${elementTag}-element.hbm.ftl">
      	</idbag>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/idbag.hbm.ftl'
