### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/GenerateJavaFunctionalTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/GenerateJavaFunctionalTest.java
@@ -46,6 +46,7 @@ public class GenerateJavaFunctionalTest {
             "  implementation('com.h2database:h2:2.1.214')\n" +
             "}\n" +
             "hibernateTools {\n" +
+            "  packageName = 'foo.model'" +
             "}\n";
 
 	@TempDir
@@ -102,7 +103,7 @@ public class GenerateJavaFunctionalTest {
         assertTrue(result.getOutput().contains("Starting POJO export to directory: " + generatedSourcesFolder.getCanonicalPath()));
         assertTrue(generatedSourcesFolder.exists());
         assertTrue(generatedSourcesFolder.isDirectory());
-        File fooFile = new File(generatedSourcesFolder, "Foo.java");
+        File fooFile = new File(generatedSourcesFolder, "foo/model/Foo.java");
         assertTrue(fooFile.exists());
         assertTrue(fooFile.isFile());
     }

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
@@ -7,6 +7,7 @@ public class Extension {
 	public String sqlToRun = "";
 	public String hibernateProperties = "hibernate.properties";
 	public String outputFolder = "generated-sources";
+	public String packageName = "";
 	
 	public Extension(Project project) {}
 	

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -11,6 +11,7 @@ import org.hibernate.tool.api.export.ExporterType;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 
@@ -44,7 +45,11 @@ public class GenerateJavaTask extends AbstractTask {
 	}
 	
 	private RevengStrategy setupReverseEngineeringStrategy() {
-		return new DefaultStrategy();
+		RevengStrategy result = new DefaultStrategy();
+		RevengSettings settings = new RevengSettings(result);
+		settings.setDefaultPackageName(getExtension().packageName);
+		result.setSettings(settings);
+		return result;
 	}
 
 }


### PR DESCRIPTION
  - Add new configuration property 'packageName' to 'org.hibernate.tool.gradle.Extension'
  - Use the 'packageName' property in 'org.hibernate.tool.gradle.task.GenerateJavaTask' to set the default package name for generated classes
  - Modify functional test 'org.hibernate.tool.gradle.GenerateJavaFunctionalTest' to test this added behaviour
