### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/primitive-array.hbm.ftl
+++ b/orm/src/main/resources/hbm/primitive-array.hbm.ftl
@@ -9,18 +9,18 @@
  <#assign metaattributable=property>
  <#include "meta.hbm.ftl">
  <key>
-       <#foreach column in dependentValue.getColumnIterator()>
-        <#include "column.hbm.ftl">
-       </#foreach>
+       <#list dependentValue.selectables as column>
+         <#include "column.hbm.ftl">
+       </#list>
  </key>
  <index>
-       <#foreach column in value.getIndex().getColumnIterator()>
+       <#list value.index.selectables as column>
          <#include "column.hbm.ftl">   
-       </#foreach>
+       </#list>
  </index>
  <element type="${value.getElementClass()}" >
-       <#foreach column in value.getElement().getColumnIterator()>         
+       <#list value.element.selectables as column>
          <#include "column.hbm.ftl">   
-       </#foreach>
+       </#list>
  </element>
 </primitive-array>


### PR DESCRIPTION
  - Remove the uses from 'oorm/src/main/resources/hbm/primitive-array.hbm.ftl'
