### PR TITLE
Remove floating point types from types advertised to support precision & scale

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/BasicColumnProcessor.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/reveng/reader/BasicColumnProcessor.java
@@ -85,12 +85,12 @@ public class BasicColumnProcessor {
                 	if(JdbcToHibernateTypeHelper.typeHasLength(sqlType) ) {
                 		column.setLength(size);
                 	} 
-                	if(JdbcToHibernateTypeHelper.typeHasScaleAndPrecision(sqlType) ) {
+                	if(JdbcToHibernateTypeHelper.typeHasPrecision(sqlType) ) {
                 		column.setPrecision(size); 
                 	}
 				} 
                 if(intBounds(decimalDigits) ) {
-                	if(JdbcToHibernateTypeHelper.typeHasScaleAndPrecision(sqlType) ) {
+                	if(JdbcToHibernateTypeHelper.typeHasScale(sqlType) ) {
                 		column.setScale(decimalDigits);
                 	}
 				}

--- a/orm/src/main/java/org/hibernate/tool/internal/util/JdbcToHibernateTypeHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/util/JdbcToHibernateTypeHelper.java
@@ -183,17 +183,25 @@ public final class JdbcToHibernateTypeHelper {
 			 * @throws SQLException
 			 */
 			
-	//		 scale and precision have numeric column
-    public static boolean typeHasScaleAndPrecision(int sqlType) {
-    	return (sqlType == Types.DECIMAL || sqlType == Types.NUMERIC
-    			|| sqlType == Types.REAL || sqlType == Types.FLOAT || sqlType == Types.DOUBLE);
-    }
-    
-    // length is for string column
-    public static boolean typeHasLength(int sqlType) {
-    	return (sqlType == Types.CHAR || sqlType == Types.DATE
-    			|| sqlType == Types.LONGVARCHAR || sqlType == Types.TIME || sqlType == Types.TIMESTAMP
-    			|| sqlType == Types.VARCHAR );
-    }
-}
+	// scale is for non floating point numeric columns
+	public static boolean typeHasScale(int sqlType) {
+		return (sqlType == Types.DECIMAL || sqlType == Types.NUMERIC);
+	}
 
+	// precision is for numeric columns
+	public static boolean typeHasPrecision(int sqlType) {
+		return (sqlType == Types.DECIMAL || sqlType == Types.NUMERIC
+				|| sqlType == Types.REAL || sqlType == Types.FLOAT || sqlType == Types.DOUBLE);
+	}
+
+	public static boolean typeHasScaleAndPrecision(int sqlType) {
+		return typeHasScale(sqlType) && typeHasPrecision(sqlType);
+	}
+
+	// length is for string columns
+	public static boolean typeHasLength(int sqlType) {
+		return (sqlType == Types.CHAR || sqlType == Types.DATE
+				|| sqlType == Types.LONGVARCHAR || sqlType == Types.TIME || sqlType == Types.TIMESTAMP
+				|| sqlType == Types.VARCHAR );
+	}
+}


### PR DESCRIPTION
Related to HBX-1408

This PR fixes an inconsistency in Java entities generation. Indeed `hibernate-tools` generate entities whose floating point type fields are annotated with a `@Type` with `scale` and `precision` parameters. However these parameters are not relevant and generate `IllegalArgumentException` as per https://github.com/hibernate/hibernate-orm/blob/7c58fe9a16eb15e5d1432e4bb3434c89cf214e16/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java#L5097-L5112.

This PR changes `JdbcToHibernateTypeHelper` so that `typeHasScaleAndPrecision` do not advertise these types to support scale and precision.