### PR TITLE
HBX-2968 Publish the Gradle Plugins on the Plugin Portal

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -82,7 +82,8 @@ pipeline {
 											configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: env.HOME + '/.ssh/known_hosts')]) {
 							// using MAVEN_GPG_PASSPHRASE (the default env variable name for passphrase in maven gpg plugin)
 							withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
-											 string(credentialsId: 'release.gpg.passphrase', variable: 'MAVEN_GPG_PASSPHRASE')]) {
+											 string(credentialsId: 'release.gpg.passphrase', variable: 'MAVEN_GPG_PASSPHRASE'),
+											 usernamePassword(credentialsId: 'gradle-plugin-portal-api-key', passwordVariable: 'GRADLE_PUBLISH_SECRET', usernameVariable: 'GRADLE_PUBLISH_KEY')]) {
 								sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
 									sh 'cat $HOME/.ssh/config'
 									sh 'git clone https://github.com/hibernate/hibernate-release-scripts.git'

--- a/gradle/plugin/build.gradle
+++ b/gradle/plugin/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
+    id 'com.gradle.plugin-publish' version '1.2.1'
 }
 
 group = 'org.hibernate.tool'
@@ -25,11 +26,19 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+rootProject.ext.set("gradle.publish.key", System.env.PLUGIN_PORTAL_USERNAME)
+rootProject.ext.set("gradle.publish.secret", System.env.PLUGIN_PORTAL_PASSWORD)
+
 gradlePlugin {
+    website = 'https://github.com/hibernate/hibernate-tools/tree/main/gradle/plugin'
+    vcsUrl = 'https://github.com/hibernate/hibernate-tools/tree/main/gradle/plugin'
     plugins {
         hibernate {
             id = 'org.hibernate.tool.hibernate-tools-gradle'
             implementationClass = 'org.hibernate.tool.gradle.Plugin'
+            displayName = 'Hibernate Tools Gradle Plugin'
+            description = 'Gradle plugin to provide hibernate-tools reverse engineering and code/schema generation abilities.'
+            tags = ['hibernate','tools','reverse engineering','reveng','generation']
         }
     }
 }

--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -30,11 +30,11 @@
 
    <name>Hibernate Tools Gradle Plugin</name>
    <description>Gradle plugin to provide hibernate-tools reverse engineering and code/schema generation abilities.</description>
-   <url>http://hibernate.org/tools/</url>
+   <url>https://hibernate.org/tools/</url>
 
    <issueManagement>
       <system>JIRA</system>
-      <url>http://hibernate.onjira.com/browse/HBX</url>
+      <url>https://hibernate.atlassian.net/projects/HBX</url>
    </issueManagement>
 
    <properties>
@@ -100,5 +100,42 @@
          </plugin>
       </plugins>
    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>gradle-publish-to-plugin-portal</id>
+                                <phase>deploy</phase>
+                                <configuration>
+                                    <executable>${gradle.executable}</executable>
+                                    <arguments>
+                                        <argument>publishPlugins</argument>
+                                        <argument>-Pversion=${project.version}</argument>
+                                        <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HBX-2968

I thiiiink this should do it ... though not sure how we could test that all really works fine...
The idea here is that there's an additional execution "hidden" within the release profile that is going to execute another gradle command to publish the plugin to the portal. I've put that execution to run at the `deploy` phase.