### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/import.hbm.ftl
+++ b/orm/src/main/resources/hbm/import.hbm.ftl
@@ -1,5 +1,5 @@
-<#foreach importKey in md.imports.keySet()>
+<#list md.imports.keySet() as importKey>
 <#assign importDef = md.imports.get(importKey)>
 <#if !importKey.equals(importDef)>
     <import class="${importKey}" rename="${importDef}"/>
-</#if></#foreach>
+</#if></#list>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/import.hbm.ftl'
