### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -1,12 +1,8 @@
 package org.hibernate.tool.gradle.task;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.Properties;
 
-import org.apache.tools.ant.BuildException;
 import org.gradle.api.tasks.TaskAction;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
@@ -20,34 +16,6 @@ import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 
 public class GenerateJavaTask extends AbstractTask {
 
-	private Properties hibernateProperties = null;
-	
-	private Properties getHibernateProperties() {
-		if (hibernateProperties == null) {
-			loadPropertiesFile(getPropertyFile());
-		}
-		return hibernateProperties;
-	}
-	
-	private File getPropertyFile() {
-		return new File(getProject().getProjectDir(), "src/main/resources/hibernate.properties");
-	}
-
-	private void loadPropertiesFile(File propertyFile) {
-		getLogger().lifecycle("Loading the properties file : " + propertyFile.getPath());
-		try (FileInputStream is = new FileInputStream(propertyFile)) {
-			hibernateProperties = new Properties();
-			hibernateProperties.load(is);
-			getLogger().lifecycle("Properties file is loaded");
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-			throw new BuildException(propertyFile + " not found.", e);
-		} catch (IOException e) {
-			e.printStackTrace();
-			throw new BuildException("Problem while loading " + propertyFile, e);
-		}
-	}
-	
 	@TaskAction
 	public void performTask() {
 		super.perform();

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/RunSqlTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/RunSqlTask.java
@@ -1,9 +1,5 @@
 package org.hibernate.tool.gradle.task;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -13,44 +9,10 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Properties;
 
-import org.apache.tools.ant.BuildException;
 import org.gradle.api.tasks.TaskAction;
 
 public class RunSqlTask extends AbstractTask {
-	
-	private Properties hibernateProperties = null;
-	
-	private Properties getHibernateProperties() {
-		if (hibernateProperties == null) {
-			loadPropertiesFile(getPropertyFile());
-		}
-		return hibernateProperties;
-	}
-	
-	private String getHibernateProperty(String name) {
-		return getHibernateProperties().getProperty(name);
-	}
-	
-	private File getPropertyFile() {
-		return new File(getProject().getProjectDir(), "src/main/resources/hibernate.properties");
-	}
-
-	private void loadPropertiesFile(File propertyFile) {
-		getLogger().lifecycle("Loading the properties file : " + propertyFile.getPath());
-		try (FileInputStream is = new FileInputStream(propertyFile)) {
-			hibernateProperties = new Properties();
-			hibernateProperties.load(is);
-			getLogger().lifecycle("Properties file is loaded");
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-			throw new BuildException(propertyFile + " not found.", e);
-		} catch (IOException e) {
-			e.printStackTrace();
-			throw new BuildException("Problem while loading " + propertyFile, e);
-		}
-	}
 	
 	@TaskAction
 	public void performTask() {


### PR DESCRIPTION
  - Pull up the management of the Hibernate properties to class 'org.hibernate.tool.gradle.task.AbstractTask'
  - Remove the management of Hibernate properties from 'GenerateJavaTask' and 'RunSqlTask'
