### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
@@ -6,6 +6,7 @@ public class Extension {
 	
 	public String sqlToRun = "";
 	public String hibernateProperties = "hibernate.properties";
+	public String outputFolder = "generated-sources";
 	
 	public Extension(Project project) {}
 	

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Plugin.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Plugin.java
@@ -1,19 +1,28 @@
 package org.hibernate.tool.gradle;
 
+import java.util.Map;
+
 import org.gradle.api.Project;
+import org.hibernate.tool.gradle.task.AbstractTask;
 import org.hibernate.tool.gradle.task.GenerateJavaTask;
 import org.hibernate.tool.gradle.task.RunSqlTask;
 
 public class Plugin implements org.gradle.api.Plugin<Project> {
 	
-    public void apply(Project project) {
+	private static Map<String, Class<?>> PLUGIN_TASK_MAP = Map.of(
+			"runSql", RunSqlTask.class,
+			"generateJava", GenerateJavaTask.class
+		);
+	
+    @SuppressWarnings("unchecked")
+	public void apply(Project project) {
     	Extension extension =  project.getExtensions().create("hibernateTools", Extension.class, project);
-    	project.getTasks().register("generateJava", GenerateJavaTask.class);
-    	project.getTasks().register("runSql", RunSqlTask.class);
-    	RunSqlTask runSqlTask = (RunSqlTask)project.getTasks().getByName("runSql");
-    	runSqlTask.doFirst(w -> runSqlTask.initialize(extension));
-    	GenerateJavaTask generateJavaTask = (GenerateJavaTask)project.getTasks().getByName("generateJava");
-    	generateJavaTask.doFirst(w -> generateJavaTask.initialize(extension));
+    	for (String key : PLUGIN_TASK_MAP.keySet()) {
+    		Class<?> taskClass = PLUGIN_TASK_MAP.get(key);
+    		project.getTasks().register(key, (Class<AbstractTask>)taskClass);
+    		AbstractTask task = (AbstractTask)project.getTasks().getByName(key);
+    		task.doFirst(w -> task.initialize(extension));
+    	}
     }
     
 }

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -40,7 +40,7 @@ public class GenerateJavaTask extends AbstractTask {
 	}
 
 	private File getOutputFolder() {
-		return new File(getProject().getProjectDir(), "generated-sources");
+		return new File(getProject().getProjectDir(), getExtension().outputFolder);
 	}
 	
 	private RevengStrategy setupReverseEngineeringStrategy() {


### PR DESCRIPTION
  - Add new configuration property 'outputFolder' to 'org.hibernate.tool.gradle.Extension' with default value 'generated-sources'
  - Use the 'outputFolder' property as the target folder in 'org.hibernate.tool.gradle.task.GenerateJavaTask'
  - Refactor class 'org.hibernate.tool.gradle.Plugin' to loop over a static Map to register and initialize the different provided tasks
