### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/RunSqlFunctionalTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/RunSqlFunctionalTest.java
@@ -31,7 +31,7 @@ class RunSqlFunctionalTest {
     private File getHibernatePropertiesFile() {
     	File resourcesDir = new File(projectDir, "src/main/resources");
     	resourcesDir.mkdirs();
-    	return new File(resourcesDir, "hibernate.properties");
+    	return new File(resourcesDir, "foo.bar");
     }
     
     @Test 
@@ -73,6 +73,7 @@ class RunSqlFunctionalTest {
             "}\n" +
             "hibernateTools {\n" +
             "  sqlToRun = 'create table foo (id int not null primary key, baz varchar(256))'\n" +
+            "  hibernateProperties = 'foo.bar'" +
             "}\n";
     
     private static final String HIBERNATE_PROPERTIES_CONTENTS = 

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
@@ -5,6 +5,7 @@ import org.gradle.api.Project;
 public class Extension {
 	
 	public String sqlToRun = "";
+	public String hibernateProperties = "hibernate.properties";
 	
 	public Extension(Project project) {}
 	

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Plugin.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Plugin.java
@@ -12,6 +12,8 @@ public class Plugin implements org.gradle.api.Plugin<Project> {
     	project.getTasks().register("runSql", RunSqlTask.class);
     	RunSqlTask runSqlTask = (RunSqlTask)project.getTasks().getByName("runSql");
     	runSqlTask.doFirst(w -> runSqlTask.initialize(extension));
+    	GenerateJavaTask generateJavaTask = (GenerateJavaTask)project.getTasks().getByName("generateJava");
+    	generateJavaTask.doFirst(w -> generateJavaTask.initialize(extension));
     }
     
 }

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/AbstractTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/AbstractTask.java
@@ -83,7 +83,7 @@ public abstract class AbstractTask extends DefaultTask {
 	}
 	
 	private File getPropertyFile() {
-		String hibernatePropertiesFile = "hibernate.properties";
+		String hibernatePropertiesFile = getExtension().hibernateProperties;
 		SourceSetContainer ssc = getProject().getExtensions().getByType(SourceSetContainer.class);
 		SourceSet ss = ssc.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 		SourceDirectorySet sds = ss.getResources();


### PR DESCRIPTION
  - Add new configuration property 'hibernateProperties' to 'org.hibernate.tool.gradle.Extension'
  - Read the name of the hibernate properties file from the extension in 'org.hibernate.tool.gradle.task.AbstractTask#getPropertyFile()'
  - Properly initialize the 'GenerateJavaTask' created in 'org.hibernate.tool.gradle.Plugin'
  - Change functional test 'org.hibernate.tool.gradle.RunSqlFunctionalTest' to test the modifictations properly
