### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/lint/text-report.ftl
+++ b/orm/src/main/resources/lint/text-report.ftl
@@ -1,3 +1,3 @@
-<#foreach issue in lintissues>
+<#list lintissues as issue>
 ${issue}
-</#foreach>
+</#list>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/lint/text-report.ftl'
