### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/test/maven/src/it/hbm2dao/src/main/resources/templates/dao/daohome.ftl
+++ b/test/maven/src/it/hbm2dao/src/main/resources/templates/dao/daohome.ftl
@@ -175,11 +175,11 @@ public class ${declarationName}Home {
 <#else>
                    .add( ${pojo.importType("org.hibernate.criterion.Restrictions")}.naturalId()
 </#if>                    
-<#foreach property in pojo.getAllPropertiesIterator()>
+<#list pojo.getAllPropertiesIterator() as property>
 <#if property.isNaturalIdentifier()>
                             .set("${property.name}", ${property.name})
 </#if>
-</#foreach>
+</#list>
                         )
                     .uniqueResult();
             if (instance==null) {
@@ -223,7 +223,7 @@ public class ${declarationName}Home {
             throw re;
         }
     } 
-<#foreach query in daoHelper.getNamedHqlQueryDefinitions(md)>
+<#list daoHelper.getNamedHqlQueryDefinitions(md) as query>
 <#assign queryName = query.registrationName>
 <#if queryName.startsWith(clazz.entityName + ".")>
 <#assign methname = c2j.unqualify(queryName)>
@@ -247,7 +247,7 @@ public class ${declarationName}Home {
 </#if>
     }
 </#if>
-</#foreach></#if>
+</#list></#if>
 }
 </#assign>
 


### PR DESCRIPTION
  - Remove the uses from 'test/maven/src/it/hbm2dao/src/main/resources/templates/dao/daohome.ftl'
