### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/RunSqlTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/RunSqlTask.java
@@ -22,11 +22,15 @@ public class RunSqlTask extends AbstractTask {
 	
 	private Properties hibernateProperties = null;
 	
-	private String getHibernateProperty(String name) {
+	private Properties getHibernateProperties() {
 		if (hibernateProperties == null) {
 			loadPropertiesFile(getPropertyFile());
 		}
-		return hibernateProperties.getProperty(name);
+		return hibernateProperties;
+	}
+	
+	private String getHibernateProperty(String name) {
+		return getHibernateProperties().getProperty(name);
 	}
 	
 	private File getPropertyFile() {


### PR DESCRIPTION
  - Refactoring of task 'org.hibernate.tool.gradle.task.GenerateJavaTask 
    * Maintain the Hibernate properties in a dedicated instance variable that's lazily initialized 
    * Remove arguments from method 'GenerateJavaTask#createJdbcDescriptor()' and look up this info in the body of the method 
    * Move the logic of method 'GenerateJavaTask#executeExporter(MetadataDescriptor)' to method 'GenerateJavaTask#doWork()'
  - Refactoring of task 'org.hibernate.tool.gradle.task.RunSqlTask'
    * Add a method 'RunSqlTask#getHibernateProperty(String)' as convenience
