### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/orm/src/main/resources/hbm/any.hbm.ftl
+++ b/orm/src/main/resources/hbm/any.hbm.ftl
@@ -15,7 +15,7 @@
               		<meta-value value="${entry.key}" class="${entry.value}"/>
            	</#list>
         </#if>
-        <#list property.columnIterator as column>
+        <#list property.columns as column>
             <#include "column.hbm.ftl">
         </#list>
 	</any>


### PR DESCRIPTION
  - Remove reference to deprecated 'Value#getColumnIterator()' in 'orm/src/main/resources/hbm/any.hbm.ftl'
