### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/generic-exception.ftl
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/generic-exception.ftl
@@ -1,9 +1,9 @@
 ${pojo.getShortName()}
 ${pojo.shortName}
 
-<#foreach cl in [1,2,3]>
+<#list [1,2,3] as cl>
  <@greet person=cl/>
-</#foreach>
+</#list>
 
 
 <#macro greet person>


### PR DESCRIPTION
  - Remove the uses from 'test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/generic-exception.ftl'
