### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/hbm/version.hbm.ftl
+++ b/orm/src/main/resources/hbm/version.hbm.ftl
@@ -3,8 +3,8 @@
         type="${property.value.typeName}"
 <#if !property.basicPropertyAccessor>        access="${property.propertyAccessorName}"
 </#if>    >
-<#foreach column in property.columnIterator> 
+<#list property.columns as column>
        <#include "column.hbm.ftl">
-</#foreach>
+</#list>
 	</version>
 


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/hbm/version.hbm.ftl'
