### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/properties.hbm.ftl
+++ b/orm/src/main/resources/hbm/properties.hbm.ftl
@@ -3,7 +3,7 @@
     name="${property.name}">
     <#assign metaattributable=property>
 	<#include "meta.hbm.ftl">
-	<#foreach property in c2h.getProperties(property.value)>
+	<#list c2h.getProperties(property.value) as property>
 		<#include "${c2h.getTag(property)}.hbm.ftl"/>
-	</#foreach>
+	</#list>
 </properties>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/properties.hbm.ftl'
