### PR TITLE
HBX-2916: Move XMLPrettyPrinter to the API and offer the ability to specify the XMLPrettyPrinterStrategy

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/xml/XMLPrettyPrinter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/xml/XMLPrettyPrinter.java
@@ -2,7 +2,7 @@
  * Created on 17-Dec-2004
  *
  */
-package org.hibernate.tool.internal.xml;
+package org.hibernate.tool.api.xml;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,6 +10,8 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import org.hibernate.tool.internal.xml.XMLPrettyPrinterStrategyFactory;
 
 /**
  * @author max

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/DefaultArtifactCollector.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/DefaultArtifactCollector.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.tool.api.export.ArtifactCollector;
-import org.hibernate.tool.internal.xml.XMLPrettyPrinter;
+import org.hibernate.tool.api.xml.XMLPrettyPrinter;
 
 /**
  * Callback class that all exporters are given to allow better feedback and

--- a/orm/src/main/java/org/hibernate/tool/internal/xml/XMLPrettyPrinterStrategyFactory.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/xml/XMLPrettyPrinterStrategyFactory.java
@@ -30,7 +30,6 @@ public final class XMLPrettyPrinterStrategyFactory {
                 throw new RuntimeException(e);
             }
         }
-
         return null;
     }
 }

--- a/orm/src/test/java/org/hibernate/tool/api/xml/XMLPrettyPrinterTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/xml/XMLPrettyPrinterTest.java
@@ -1,0 +1,46 @@
+package org.hibernate.tool.api.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class XMLPrettyPrinterTest {
+	
+	private static final String XML_BEFORE = "<foo><bar>foobar</bar></foo>";
+	
+	private static final String XML_AFTER = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+			"<foo>\n" +
+	        "    <bar>foobar</bar>\n" +
+			"</foo>\n";
+	
+	private static final String fileName = "foobarfile.xml";
+
+	@TempDir 
+	private File tempDir;
+	
+	private File xmlFile = null;
+	
+	@BeforeEach
+	public void beforeEach() throws Exception {
+		xmlFile = new File(tempDir, fileName);
+		PrintWriter writer = new PrintWriter(xmlFile);
+		writer.print(XML_BEFORE);
+		writer.flush();
+		writer.close();
+	}
+	
+	@Test
+	public void testXmlPrettyPrintDefault() throws Exception {
+		XMLPrettyPrinter.prettyPrintFile(xmlFile);
+		String result = Files.readString(xmlFile.toPath());
+		assertEquals(XML_AFTER, result);
+	}
+	
+}


### PR DESCRIPTION
  - Move class 'org.hibernate.tool.internal.xml.XMLPrettyPrinter' to 'org.hibernate.tool.api.xml.XMLPrettyPrinter'
  - Add a new test class 'org.hibernate.tool.api.xml.XMLPrettyPrinterTest'
