### PR TITLE
HBX-2740: Create Interface for CollectionMetadataWrapper

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/api/CollectionMetadataWrapper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/api/CollectionMetadataWrapper.java
@@ -1,7 +1,11 @@
 package org.hibernate.tool.orm.jbt.api;
 
+import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
+import org.hibernate.type.Type;
 
 public interface CollectionMetadataWrapper extends Wrapper {
+	
+	default Type getElementType() { return ((CollectionPersister)getWrappedObject()).getElementType(); }
 
 }

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/CollectionMetadataWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/CollectionMetadataWrapperTest.java
@@ -1,5 +1,6 @@
 package org.hibernate.tool.orm.jbt.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
@@ -75,4 +76,10 @@ public class CollectionMetadataWrapperTest {
 	public void testConstruction() {
 		assertNotNull(collectionMetadataWrapper);
 	}
+	
+	@Test
+	public void testGetElementType() {
+		assertEquals("string", collectionMetadataWrapper.getElementType().getName());
+	}
+
 }


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.orm.jbt.api.CollectionMetadataWrapperTest#testGetElementType()'
  - Add new default interface method 'org.hibernate.tool.orm.jbt.api.CollectionMetadataWrapper#getElementType()'
