### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/map.hbm.ftl
+++ b/orm/src/main/resources/hbm/map.hbm.ftl
@@ -25,9 +25,9 @@
     		</map-key-many-to-many>
     		<#else>
     		<map-key type="${indexValue.typeName}">
-    			<#foreach column in indexValue.columnIterator>
+    			<#list indexValue.selectables as column>
     			<#include "column.hbm.ftl">
-			</#foreach> 
+			</#list> 
 		</map-key>
     		</#if>
     		<#include "${elementTag}-element.hbm.ftl">


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/map.hbm.ftl' (part 2)
