### PR TITLE
HBX-2981: Update Hibernate ORM dependency to 7.0.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,16 +88,16 @@
 
         <ant.version>1.10.15</ant.version>
         <antlr.version>4.13.2</antlr.version>
-        <commons-collections.version>4.4</commons-collections.version>
+        <commons-collections.version>4.5.0</commons-collections.version>
         <freemarker.version>2.3.34</freemarker.version>
-        <google-java-format.version>1.25.2</google-java-format.version>
+        <google-java-format.version>1.26.0</google-java-format.version>
         <h2.version>2.3.232</h2.version>
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version>
-        <hibernate-orm.version>7.0.0.Beta5</hibernate-orm.version>
+        <hibernate-orm.version>7.0.0.CR1</hibernate-orm.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <javaee-api.version>8.0.1</javaee-api.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <junit-jupiter.version>5.12.1</junit-jupiter.version>
+        <junit-jupiter.version>5.12.2</junit-jupiter.version>
         <mysql.version>8.0.22</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
         <sqlserver.version>9.2.1.jre8</sqlserver.version>


### PR DESCRIPTION
  Additional dependency updates:
  - commons-collections to 4.5.0
  - google-java-format to 1.26.0
  - junit-jupiter to 5.12.2
