### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/pojo/PojoConstructors.ftl
+++ b/orm/src/main/resources/pojo/PojoConstructors.ftl
@@ -19,8 +19,8 @@
 <#if pojo.isSubclass() && !pojo.getPropertyClosureForSuperclassFullConstructor().isEmpty()>
         super(${c2j.asArgumentList(pojo.getPropertyClosureForSuperclassFullConstructor())});        
 </#if>
-<#foreach field in pojo.getPropertiesForFullConstructor()> 
+<#list pojo.getPropertiesForFullConstructor() as field>
        this.${c2j.keyWordCheck(field.name)} = ${c2j.keyWordCheck(field.name)};
-</#foreach>
+</#list>
     }
 </#if>    


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/pojo/PojoConstructors.ftl' (Part 2)
