### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/many-to-many-element.hbm.ftl
+++ b/orm/src/main/resources/hbm/many-to-many-element.hbm.ftl
@@ -2,7 +2,7 @@
 <#if property.value.referencedPropertyName?exists>
         property-ref="${property.value.referencedPropertyName}"
 </#if>>
-  <#foreach column in elementValue.columnIterator>
+  <#list elementValue.selectables as column>
         <#include "column.hbm.ftl">
-  </#foreach>
+  </#list>
 </many-to-many>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/many-to-many-element.hbm.ftl'
