### PR TITLE
HBX-2740: Create Interface for CollectionMetadataWrapper

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/api/CollectionMetadataWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/api/CollectionMetadataWrapper.java
@@ -1,0 +1,7 @@
+package org.hibernate.tool.orm.jbt.api;
+
+import org.hibernate.tool.orm.jbt.wrp.Wrapper;
+
+public interface CollectionMetadataWrapper extends Wrapper {
+
+}

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/CollectionMetadataWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/CollectionMetadataWrapperFactory.java
@@ -1,0 +1,14 @@
+package org.hibernate.tool.orm.jbt.internal.factory;
+
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.tool.orm.jbt.api.CollectionMetadataWrapper;
+
+public class CollectionMetadataWrapperFactory {
+
+	public static CollectionMetadataWrapper createCollectionMetadataWrapper(final CollectionPersister collectionPersister) {
+		return new CollectionMetadataWrapper() {
+			@Override public CollectionPersister getWrappedObject() { return collectionPersister; }
+		};
+	}
+	
+}

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/CollectionMetadataWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/CollectionMetadataWrapperTest.java
@@ -1,0 +1,78 @@
+package org.hibernate.tool.orm.jbt.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.tool.orm.jbt.internal.factory.CollectionMetadataWrapperFactory;
+import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.util.MockDialect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class CollectionMetadataWrapperTest {
+
+	private static final String TEST_CFG_XML_STRING =
+			"<hibernate-configuration>" +
+			"  <session-factory>" + 
+			"    <property name='" + AvailableSettings.DIALECT + "'>" + MockDialect.class.getName() + "</property>" +
+			"    <property name='" + AvailableSettings.CONNECTION_PROVIDER + "'>" + MockConnectionProvider.class.getName() + "</property>" +
+			"  </session-factory>" +
+			"</hibernate-configuration>";
+	
+	private static final String TEST_HBM_XML_STRING =
+			"<hibernate-mapping package='org.hibernate.tool.orm.jbt.api'>" +
+			"  <class name='CollectionMetadataWrapperTest$Foo'>" + 
+			"    <id name='id' access='field' />" +
+			"    <set name='bars' access='field' >" +
+			"      <key column='barId' />" +
+			"      <element column='barVal' type='string' />" +
+			"    </set>" +
+			"  </class>" +
+			"</hibernate-mapping>";
+	
+	public static class Foo {
+		public String id;
+		public Set<String> bars = new HashSet<String>();
+	}
+	
+	@TempDir
+	public File tempDir;
+	
+	private CollectionMetadataWrapper collectionMetadataWrapper = null;
+	
+	@BeforeEach
+	public void beforeEach() throws Exception {
+		tempDir = Files.createTempDirectory("temp").toFile();
+		File cfgXmlFile = new File(tempDir, "hibernate.cfg.xml");
+		FileWriter fileWriter = new FileWriter(cfgXmlFile);
+		fileWriter.write(TEST_CFG_XML_STRING);
+		fileWriter.close();
+		File hbmXmlFile = new File(tempDir, "Foo.hbm.xml");
+		fileWriter = new FileWriter(hbmXmlFile);
+		fileWriter.write(TEST_HBM_XML_STRING);
+		fileWriter.close();
+		Configuration configuration = new Configuration();
+		configuration.addFile(hbmXmlFile);
+		configuration.configure(cfgXmlFile);
+		SessionFactory sessionFactory = configuration.buildSessionFactory();
+		CollectionPersister collectionPersister = ((SessionFactoryImplementor)sessionFactory)
+				.getMappingMetamodel().getCollectionDescriptor(Foo.class.getName() + ".bars");
+		collectionMetadataWrapper = CollectionMetadataWrapperFactory.createCollectionMetadataWrapper(collectionPersister);
+	}
+	
+	@Test
+	public void testConstruction() {
+		assertNotNull(collectionMetadataWrapper);
+	}
+}


### PR DESCRIPTION
  - Create new initial test class 'org.hibernate.tool.orm.jbt.api.CollectionMetadataWrapperTest'
  - Create new initial interface class 'org.hibernate.tool.orm.jbt.api.CollectionMetadataWrapper'
  - Create new factory class 'org.hibernate.tool.orm.jbt.internal.factory.CollectionMetadataWrapperFactory'
