### PR TITLE
HBX-2835: Move classes from package 'org.hibernate.tool.orm.jbt.util' to package 'org.hibernate.tool.orm.jbt.internal.util'

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/DummyMetadataBuildingContext.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/DummyMetadataBuildingContext.java
@@ -11,7 +11,6 @@ import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 
 public class DummyMetadataBuildingContext {

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/MockConnectionProvider.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/MockConnectionProvider.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import java.sql.Array;
 import java.sql.Blob;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ClassMetadataWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ClassMetadataWrapperTest.java
@@ -20,7 +20,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.tool.orm.jbt.internal.factory.ClassMetadataWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.factory.SessionWrapperFactory;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.internal.NamedBasicTypeImpl;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/CollectionMetadataWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/CollectionMetadataWrapperTest.java
@@ -15,7 +15,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.tool.orm.jbt.internal.factory.CollectionMetadataWrapperFactory;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ColumnWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ColumnWrapperTest.java
@@ -16,7 +16,7 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.orm.jbt.internal.factory.ColumnWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.factory.ConfigurationWrapperFactory;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.junit.jupiter.api.BeforeEach;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ConfigurationWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ConfigurationWrapperTest.java
@@ -37,7 +37,7 @@ import org.hibernate.tool.orm.jbt.internal.factory.NamingStrategyWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.factory.RevengStrategyWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/SchemaExportWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/SchemaExportWrapperTest.java
@@ -14,7 +14,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.orm.jbt.internal.factory.ConfigurationWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.factory.SchemaExportWrapperFactory;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.schema.TargetType;
 import org.junit.jupiter.api.BeforeEach;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/SessionFactoryWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/SessionFactoryWrapperTest.java
@@ -19,7 +19,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.orm.jbt.internal.factory.SessionFactoryWrapperFactory;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/SessionWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/SessionWrapperTest.java
@@ -18,7 +18,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.query.Query;
 import org.hibernate.tool.orm.jbt.internal.factory.SessionWrapperFactory;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/ConfigurationMetadataDescriptorTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/ConfigurationMetadataDescriptorTest.java
@@ -10,7 +10,6 @@ import java.util.Properties;
 import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/JpaConfigurationTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/JpaConfigurationTest.java
@@ -30,7 +30,6 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.orm.jbt.internal.util.JpaConfiguration;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/MetadataHelperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/MetadataHelperTest.java
@@ -13,7 +13,6 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.junit.jupiter.api.Test;
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/MockConnectionProviderTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/MockConnectionProviderTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import java.sql.Connection;
 
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.junit.jupiter.api.Test;
 
 public class MockConnectionProviderTest {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/NativeConfigurationTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/util/NativeConfigurationTest.java
@@ -25,6 +25,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
+import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;


### PR DESCRIPTION
  - Move class 'org.hibernate.tool.orm.jbt.util.MockConnectionProvider'
  - Move test class 'org.hibernate.tool.orm.jbt.util.MockConnectionProviderTest'
