### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/freemarker.ftl
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/freemarker.ftl
@@ -2,11 +2,11 @@
 ${pojo.getShortName()}
 ${pojo.shortName}
 
-<#foreach cl in [1,2,3]>
+<#list [1,2,3] as cl>
 <#include "freeinc.ftl"/> 
 <#include "freeinc.ftl"/> 
 <@greet person=cl/>
-</#foreach>
+</#list>
 
 
 <#macro greet person>


### PR DESCRIPTION
  - Remove the uses from 'test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/freemarker.ftl'
