### PR TITLE
HBX-2835: Move classes from package 'org.hibernate.tool.orm.jbt.util' to package 'org.hibernate.tool.orm.jbt.internal.util'

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/HibernateToolsPersistenceProvider.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/HibernateToolsPersistenceProvider.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import java.util.Map;
 
@@ -7,7 +7,7 @@ import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
 
 public class HibernateToolsPersistenceProvider extends HibernatePersistenceProvider {
 
-	static EntityManagerFactoryBuilderImpl createEntityManagerFactoryBuilder(
+	public static EntityManagerFactoryBuilderImpl createEntityManagerFactoryBuilder(
 			final String persistenceUnit, 
 			final Map<Object, Object> properties) {
 		return new HibernateToolsPersistenceProvider()

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/JpaConfiguration.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/JpaConfiguration.java
@@ -17,6 +17,7 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.orm.jbt.api.wrp.SessionFactoryWrapper;
 import org.hibernate.tool.orm.jbt.internal.factory.SessionFactoryWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.util.ExtendedConfiguration;
+import org.hibernate.tool.orm.jbt.internal.util.HibernateToolsPersistenceProvider;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/HibernateToolsPersistenceProviderTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/HibernateToolsPersistenceProviderTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.util.Properties;
 
 import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
+import org.hibernate.tool.orm.jbt.internal.util.HibernateToolsPersistenceProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
  - Move class 'org.hibernate.tool.orm.jbt.util.HibernateToolsPersistenceProvider'
  - Move test class 'org.hibernate.tool.orm.jbt.util.HibernateToolsPersistenceProviderTest'
