### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/AbstractTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/AbstractTask.java
@@ -1,6 +1,15 @@
 package org.hibernate.tool.gradle.task;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Set;
+
 import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.tasks.Internal;
 import org.hibernate.tool.gradle.Extension;
 
@@ -16,5 +25,40 @@ public abstract class AbstractTask extends DefaultTask {
 	Extension getExtension() {
 		return this.extension;
 	}
+	
+	void perform() {
+		getLogger().lifecycle("Starting Task '" + getName() + "'");
+		ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
+		try {
+			Thread.currentThread().setContextClassLoader(
+					new URLClassLoader(
+							resolveProjectClassPath(), 
+							oldLoader));
+			doWork();
+		} finally {
+			Thread.currentThread().setContextClassLoader(oldLoader);
+			getLogger().lifecycle("Ending Task '" + getName() + "'");
+		}
+	}
+	
+	URL[] resolveProjectClassPath() {
+		try {
+			ConfigurationContainer cc = getProject().getConfigurations();
+			Configuration defaultConf = cc.getByName("compileClasspath");
+			ResolvedConfiguration resolvedConf = defaultConf.getResolvedConfiguration();
+			Set<ResolvedArtifact> ras = resolvedConf.getResolvedArtifacts();
+			ResolvedArtifact[] resolvedArtifacts = ras.toArray(new ResolvedArtifact[ras.size()]);
+			URL[] urls = new URL[ras.size()];
+			for (int i = 0; i < ras.size(); i++) {
+				urls[i] = resolvedArtifacts[i].getFile().toURI().toURL();
+			}
+			return urls;
+		} catch (MalformedURLException e) {
+			getLogger().error("MalformedURLException while compiling project classpath");
+			throw new RuntimeException(e);
+		}
+	}
+	
+	abstract void doWork();
 
 }

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -4,17 +4,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Properties;
-import java.util.Set;
 
 import org.apache.tools.ant.BuildException;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.tasks.TaskAction;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
@@ -30,18 +22,7 @@ public class GenerateJavaTask extends AbstractTask {
 
 	@TaskAction
 	public void performTask() {
-		getLogger().lifecycle("Starting Task 'GenerateJavaTask'");
-		ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
-		try {
-			Thread.currentThread().setContextClassLoader(
-					new URLClassLoader(
-							resolveProjectClassPath(), 
-							oldLoader));
-			generate();
-		} finally {
-			Thread.currentThread().setContextClassLoader(oldLoader);
-			getLogger().lifecycle("Ending Task 'GenerateJavaTask");
-		}
+		super.perform();
 	}
 
 	private RevengStrategy setupReverseEngineeringStrategy() {
@@ -84,25 +65,7 @@ public class GenerateJavaTask extends AbstractTask {
 		getLogger().lifecycle("POJO export finished");
 	}
 	
-	private URL[] resolveProjectClassPath() {
-		try {
-			ConfigurationContainer cc = getProject().getConfigurations();
-			Configuration defaultConf = cc.getByName("compileClasspath");
-			ResolvedConfiguration resolvedConf = defaultConf.getResolvedConfiguration();
-			Set<ResolvedArtifact> ras = resolvedConf.getResolvedArtifacts();
-			ResolvedArtifact[] resolvedArtifacts = ras.toArray(new ResolvedArtifact[ras.size()]);
-			URL[] urls = new URL[ras.size()];
-			for (int i = 0; i < ras.size(); i++) {
-				urls[i] = resolvedArtifacts[i].getFile().toURI().toURL();
-			}
-			return urls;
-		} catch (MalformedURLException e) {
-			getLogger().error("MalformedURLException while compiling project classpath");
-			throw new RuntimeException(e);
-		}
-	}
-	
-	private void generate() {
+	void doWork() {
 		File propertyFile = getPropertyFile();
 		if (propertyFile.exists()) {
 			executeExporter(

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/RunSqlTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/RunSqlTask.java
@@ -8,58 +8,21 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-import java.util.Set;
 
 import org.apache.tools.ant.BuildException;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.tasks.TaskAction;
 
 public class RunSqlTask extends AbstractTask {
 	
 	@TaskAction
 	public void performTask() {
-		getLogger().lifecycle("Starting Task 'RunSqlTask'");
-		ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
-		try {
-			Thread.currentThread().setContextClassLoader(
-					new URLClassLoader(
-							resolveProjectClassPath(), 
-							oldLoader));
-			runSql();
-		} finally {
-			Thread.currentThread().setContextClassLoader(oldLoader);
-			getLogger().lifecycle("Ending Task 'RunSqlTask");
-		}
-	}
-	
-	private URL[] resolveProjectClassPath() {
-		try {
-			ConfigurationContainer cc = getProject().getConfigurations();
-			Configuration defaultConf = cc.getByName("compileClasspath");
-			ResolvedConfiguration resolvedConf = defaultConf.getResolvedConfiguration();
-			Set<ResolvedArtifact> ras = resolvedConf.getResolvedArtifacts();
-			ResolvedArtifact[] resolvedArtifacts = ras.toArray(new ResolvedArtifact[ras.size()]);
-			URL[] urls = new URL[ras.size()];
-			for (int i = 0; i < ras.size(); i++) {
-				urls[i] = resolvedArtifacts[i].getFile().toURI().toURL();
-			}
-			return urls;
-		} catch (MalformedURLException e) {
-			getLogger().error("MalformedURLException while compiling project classpath");
-			throw new RuntimeException(e);
-		}
+		super.perform();
 	}
 	
 	private File getPropertyFile() {
@@ -79,7 +42,7 @@ public class RunSqlTask extends AbstractTask {
 		}
 	}
 	
-	private void runSql() {
+	void doWork() {
 		Properties properties = loadPropertiesFile(getPropertyFile());
 		registerDriver(properties.getProperty("hibernate.connection.driver_class"));
 		try {


### PR DESCRIPTION
  - Pull up methods 'perform()' and 'resolveProjectClassPath()' to class 'AbstractTask' and remove them from 'GenerateJavaTask' and 'RunSqlTask'
  - Create abstract method 'doWork()' in AbstractTask'
  - Rename 'GenerateJavaTask#generate()' and 'RunSqlTask#runSql' to 'doWork()'
  - Add following test methods to 'AbstractTaskTest'
    * testPerform()
    * testResolveProjectClassPath()
