### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/orm/src/main/resources/debug.ftl
+++ b/orm/src/main/resources/debug.ftl
@@ -20,15 +20,15 @@
 <#macro dump var>
    <#if var?is_hash>
    {
-     <#foreach key in var?keys>
+     <#list var?keys as key>
         ${key}:< <at> dump var[key]/>,
-     </#foreach>
+     </#list>
    }
    <#elseif var?is_sequence>
    [
-     <#foreach elem in sequence>
+     <#list sequence as elem>
        < <at> dump elem/>,
-     </#foreach>
+     </#list>
    ]
    <#else>
      ${var}


### PR DESCRIPTION
  - Remove the uses from 'orm/src/main/resources/debug.ftl'
