### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/pojo/PojoFields.ftl
+++ b/orm/src/main/resources/pojo/PojoFields.ftl
@@ -1,8 +1,8 @@
 <#-- // Fields -->
 
-<#foreach field in pojo.getAllPropertiesIterator()><#if pojo.getMetaAttribAsBool(field, "gen-property", true)> <#if pojo.hasMetaAttribute(field, "field-description")>    /**
+<#list pojo.getAllPropertiesIterator() as field><#if pojo.getMetaAttribAsBool(field, "gen-property", true)> <#if pojo.hasMetaAttribute(field, "field-description")>    /**
      ${pojo.getFieldJavaDoc(field, 0)}
      */
  </#if>    ${pojo.getFieldModifiers(field)} ${pojo.getJavaTypeName(field, jdk5)} ${c2j.keyWordCheck(field.name)}<#if pojo.hasFieldInitializor(field, jdk5)> = ${pojo.getFieldInitialization(field, jdk5)}</#if>;
 </#if>
-</#foreach>
+</#list>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/pojo/PojoFields.ftl'
