### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/pojo/PojoEqualsHashcode.ftl
+++ b/orm/src/main/resources/pojo/PojoEqualsHashcode.ftl
@@ -12,7 +12,7 @@
    public int hashCode() {
          int result = 17;
          
-<#foreach property in pojo.getAllPropertiesIterator()>         ${pojo.generateHashCode(property, "result", "this", jdk5)}
-</#foreach>         return result;
+<#list pojo.getAllPropertiesIterator() as property>        ${pojo.generateHashCode(property, "result", "this", jdk5)}
+</#list>         return result;
    }   
 </#if>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/pojo/PojoEqualsHashcode.ftl'
