### PR TITLE
HBX-2851: Library JavaGoogleFormat needs special configuration starting from Java 16 and throws an IllegalAccessError

### DIFF
--- a/test/nodb/pom.xml
+++ b/test/nodb/pom.xml
@@ -59,4 +59,22 @@
 		</dependency>
     </dependencies>
     
+    <build>
+       <plugins>
+          <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+             <artifactId>maven-surefire-plugin</artifactId>
+             <configuration>
+                <argLine>
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED				</argLine>   
+             </configuration>
+          </plugin>
+       </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
  - Add configuration for in 'test/nodb/pom.xml' to avoid failing tests under Java 17
