### PR TITLE
HBX-2980: Update Hibernate ORM dependency to 6.6.14.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,13 +88,13 @@
 
         <ant.version>1.10.15</ant.version>
         <antlr.version>4.13.2</antlr.version>
-        <commons-collections.version>4.4</commons-collections.version>
+        <commons-collections.version>4.5.0</commons-collections.version>
         <freemarker.version>2.3.34</freemarker.version>
         <!-- version 1.24.0 of google-java-format is the last one compatible with java 11 -->
         <google-java-format.version>1.24.0</google-java-format.version>
         <h2.version>2.3.232</h2.version>
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version>
-        <hibernate-orm.version>6.6.13.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.6.14.Final</hibernate-orm.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <javaee-api.version>8.0.1</javaee-api.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>


### PR DESCRIPTION
  - This also includes an update of the commons-collections dependency to 4.5.0
