### PR TITLE
HBX-2835: Move classes from package 'org.hibernate.tool.orm.jbt.util' to package 'org.hibernate.tool.orm.jbt.internal.util'

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/ConfigurationWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/ConfigurationWrapperFactory.java
@@ -19,8 +19,8 @@ import org.hibernate.tool.orm.jbt.api.wrp.TableWrapper;
 import org.hibernate.tool.orm.jbt.internal.util.ExtendedConfiguration;
 import org.hibernate.tool.orm.jbt.internal.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.internal.util.NativeConfiguration;
+import org.hibernate.tool.orm.jbt.internal.util.RevengConfiguration;
 import org.hibernate.tool.orm.jbt.internal.wrp.AbstractWrapper;
-import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
 

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/RevengConfiguration.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/RevengConfiguration.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import java.io.File;
 import java.util.Collections;
@@ -13,7 +13,6 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.orm.jbt.internal.util.ExtendedConfiguration;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/factory/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/factory/WrapperFactoryTest.java
@@ -75,7 +75,7 @@ import org.hibernate.tool.orm.jbt.internal.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.internal.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.internal.util.NativeConfiguration;
-import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
+import org.hibernate.tool.orm.jbt.internal.util.RevengConfiguration;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 import org.junit.jupiter.api.Test;
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ConfigurationWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/ConfigurationWrapperTest.java
@@ -40,7 +40,7 @@ import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.internal.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.internal.util.MockDialect;
 import org.hibernate.tool.orm.jbt.internal.util.NativeConfiguration;
-import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
+import org.hibernate.tool.orm.jbt.internal.util.RevengConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/RevengConfigurationTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/RevengConfigurationTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -29,6 +29,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
+import org.hibernate.tool.orm.jbt.internal.util.RevengConfiguration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
  - Move class 'org.hibernate.tool.orm.jbt.util.RevengConfiguration'
  - Move test class 'org.hibernate.tool.orm.jbt.util.RevengConfigurationTest'
