### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/build.gradle
+++ b/gradle/plugin/build.gradle
@@ -23,9 +23,13 @@ java {
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
+
+    implementation 'org.hibernate.tool:hibernate-tools-orm:6.6.0-SNAPSHOT'
+
     // Use JUnit Jupiter for testing.
     testImplementation libs.junit.jupiter
 

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Plugin.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Plugin.java
@@ -1,11 +1,10 @@
 package org.hibernate.tool.gradle;
 
 import org.gradle.api.Project;
+import org.hibernate.tool.gradle.task.GenerateJavaTask;
 
 public class Plugin implements org.gradle.api.Plugin<Project> {
     public void apply(Project project) {
-         project.getTasks().register("hibernate", task -> {
-            task.doLast(s -> System.out.println("Hello from plugin 'org.hibernate.tool.gradle.Plugin'"));
-        });
+    	project.getTasks().register("hbm2java", GenerateJavaTask.class);
     }
 }

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -1,0 +1,15 @@
+package org.hibernate.tool.gradle.task;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+public class GenerateJavaTask extends DefaultTask {
+	
+	@TaskAction
+	public void generate() {
+		getLogger().lifecycle("Starting Task 'GenerateJavaTask'");
+		System.out.println("I am now generating Java files");
+		getLogger().lifecycle("Ending Task 'GenerateJavaTask");
+	}
+
+}


### PR DESCRIPTION
  - Add a new (empty) Task 'org.hibernate.tool.gradle.task.GenerateJavaTask'
  - Register the above task in 'org.hibernate.tool.gradle.Plugin'
  - Add a dependency on 'org.hibernate.tool:hibernate-tools-orm'
  - Also use the local Maven repo for the SNAPSHOT dependencies
