### PR TITLE
HBX-2835: Move classes from package 'org.hibernate.tool.orm.jbt.util' to package 'org.hibernate.tool.orm.jbt.internal.util'

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/ColumnWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/ColumnWrapperFactory.java
@@ -6,8 +6,8 @@ import org.hibernate.mapping.Value;
 import org.hibernate.tool.orm.jbt.api.wrp.ColumnWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.ConfigurationWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.ValueWrapper;
+import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.internal.wrp.AbstractWrapper;
-import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 
 public class ColumnWrapperFactory {
 	

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/HqlCodeAssistWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/HqlCodeAssistWrapperFactory.java
@@ -6,8 +6,8 @@ import org.hibernate.tool.ide.completion.HQLCodeAssist;
 import org.hibernate.tool.orm.jbt.api.wrp.ConfigurationWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.HqlCodeAssistWrapper;
 import org.hibernate.tool.orm.jbt.internal.util.HqlCompletionRequestor;
+import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.internal.wrp.AbstractWrapper;
-import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 
 public class HqlCodeAssistWrapperFactory {
 

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/SchemaExportWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/SchemaExportWrapperFactory.java
@@ -7,8 +7,8 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.orm.jbt.api.wrp.ConfigurationWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.SchemaExportWrapper;
+import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.internal.wrp.AbstractWrapper;
-import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 import org.hibernate.tool.schema.TargetType;
 
 public class SchemaExportWrapperFactory {

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/ConfigurationMetadataDescriptor.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/ConfigurationMetadataDescriptor.java
@@ -5,7 +5,6 @@ import java.util.Properties;
 import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 
 public class ConfigurationMetadataDescriptor implements MetadataDescriptor {
 	

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/MetadataHelper.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/MetadataHelper.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/NativeConfiguration.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/util/NativeConfiguration.java
@@ -20,6 +20,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.orm.jbt.internal.util.ExtendedConfiguration;
+import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/factory/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/factory/WrapperFactoryTest.java
@@ -73,7 +73,7 @@ import org.hibernate.tool.orm.jbt.internal.factory.TableWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.internal.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.internal.util.JpaConfiguration;
-import org.hibernate.tool.orm.jbt.util.MetadataHelper;
+import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ConfigurationWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ConfigurationWrapperTest.java
@@ -36,7 +36,7 @@ import org.hibernate.tool.orm.jbt.internal.factory.ConfigurationWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.factory.NamingStrategyWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.factory.RevengStrategyWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.util.JpaConfiguration;
-import org.hibernate.tool.orm.jbt.util.MetadataHelper;
+import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/MetadataHelperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/MetadataHelperTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -13,6 +13,8 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.junit.jupiter.api.Test;
 
 public class MetadataHelperTest {
@@ -46,7 +48,7 @@ public class MetadataHelperTest {
 	     configuration.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
 	     configuration.setProperty(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
 	     Metadata metadata = MetadataHelper.getMetadata(configuration);
-	     assertNotNull(metadata.getEntityBinding("org.hibernate.tool.orm.jbt.util.MetadataHelperTest$Foo"));
+	     assertNotNull(metadata.getEntityBinding("org.hibernate.tool.orm.jbt.internal.util.MetadataHelperTest$Foo"));
 	}
 	
 	private static class MetadataMethodConfiguration extends Configuration {
@@ -89,7 +91,7 @@ public class MetadataHelperTest {
 			"<!DOCTYPE hibernate-mapping PUBLIC" +
 			"		'-//Hibernate/Hibernate Mapping DTD 3.0//EN'" +
 			"		'http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd'>" +
-			"<hibernate-mapping package='org.hibernate.tool.orm.jbt.util'>" +
+			"<hibernate-mapping package='org.hibernate.tool.orm.jbt.internal.util'>" +
 			"  <class name='MetadataHelperTest$Foo'>" + 
 			"    <id name='id'/>" +
 			"  </class>" +

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/NativeConfigurationTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/NativeConfigurationTest.java
@@ -24,6 +24,7 @@ import org.hibernate.cfg.NamingStrategy;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
+import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;


### PR DESCRIPTION
  - Move class 'org.hibernate.tool.orm.jbt.util.MetadataHelper'
  - Move test class 'org.hibernate.tool.orm.jbt.util.MetadataHelperTest'
