### PR TITLE
HBX-2835: Move classes from package 'org.hibernate.tool.orm.jbt.util' to package 'org.hibernate.tool.orm.jbt.internal.util'

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/PersistentClassWrapperFactory.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/factory/PersistentClassWrapperFactory.java
@@ -20,8 +20,8 @@ import org.hibernate.tool.orm.jbt.api.wrp.PropertyWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.TableWrapper;
 import org.hibernate.tool.orm.jbt.api.wrp.ValueWrapper;
 import org.hibernate.tool.orm.jbt.internal.util.DummyMetadataBuildingContext;
+import org.hibernate.tool.orm.jbt.internal.util.SpecialRootClass;
 import org.hibernate.tool.orm.jbt.internal.wrp.AbstractWrapper;
-import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 
 public class PersistentClassWrapperFactory {
 	

--- a/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/SpecialRootClass.java
+++ b/jbt/src/main/java/org/hibernate/tool/orm/jbt/internal/util/SpecialRootClass.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import java.lang.reflect.Field;
 import java.util.Iterator;
@@ -11,7 +11,6 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.orm.jbt.api.wrp.Wrapper;
-import org.hibernate.tool.orm.jbt.internal.util.DummyMetadataBuildingContext;
 
 public class SpecialRootClass extends RootClass {
 	

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/factory/WrapperFactoryTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/factory/WrapperFactoryTest.java
@@ -76,7 +76,7 @@ import org.hibernate.tool.orm.jbt.internal.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.internal.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.internal.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.internal.util.RevengConfiguration;
-import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
+import org.hibernate.tool.orm.jbt.internal.util.SpecialRootClass;
 import org.junit.jupiter.api.Test;
 
 public class WrapperFactoryTest {

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/PersistentClassWrapperTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/api/wrp/PersistentClassWrapperTest.java
@@ -30,7 +30,7 @@ import org.hibernate.tool.orm.jbt.internal.factory.PropertyWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.factory.TableWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.factory.ValueWrapperFactory;
 import org.hibernate.tool.orm.jbt.internal.util.DummyMetadataBuildingContext;
-import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
+import org.hibernate.tool.orm.jbt.internal.util.SpecialRootClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/SpecialRootClassTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/orm/jbt/internal/util/SpecialRootClassTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.orm.jbt.util;
+package org.hibernate.tool.orm.jbt.internal.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -16,6 +16,7 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Set;
 import org.hibernate.tool.orm.jbt.internal.util.DummyMetadataBuildingContext;
+import org.hibernate.tool.orm.jbt.internal.util.SpecialRootClass;
 import org.junit.jupiter.api.Test;
 
 public class SpecialRootClassTest {


### PR DESCRIPTION
  - Move class 'org.hibernate.tool.orm.jbt.util.SpecialRootClass'
  - Move test class 'org.hibernate.tool.orm.jbt.util.SpecialRootClassTest'
