### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/many-to-one.hbm.ftl
+++ b/orm/src/main/resources/hbm/many-to-one.hbm.ftl
@@ -27,7 +27,7 @@
     >
     <#assign metaattributable=property>
 	<#include "meta.hbm.ftl">    
-<#foreach column in property.columnIterator>
+<#list property.columns as column>
         <#include "column.hbm.ftl">
-</#foreach>	
+</#list>	
    </many-to-one>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/many-to-one.hbm.ftl'

