### PR TITLE
HBX-2916: Move XMLPrettyPrinter to the API and offer the ability to specify the XMLPrettyPrinterStrategy

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/xml/XMLPrettyPrinter.java
+++ b/orm/src/main/java/org/hibernate/tool/api/xml/XMLPrettyPrinter.java
@@ -18,10 +18,14 @@ import org.hibernate.tool.internal.xml.XMLPrettyPrinterStrategyFactory;
  * 
  */
 public final class XMLPrettyPrinter {
-
+	
 	public static void prettyPrintFile(File file) throws IOException {
+		prettyPrintFile(file, null);
+	}
+
+	public static void prettyPrintFile(File file, XMLPrettyPrinterStrategy strategy) throws IOException {
 		String input = readFile(file.getAbsolutePath(), Charset.defaultCharset());
-		String output = prettyFormat(input);
+		String output = prettyFormat(input, strategy);
 		PrintWriter writer = new PrintWriter(file);
 		writer.print(output);
 		writer.flush();
@@ -33,9 +37,12 @@ public final class XMLPrettyPrinter {
 		return new String(encoded, encoding);
 	}
 
-	private static String prettyFormat(String input) {
+	private static String prettyFormat(String input, XMLPrettyPrinterStrategy strategy) {
 	    try {
-			return XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy().prettyPrint(input);
+	    	if (strategy == null) {
+	    		strategy = XMLPrettyPrinterStrategyFactory.newXMLPrettyPrinterStrategy();
+	    	}
+			return strategy.prettyPrint(input);
 	    } catch (Exception e) {
 	        throw new RuntimeException(e); // simple exception handling, please review it
 	    }

--- a/orm/src/test/java/org/hibernate/tool/api/xml/XMLPrettyPrinterTest.java
+++ b/orm/src/test/java/org/hibernate/tool/api/xml/XMLPrettyPrinterTest.java
@@ -20,6 +20,8 @@ public class XMLPrettyPrinterTest {
 	        "    <bar>foobar</bar>\n" +
 			"</foo>\n";
 	
+	private static final String XML_COMMENT = "<!-- Just a comment! -->";
+	
 	private static final String fileName = "foobarfile.xml";
 
 	@TempDir 
@@ -41,6 +43,20 @@ public class XMLPrettyPrinterTest {
 		XMLPrettyPrinter.prettyPrintFile(xmlFile);
 		String result = Files.readString(xmlFile.toPath());
 		assertEquals(XML_AFTER, result);
+	}
+	
+	@Test
+	public void testXmlPrettyPrintWithStrategy() throws Exception {
+		XMLPrettyPrinter.prettyPrintFile(xmlFile, new FooBarStrategy());
+		String result = Files.readString(xmlFile.toPath());
+		assertEquals(XML_AFTER + XML_COMMENT, result);
+	}
+	
+	public static class FooBarStrategy implements XMLPrettyPrinterStrategy {
+		@Override
+		public String prettyPrint(String xml) throws Exception {
+			return XML_AFTER + XML_COMMENT;
+		}		
 	}
 	
 }


### PR DESCRIPTION
  - Add new test case 'org.hibernate.tool.api.xml.XMLPrettyPrinterTest#testXmlPrettyPrintWithStrategy()'
  - Add new method 'org.hibernate.tool.api.xml.XMLPrettyPrinter#prettyPrintFile(File,XMLPrettyPrinterStrategy)'
