### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/query.hbm.ftl
+++ b/orm/src/main/resources/hbm/query.hbm.ftl
@@ -1,4 +1,4 @@
-<#foreach queryDef in md.namedQueryDefinitions>
+<#list md.namedQueryDefinitions as queryDef>
     <query 
         name="${queryDef.name}"
 <#if queryDef.flushMode?exists>
@@ -18,4 +18,4 @@
 </#if>    >
         <![CDATA[${queryDef.queryString.trim()}]]>
     </query> 
-</#foreach>
+</#list>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/query.hbm.ftl'
