### PR TITLE
HBX-2614 - Check isNullable() in BasicPOJOClass::isRequiredInConstructor.

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/BasicPOJOClass.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/BasicPOJOClass.java
@@ -818,7 +818,9 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 			return false;
 		}
 		if(field.getValue()!=null) {			
-			if (!field.isOptional() && (field.getValueGenerationStrategy() == null || field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER))) {				
+			if (!(field.isOptional() || field.getValue().isNullable()) && 
+					(field.getValueGenerationStrategy() == null || 
+					 field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER))) {				
 				return true;
 			} else if (field.getValue() instanceof Component) {
 				Component c = (Component) field.getValue();


### PR DESCRIPTION
Restores previous Minimal Constructors behavior lost when isNullable() check removed from core org.hibernate.mapping.Property.isOptional().
