### PR TITLE
HBX-2732: Create Interface for ArtifactCollectorWrapper

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactory.java
@@ -15,6 +15,7 @@ import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.hibernate.tool.internal.export.query.QueryExporter;
+import org.hibernate.tool.orm.jbt.api.ArtifactCollectorWrapper;
 import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.util.ReflectUtil;
@@ -67,8 +68,8 @@ public class ExporterWrapperFactory {
 					ExporterConstants.METADATA_DESCRIPTOR, 
 					new ConfigurationMetadataDescriptor(configuration));
 		}
-		default void setArtifactCollector(ArtifactCollector artifactCollector) {
-			getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollector);
+		default void setArtifactCollector(ArtifactCollectorWrapper artifactCollectorWrapper) {
+			getProperties().put(ExporterConstants.ARTIFACT_COLLECTOR, artifactCollectorWrapper.getWrappedObject());
 		}
 		default void setOutputDirectory(File dir) {
 			getProperties().put(ExporterConstants.DESTINATION_FOLDER, dir);

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactory.java
@@ -27,9 +27,9 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
-import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
+import org.hibernate.tool.orm.jbt.internal.factory.ArtifactCollectorWrapperFactory;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.MetadataHelper;
@@ -42,7 +42,7 @@ public class WrapperFactory {
 	private WrapperFactory() {}
 
 	public static Object createArtifactCollectorWrapper() {
-		return new DefaultArtifactCollector();
+		return ArtifactCollectorWrapperFactory.createArtifactCollectorWrapper();
 	}
 	
 	public static Object createCfg2HbmWrapper() {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/ExporterWrapperFactoryTest.java
@@ -13,15 +13,15 @@ import java.lang.reflect.Field;
 import java.util.Properties;
 
 import org.hibernate.cfg.Configuration;
-import org.hibernate.tool.api.export.ArtifactCollector;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.internal.export.common.AbstractExporter;
-import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.hibernate.tool.internal.export.query.QueryExporter;
+import org.hibernate.tool.orm.jbt.api.ArtifactCollectorWrapper;
+import org.hibernate.tool.orm.jbt.internal.factory.ArtifactCollectorWrapperFactory;
 import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.wrp.DdlExporterWrapperFactory.DdlExporterWrapper;
@@ -93,10 +93,11 @@ public class ExporterWrapperFactoryTest {
 	
 	@Test
 	public void testSetArtifactCollector() {
-		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
-		assertNotSame(artifactCollector, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
-		exporterWrapper.setArtifactCollector(artifactCollector);
-		assertSame(artifactCollector, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
+		ArtifactCollectorWrapper artifactCollectorWrapper = ArtifactCollectorWrapperFactory.createArtifactCollectorWrapper();
+		Object wrappedArtifactCollector = artifactCollectorWrapper.getWrappedObject();
+		assertNotSame(wrappedArtifactCollector, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
+		exporterWrapper.setArtifactCollector(artifactCollectorWrapper);
+		assertSame(wrappedArtifactCollector, exporterWrapper.getWrappedObject().getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
 	}
 	
 	@Test

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/wrp/WrapperFactoryTest.java
@@ -38,6 +38,7 @@ import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
+import org.hibernate.tool.api.export.ArtifactCollector;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
@@ -69,7 +70,9 @@ public class WrapperFactoryTest {
 	public void testCreateArtifactCollectorWrapper() {
 		Object artifactCollectorWrapper = WrapperFactory.createArtifactCollectorWrapper();
 		assertNotNull(artifactCollectorWrapper);
-		assertTrue(artifactCollectorWrapper instanceof DefaultArtifactCollector);
+		assertTrue(artifactCollectorWrapper instanceof Wrapper);
+		Object wrappedArtifactCollector = ((Wrapper)artifactCollectorWrapper).getWrappedObject();
+		assertTrue(wrappedArtifactCollector instanceof ArtifactCollector);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Modify method 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createArtifactCollectorWrapper()' to delegate to 'ArtifactCollectorWrapperFactory'
  - Modify test 'org.hibernate.tool.orm.jbt.wrp.WrapperFactoryTest#testCreateArtifactCollectorWrapper()' accordingly
  - Modify method 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactory.ExporterWrapper#setArtifactCollector(...)' to take 'ArtifactExporterWrapper' as argument
  - Modify test 'org.hibernate.tool.orm.jbt.wrp.ExporterWrapperFactoryTest#testSetArtifactCollector()' accordingly

