### PR TITLE
HBX-2835: Move classes from package 'org.hibernate.tool.orm.jbt.util' to package 'org.hibernate.tool.orm.jbt.internal.util'

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/ExporterWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/ExporterWrapperFactory.java
@@ -19,8 +19,8 @@ import org.hibernate.tool.orm.jbt.api.wrp.GenericExporterWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.QueryExporterWrapper;
 import org.hibernate.tool.orm.jbt.internal.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.internal.util.DummyMetadataDescriptor;
+import org.hibernate.tool.orm.jbt.internal.util.ReflectUtil;
 import org.hibernate.tool.orm.jbt.internal.wrp.AbstractWrapper;
-import org.hibernate.tool.orm.jbt.util.ReflectUtil;
 
 public class ExporterWrapperFactory {
 	

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/NamingStrategyWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/NamingStrategyWrapperFactory.java
@@ -2,8 +2,8 @@ package org.hibernate.tool.orm.jbt.internal.factory;
 
 import org.hibernate.cfg.NamingStrategy;
 import org.hibernate.tool.orm.jbt.api.wrp.NamingStrategyWrapper;
+import org.hibernate.tool.orm.jbt.internal.util.ReflectUtil;
 import org.hibernate.tool.orm.jbt.internal.wrp.AbstractWrapper;
-import org.hibernate.tool.orm.jbt.util.ReflectUtil;
 
 public class NamingStrategyWrapperFactory {
 	

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/RevengStrategyWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/RevengStrategyWrapperFactory.java
@@ -8,8 +8,8 @@ import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.orm.jbt.api.wrp.RevengSettingsWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.RevengStrategyWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.Wrapper;
+import org.hibernate.tool.orm.jbt.internal.util.ReflectUtil;
 import org.hibernate.tool.orm.jbt.internal.wrp.AbstractWrapper;
-import org.hibernate.tool.orm.jbt.util.ReflectUtil;
 
 public class RevengStrategyWrapperFactory {
 

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/ReflectUtil.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/ReflectUtil.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import java.lang.reflect.Constructor;
 


### PR DESCRIPTION
  - Move class 'org.hibernate.tool.orm.jbt.util.ReflectUtil'
