### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/orm/src/main/resources/doc/entities/entity.ftl
+++ b/orm/src/main/resources/doc/entities/entity.ftl
@@ -77,7 +77,7 @@
 					<#if dochelper.getComponentPOJO(propertyIdentifier)?exists>
 						<#assign compoclass = dochelper.getComponentPOJO(propertyIdentifier)>
 						<#list compoclass.allPropertiesIterator as property>
-							<#assign columnIterator = property.getValue().columnIterator>
+							<#assign columnIterator = property.getValue().selectables.iterator()>
 							<#assign rowspan = property.getValue().getColumnSpan()>
 							<tr>
 								<td <#if (rowspan>0)>rowspan="${rowspan}"</#if>>
@@ -287,7 +287,7 @@
 				<tbody>
 	
 					<#list properties as property>
-						<#assign columnIterator = property.getValue().columnIterator>
+						<#assign columnIterator = property.getValue().selectables.iterator()>
 						<#assign rowspan = property.getValue().getColumnSpan()>
 						<tr>
 							<td <#if (rowspan > 0)>rowspan="${rowspan}"</#if>>


### PR DESCRIPTION
  - Remove references to deprecated 'Value.getColumnIterator()' from 'orm/src/main/resources/doc/entities/entity.ftl'
