### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/orm/src/main/resources/dot/tablegraph.dot.ftl
+++ b/orm/src/main/resources/dot/tablegraph.dot.ftl
@@ -27,9 +27,9 @@ digraph TableGraph {
 <#list tables as table>
   <#if table.isPhysicalTable()>
   /* Node ${table.name} */
-  <@nodeName table/> [ label = "<@columnLabels name=table.name columns=table.columnIterator/>" ]  
+  <@nodeName table/> [ label = "<@columnLabels name=table.name columns=table.columns/>" ]  
   
-  <@propertyEdges root=table.name?replace(".","_dot_") foreignKeys=table.foreignKeyIterator/>     
+  <@propertyEdges root=table.name?replace(".","_dot_") foreignKeys=table.foreignKeys.values()/>     
   </#if>
 </#list>
 


### PR DESCRIPTION
  - Remove reference to deprecated 'Table.getColumnIterator()' from 'orm/src/main/resources/dot/tablegraph.dot.ftl'
  - Remove reference to deprecated 'Table.getForeignKeyIterator()' from 'orm/src/main/resources/dot/tablegraph.dot.ftl'
