### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/timestamp.hbm.ftl
+++ b/orm/src/main/resources/hbm/timestamp.hbm.ftl
@@ -1,7 +1,7 @@
     <timestamp
         name="${property.name}"
 <#if !property.basicPropertyAccessor>        access="${property.propertyAccessorName}"
-</#if><#foreach column in property.columnIterator> <#-- always only one column, but no direct access method.-->
+</#if><#list property.columns as column> <#-- always only one column, but no direct access method.-->
         column="${column.quotedName}" 
-</#foreach>    />
+</#list>    />
 


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/timestamp.hbm.ftl'
