### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/orm/src/main/resources/hbm/idbag.hbm.ftl
+++ b/orm/src/main/resources/hbm/idbag.hbm.ftl
@@ -16,7 +16,7 @@
 	 <#assign metaattributable=property>
 	 	<#include "meta.hbm.ftl">
 	 	<collection-id type="${value.identifier.typeName}" 
-	 		column="${value.getIdentifier().getColumnIterator().next().getQuotedName()}">
+	 		column="${value.getIdentifier().getColumns().iterator().next().getQuotedName()}">
 	 		<generator class="${value.identifier.identifierGeneratorStrategy}"/>
 	 	</collection-id>
  		<key> 


### PR DESCRIPTION
  - Remove reference to deprecated 'Value#getColumnIterator()' in 'orm/src/main/resources/hbm/idbag.hbm.ftl'
