### PR TITLE
HBX-2992: Backport automated releases to branch 6.5

### DIFF
--- a/orm/src/main/java/org/hibernate/tool/api/version/Version.java
+++ b/orm/src/main/java/org/hibernate/tool/api/version/Version.java
@@ -12,5 +12,5 @@ public interface Version {
 		// This implementation is replaced during the build with another one that returns the correct value.
 		return "UNKNOWN";
 	}
-
+	
 }

--- a/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateHelper.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/common/TemplateHelper.java
@@ -177,7 +177,7 @@ public class TemplateHelper {
 	}
 	
     public void setupContext() {
-    	getContext().put("version", Version.CURRENT_VERSION);
+    	getContext().put("version", Version.versionString());
         getContext().put("ctx", getContext() ); //TODO: I would like to remove this, but don't know another way to actually get the list possible "root" keys for debugging.
         getContext().put("templates", new Templates());
         

--- a/test/nodb/src/test/java/org/hibernate/tool/VersionTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/VersionTest/TestCase.java
@@ -45,7 +45,7 @@ public class TestCase {
 	@Test
 	public void testVersion() throws Exception {
 		assertEquals(
-				org.hibernate.tool.api.version.Version.CURRENT_VERSION,
+				org.hibernate.tool.api.version.Version.versionString(),
 				extractVersion(getPomXml()));
 	}
 	

--- a/test/nodb/src/test/java/org/hibernate/tool/hbm2x/GenericExporterTest/TestCase.java
+++ b/test/nodb/src/test/java/org/hibernate/tool/hbm2x/GenericExporterTest/TestCase.java
@@ -90,7 +90,7 @@ public class TestCase {
 				null, 
 				FileUtil.findFirstString("$", new File(outputDir, "artifacts.txt")));	
 		assertEquals(
-				"File for artifacts in " + Version.CURRENT_VERSION, 
+				"File for artifacts in " + Version.versionString(), 
 				FileUtil.findFirstString("artifacts", new File( outputDir, "artifacts.txt")));
 	}
 


### PR DESCRIPTION
  - Use maven-injection-plugin to set the version string in the org.hibernate.tool.api.version.Version
