### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/list.hbm.ftl
+++ b/orm/src/main/resources/hbm/list.hbm.ftl
@@ -18,9 +18,9 @@
 		<#include "meta.hbm.ftl">
 		<#include "key.hbm.ftl">		
     		<list-index>
-    			<#foreach column in indexValue.columnIterator>
+    			<#list indexValue.columns as column>
     			<#include "column.hbm.ftl">
-			</#foreach>  
+			</#list>  
     		</list-index>
     		<#include "${elementTag}-element.hbm.ftl">
 	</list>

--- a/orm/src/main/resources/hbm/many-to-any-element.hbm.ftl
+++ b/orm/src/main/resources/hbm/many-to-any-element.hbm.ftl
@@ -1,11 +1,11 @@
 <many-to-any id-type="${elementValue.getIdentifierType()}" meta-type="${elementValue.getMetaType()}">
 	<#if elementValue.metaValues?exists>
-	<#foreach entry in elementValue.metaValues.entrySet()>
+	<#list elementValue.metaValues.entrySet() as entry>
         	<meta-value value="${entry.key}" class="${entry.value}"/>
-        </#foreach>
+        </#list>
         </#if>
-	<#foreach column in elementValue.columnIterator>
+	<#list elementValue.columns as column>
 		<#include "column.hbm.ftl">
-	</#foreach>
+	</#list>
 </many-to-any>
 			


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/list.hbm.ftl'
