### PR TITLE
HBX-2910: Make sure that the Exporter classes needed by plugin 'org.hibernate.eclipse.console' are visible and available

### DIFF
--- a/jbt/src/main/java/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/jbt/src/main/java/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/jbt/src/test/java/org/hibernate/tool/hbm2x/ExportersPresenceTest.java
+++ b/jbt/src/test/java/org/hibernate/tool/hbm2x/ExportersPresenceTest.java
@@ -84,4 +84,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }


### PR DESCRIPTION
  - Handle the case for 'org.hibernate.tool.hbm2x.DocExporter'
