### PR TITLE
HBX-2614 - Check isNullable() in BasicPOJOClass::isRequiredInConstructor

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/BasicPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/BasicPOJOClass.java
@@ -817,7 +817,7 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 			return false;
 		}
 		if(field.getValue()!=null) {			
-			if (!field.isOptional() && (field.getValueGeneratorCreator() == null )) {				
+			if (!(field.isOptional() || field.getValue().isNullable()) && (field.getValueGeneratorCreator() == null )) {				
 				return true;
 			} else if (field.getValue() instanceof Component) {
 				Component c = (Component) field.getValue();


### PR DESCRIPTION
Restores previous Minimal Constructors behavior lost when isNullable() check removed from core org.hibernate.mapping.Property.isOptional().

(https://hibernate.atlassian.net/browse/HBX-2614)