### PR TITLE
HBX-1232: Add gradle support

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/GenerateJavaFunctionalTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/GenerateJavaFunctionalTest.java
@@ -46,7 +46,7 @@ public class GenerateJavaFunctionalTest {
             "  implementation('com.h2database:h2:2.1.214')\n" +
             "}\n" +
             "hibernateTools {\n" +
-            "  packageName = 'foo.model'" +
+            "  packageName = 'foo.model'\n" +
             "}\n";
 
 	@TempDir

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
@@ -8,6 +8,7 @@ public class Extension {
 	public String hibernateProperties = "hibernate.properties";
 	public String outputFolder = "generated-sources";
 	public String packageName = "";
+	public String revengStrategy = null;
 	
 	public Extension(Project project) {}
 	

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -13,7 +13,7 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
+import org.hibernate.tool.api.reveng.RevengStrategyFactory;
 
 public class GenerateJavaTask extends AbstractTask {
 
@@ -45,11 +45,12 @@ public class GenerateJavaTask extends AbstractTask {
 	}
 	
 	private RevengStrategy setupReverseEngineeringStrategy() {
-		RevengStrategy result = new DefaultStrategy();
+		RevengStrategy result = RevengStrategyFactory
+				.createReverseEngineeringStrategy(getExtension().revengStrategy);
 		RevengSettings settings = new RevengSettings(result);
 		settings.setDefaultPackageName(getExtension().packageName);
 		result.setSettings(settings);
 		return result;
 	}
-
+	
 }

--- a/gradle/plugin/src/test/java/org/hibernate/tool/gradle/task/GenerateJavaTaskTest.java
+++ b/gradle/plugin/src/test/java/org/hibernate/tool/gradle/task/GenerateJavaTaskTest.java
@@ -1,0 +1,34 @@
+package org.hibernate.tool.gradle.task;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hibernate.tool.api.reveng.RevengStrategy;
+import org.hibernate.tool.gradle.Extension;
+import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
+import org.junit.jupiter.api.Test;
+
+public class GenerateJavaTaskTest {
+	
+	@Test
+	public void testSetupReverseEngineeringStrategy() throws Exception {
+		Project project = ProjectBuilder.builder().build();
+		Extension extension = new Extension(project);
+		extension.revengStrategy = FooStrategy.class.getName();
+		GenerateJavaTask generateJavaTask = project.getTasks().create("foo", GenerateJavaTask.class);
+		generateJavaTask.initialize(extension);
+		Method method = GenerateJavaTask.class.getDeclaredMethod(
+				"setupReverseEngineeringStrategy", 
+				new Class[] {});
+		method.setAccessible(true);
+		RevengStrategy revengStrategy = (RevengStrategy)method.invoke(generateJavaTask, new Object[] {});
+		assertTrue(revengStrategy instanceof FooStrategy);
+	}
+	
+	public static class FooStrategy extends AbstractStrategy {}
+	
+
+}


### PR DESCRIPTION
  - Add new configuration property 'revengStrategy' to 'org.hibernate.tool.gradle.Extension'
  - Use the 'revengStrategy' property in 'org.hibernate.tool.gradle.task.GenerateJavaTask' to create the RevengStrategy to use
  - Create a new unit test class 'org.hibernate.tool.gradle.task.GenerateJavaTask' and add a test to verify that the above behaviour works
