### PR TITLE
HBX-2614 - Check isNullable() in BasicPOJOClass::isRequiredInConstructor.

### DIFF
--- a/main/src/main/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
+++ b/main/src/main/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
@@ -825,7 +825,9 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 			return false;
 		}
 		if(field.getValue()!=null) {			
-			if (!field.isOptional() && (field.getValueGenerationStrategy() == null || field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER))) {				
+			if (!(field.isOptional() || field.getValue().isNullable()) && 
+					(field.getValueGenerationStrategy() == null || 
+					 field.getValueGenerationStrategy().getGenerationTiming().equals(GenerationTiming.NEVER))) {				
 				return true;
 			} else if (field.getValue() instanceof Component) {
 				Component c = (Component) field.getValue();


### PR DESCRIPTION
Restores previous Minimal Constructors behavior lost when isNullable() check removed from core org.hibernate.mapping.Property.isOptional().
