### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/orm/src/main/resources/doc/tables/table.ftl
+++ b/orm/src/main/resources/doc/tables/table.ftl
@@ -208,7 +208,7 @@
 		</#if>
 		
 		<#-- SHOW THE TABLE INDEXES -->
-		<#if table.indexIterator.hasNext()>
+		<#if !table.indexes.isEmpty()>
 			<table id="indexes">
 				<thead>
 					<tr>
@@ -244,7 +244,7 @@
 			</table>
 		</#if>
 		
-		<#if table.columnIterator.hasNext()>
+		<#if !table.columns.isEmpty()>
 			<p id="column_detail" class="MainTableHeading">
 				Column Detail
 			</p>


### PR DESCRIPTION
  - Remove reference to deprecated 'Table.getIndexIterator()' from 'orm/src/main/resources/doc/tables/table.ftl'
  - Remove referency to deprecated 'Table.getColumnIterator()' from 'orm/src/main/resources/doc/tables/table.ftl'
