### PR TITLE
HBX-2732: Create Interface for ArtifactCollectorWrapper

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/api/ArtifactCollectorWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/api/ArtifactCollectorWrapper.java
@@ -8,9 +8,8 @@ import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 
 public interface ArtifactCollectorWrapper extends Wrapper {
 
-	default ArtifactCollector getWrappedObject() { return (ArtifactCollector)getWrappedObject();}
-	default Set<String> getFileTypes() { return getWrappedObject().getFileTypes(); }
-	default void formatFiles() { getWrappedObject().formatFiles(); }
-	default File[] getFiles(String string) { return getWrappedObject().getFiles(string); }
+	default Set<String> getFileTypes() { return ((ArtifactCollector)getWrappedObject()).getFileTypes(); }
+	default void formatFiles() { ((ArtifactCollector)getWrappedObject()).formatFiles(); }
+	default File[] getFiles(String string) { return ((ArtifactCollector)getWrappedObject()).getFiles(string); }
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/ArtifactCollectorWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/ArtifactCollectorWrapperTest.java
@@ -36,7 +36,7 @@ public class ArtifactCollectorWrapperTest {
 	@BeforeEach
 	public void beforeEach() throws Exception {
 		wrapper = ArtifactCollectorWrapperFactory.createArtifactCollectorWrapper();
-		ArtifactCollector wrapped = wrapper.getWrappedObject();
+		ArtifactCollector wrapped = (ArtifactCollector)wrapper.getWrappedObject();
 		Field filesField = wrapped.getClass().getDeclaredField("files");
 		filesField.setAccessible(true);
 		filesMap = (Map<String, List<File>>)filesField.get(wrapped);


### PR DESCRIPTION
  - Remove unneeded override of method 'getWrappedObject()'
