### PR TITLE
HBX-2586: Remove uses of the deprecated #foreach Freemarker instruction from the template files

### DIFF
--- a/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/generic-test.ftl
+++ b/test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/generic-test.ftl
@@ -1,5 +1,5 @@
-<#foreach item in ctx?keys>	
+<#list ctx?keys as item>	
 <#-- ${templates.create("generictemplates/pojo/generic-content", item + ".txt")}  -->
 <#assign captured><#include "generic-content.ftl"/></#assign>
 ${templates.createFile(captured, "${item}.txt")}
-</#foreach>
+</#list>


### PR DESCRIPTION
  - Remove the uses from 'test/nodb/src/test/resources/org/hibernate/tool/hbm2x/GenericExporterTest/generic-test.ftl'
