### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/pojo/PojoPropertyAccessors.ftl
+++ b/orm/src/main/resources/pojo/PojoPropertyAccessors.ftl
@@ -1,5 +1,5 @@
 <#-- // Property accessors -->
-<#foreach property in pojo.getAllPropertiesIterator()>
+<#list pojo.getAllPropertiesIterator() as property>
 <#if pojo.getMetaAttribAsBool(property, "gen-property", true)>
  <#if pojo.hasFieldJavaDoc(property)>    
     /**       
@@ -15,4 +15,4 @@
         this.${c2j.keyWordCheck(property.name)} = ${c2j.keyWordCheck(property.name)};
     }
 </#if>
-</#foreach>
+</#list>


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/pojo/PojoPropertyAccessors.ftl'

