### PR TITLE
HBX-2980: Update Hibernate ORM dependency to 6.6.14.Final

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -37,13 +37,13 @@ pipeline {
 		string(
 				name: 'RELEASE_VERSION',
 				defaultValue: '',
-				description: 'The version to be released, e.g. 6.6.9.Final.',
+				description: 'The version to be released, e.g. 6.6.15.Final.',
 				trim: true
 		)
 		string(
 				name: 'DEVELOPMENT_VERSION',
 				defaultValue: '',
-				description: 'The next version to be used after the release, e.g. 6.6.10-SNAPSHOT.',
+				description: 'The next version to be used after the release, e.g. 6.6.16-SNAPSHOT.',
 				trim: true
 		)
 		booleanParam(


### PR DESCRIPTION
  - Amend the version identifiers in the 'release/Jenkinsfile' script
