### PR TITLE
HBX-2954: Update Hibernate ORM dependency to version 6.6.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,18 +86,18 @@
 
     <properties>
 
-        <ant.version>1.10.14</ant.version>
-        <antlr.version>4.13.1</antlr.version>
+        <ant.version>1.10.15</ant.version>
+        <antlr.version>4.13.2</antlr.version>
         <commons-collections.version>4.4</commons-collections.version>
-        <freemarker.version>2.3.32</freemarker.version>
-        <google-java-format.version>1.19.1</google-java-format.version>
-        <h2.version>2.2.224</h2.version>
+        <freemarker.version>2.3.34</freemarker.version>
+        <google-java-format.version>1.24.0</google-java-format.version>
+        <h2.version>2.3.232</h2.version>
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version>
-        <hibernate-orm.version>6.6.4.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.6.5.Final</hibernate-orm.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <javaee-api.version>8.0.1</javaee-api.version>
-        <jboss-logging.version>3.5.3.Final</jboss-logging.version>
-        <junit-jupiter.version>5.10.1</junit-jupiter.version>
+        <jboss-logging.version>3.6.1.Final</jboss-logging.version>
+        <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <mysql.version>8.0.22</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
         <sqlserver.version>9.2.1.jre8</sqlserver.version>
@@ -105,7 +105,7 @@
         <!-- Plugins not managed by the JBoss parent POM: -->
         <maven-wrapper-plugin.version>3.3.2</maven-wrapper-plugin.version>
         <nexus-staging.plugin.version>1.7.0</nexus-staging.plugin.version>
-        <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+        <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
 
         <!--
             We don't want to publish or sign any modules by default.


### PR DESCRIPTION
  Also updates of the following libraries:
  - ant from '1.10.14' to '1.10.15'
  - antlr-runtime from '4.13.1' to '4.13.2'
  - freemarker from '2.3.32' to '2.3.34'
  - google-java-format from '1.19.1' to '1.24.0'
  - h2database from '2.2.224' to '2.3.232'
  - jboss-logging from '3.5.3.Final' to '3.6.1.Final'
  - junit-jupiter from '5.10.1' to '5.11.4'
  - flatten-maven-plugin from '1.5.0' to '1.6.0'
