### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/build.gradle
+++ b/gradle/plugin/build.gradle
@@ -12,7 +12,6 @@ plugins {
 }
 
 group = 'org.hibernate.tool'
-version = '1.0'
 
 java {
     toolchain {
@@ -28,7 +27,7 @@ repositories {
 
 dependencies {
 
-    implementation 'org.hibernate.tool:hibernate-tools-orm:6.6.0-SNAPSHOT'
+    implementation "org.hibernate.tool:hibernate-tools-orm:$version"
 
     // Use JUnit Jupiter for testing.
     testImplementation libs.junit.jupiter

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/GenerateJavaFunctionalTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/GenerateJavaFunctionalTest.java
@@ -99,7 +99,7 @@ public class GenerateJavaFunctionalTest {
 
         // Verify the result
         File generatedSourcesFolder = new File(projectDir, "generated-sources");
-        assertTrue(result.getOutput().contains("Starting POJO export to directory: " + generatedSourcesFolder.getAbsolutePath()));
+        assertTrue(result.getOutput().contains("Starting POJO export to directory: " + generatedSourcesFolder.getCanonicalPath()));
         assertTrue(generatedSourcesFolder.exists());
         assertTrue(generatedSourcesFolder.isDirectory());
         File fooFile = new File(generatedSourcesFolder, "Foo.java");

--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 - 2024 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.hibernate.tool</groupId>
+      <artifactId>hibernate-tools-parent</artifactId>
+      <version>7.0.0-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>hibernate-tools-gradle</artifactId>
+
+   <properties>
+       <gradle.executable>./gradlew</gradle.executable>
+   </properties>
+   
+   <build>
+      <plugins>
+        <!-- execute Gradle command -->
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+			<artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>gradle</id>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <executable>${gradle.executable}</executable>
+                            <arguments>
+                                <argument>clean</argument>
+                                <argument>build</argument>
+ <!--                           <argument>-Pgroup=${project.groupId}</argument> -->
+                                <argument>-Pversion=${project.version}</argument>
+                            </arguments>
+                        </configuration>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+		 </plugin>
+      </plugins>
+   </build>
+
+</project>


### PR DESCRIPTION
  - Fix a test issue involving absolute/canonical path confusion
  - Add the gradle plugin to the main Maven build
  - Forward ${project.version} as the $version argument for the gradle build in 'gradle/pom.xml'
  - Delete the version variable in 'gradle/plugin/build.gradle' and use the forwarded $version variable
