### PR TITLE
HBX-2972: Update Hibernate ORM dependency to version 6.2.36.Final

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -37,13 +37,13 @@ pipeline {
 		string(
 				name: 'RELEASE_VERSION',
 				defaultValue: '',
-				description: 'The version to be released, e.g. 6.2.34.Final.',
+				description: 'The version to be released, e.g. 6.2.36.Final.',
 				trim: true
 		)
 		string(
 				name: 'DEVELOPMENT_VERSION',
 				defaultValue: '',
-				description: 'The next version to be used after the release, e.g. 6.2.35-SNAPSHOT.',
+				description: 'The next version to be used after the release, e.g. 6.2.37-SNAPSHOT.',
 				trim: true
 		)
 		booleanParam(

--- a/pom.xml
+++ b/pom.xml
@@ -89,14 +89,15 @@
         <antlr.version>4.13.2</antlr.version>
         <commons-collections.version>4.4</commons-collections.version>
         <freemarker.version>2.3.34</freemarker.version>
+        <!-- version 1.24.0 of google-java-format is the last one compatible with java 11 -->
         <google-java-format.version>1.24.0</google-java-format.version>
         <h2.version>2.3.232</h2.version>
-        <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version>
-        <hibernate-orm.version>6.2.35.Final</hibernate-orm.version>
+        <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version>
+        <hibernate-orm.version>6.2.36.Final</hibernate-orm.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <javaee-api.version>8.0.1</javaee-api.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <junit-jupiter.version>5.12.0</junit-jupiter.version>
+        <junit-jupiter.version>5.12.1</junit-jupiter.version>
         <mysql.version>8.0.22</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
         <sqlserver.version>9.2.1.jre8</sqlserver.version>


### PR DESCRIPTION
  - Update the version examples in 'ci/Jenkinsfile'
  - Also update:
    * hibernate-commons-annotations to version 7.0.3.Final
    * junit-jupiter to version 5.12.1
