### PR TITLE
HBX-2835: Move classes from package 'org.hibernate.tool.orm.jbt.util' to package 'org.hibernate.tool.orm.jbt.internal.util'

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/JpaMappingFileHelper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/JpaMappingFileHelper.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/JpaMappingFileHelperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/JpaMappingFileHelperTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,6 +9,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 
+import org.hibernate.tool.orm.jbt.internal.util.JpaMappingFileHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
  - Move class 'org.hibernate.tool.orm.jbt.util.JpaMappingFileHelper'
  - Move test class 'org.hibernate.tool.orm.jbt.util.JpaMappingFileHelperTest'
