### PR TITLE
HBX-2563: Update Hibernate ORM Dependency to Version 6.3.0.Final

### DIFF
--- a/orm/src/main/resources/hbm/persistentclass.hbm.ftl
+++ b/orm/src/main/resources/hbm/persistentclass.hbm.ftl
@@ -89,7 +89,7 @@
         	</composite-id>
  	<#else>
  		 <id type="${clazz.identifier.typeName}">
-		 <#list class.identifier.columns as column>
+		 <#list clazz.identifier.selectables as column>
         	<#include "column.hbm.ftl">
  		</#list>
  		</id>


### PR DESCRIPTION
  - Correct typo in 'orm/src/main/resources/hbm/persistentclass.hbm.ftl'
