### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/pojo/PojoInterfacePropertyAccessors.ftl
+++ b/orm/src/main/resources/pojo/PojoInterfacePropertyAccessors.ftl
@@ -1,8 +1,8 @@
 <#-- if interface -->
 <#-- Property accessors for interface -->
-<#foreach property in pojo.getAllPropertiesIterator()><#if pojo.getMetaAttribAsBool(property, "gen-property", true)>   /**
+<#list pojo.getAllPropertiesIterator() as property><#if pojo.getMetaAttribAsBool(property, "gen-property", true)>   /**
    ${c2j.toJavaDoc(c2j.getMetaAsString(property, "field-description"), 4)} */
    ${pojo.getPropertyGetModifiers(property)} ${pojo.getJavaTypeName(property, jdk5)} ${pojo.getGetterSignature(property)}();
     
    ${pojo.getPropertySetModifiers(property)} void set${pojo.getPropertyName(property)}(${pojo.getJavaTypeName(property, jdk5)} ${property.name});
-</#if></#foreach>
+</#if></#list>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/pojo/PojoInterfacePropertyAccessors.ftl'
