### PR TITLE
HBX-2992: Backport automated releases to branch 6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,24 @@
 
         <!-- Plugins not managed by the JBoss parent POM: -->
         <maven-wrapper-plugin.version>3.3.2</maven-wrapper-plugin.version>
+        <nexus-staging.plugin.version>1.7.0</nexus-staging.plugin.version>
+        <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+
+        <!--
+            We don't want to publish or sign any modules by default.
+            Specific modules will override the setting at their own level.
+        -->
+        <deploy.skip>true</deploy.skip>
+        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
+
+        <!-- Repository Deployment URLs -->
+        <ossrh.releases.repo.id>ossrh</ossrh.releases.repo.id>
+        <ossrh.releases.repo.name>Sonatype OSSRH Releases</ossrh.releases.repo.name>
+        <ossrh.releases.repo.url>https://oss.sonatype.org/service/local/staging/deploy/maven2</ossrh.releases.repo.url>
+        <ossrh.releases.repo.baseUrl>https://oss.sonatype.org</ossrh.releases.repo.baseUrl>
+        <ossrh.snapshots.repo.id>ossrh</ossrh.snapshots.repo.id>
+        <ossrh.snapshots.repo.name>Sonatype OSSRH Snapshots</ossrh.snapshots.repo.name>
+        <ossrh.snapshots.repo.url>https://oss.sonatype.org/content/repositories/snapshots</ossrh.snapshots.repo.url>
 
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
@@ -228,36 +246,17 @@
          </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>ossrh-releases-repository</id>
-            <name>Sonatype OSSRH Releases</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-       <repository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>ossrh-snapshots-repository</id>
-            <name>Sonatype OSSRH Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
-    </repositories>
-
     <distributionManagement>
-      <repository>
-        <id>ossrh-releases-repository</id>
-        <name>Sonatype OSSRH Releases</name>
-        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      </repository>
-      <snapshotRepository>
-        <id>ossrh-snapshots-repository</id>
-        <name>Sonatype OSSRH Snapshots</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-      </snapshotRepository>
+        <repository>
+            <id>${ossrh.releases.repo.id}</id>
+            <name>${ossrh.releases.repo.name}</name>
+            <url>${ossrh.releases.repo.url}</url>
+        </repository>
+        <snapshotRepository>
+            <id>${ossrh.snapshots.repo.id}</id>
+            <name>${ossrh.snapshots.repo.name}</name>
+            <url>${ossrh.snapshots.repo.url}</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <build>
@@ -272,8 +271,161 @@
                         <distributionType>bin</distributionType>
                     </configuration>
                 </plugin>
+                <!-- Published artifacts have to be signed: -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                            <configuration>
+                                <skip>${deploy.skip}</skip>
+                                <homedir>${env.RELEASE_GPG_HOMEDIR}</homedir>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus-staging.plugin.version}</version>
+                    <extensions>false</extensions><!-- This is essential: do not put true here -->
+                    <configuration>
+                        <skipNexusStagingDeployMojo>${deploy.skip}</skipNexusStagingDeployMojo>
+                        <serverId>${ossrh.releases.repo.id}</serverId>
+                        <!-- The following, by default, is only used for actual releases, not for snapshot deployments -->
+                        <nexusUrl>${ossrh.releases.repo.baseUrl}</nexusUrl>
+                        <!-- oss.sonatype.org has been very slow when closing repositories lately;
+                             let's raise the timeout until we switch to s01.sonatype.org -->
+                        <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>${flatten-maven-plugin.version}</version>
+                    <configuration>
+                        <outputDirectory>${project.build.directory}</outputDirectory>
+                        <!-- Keep things like url, inceptionYear, authors...
+                             everything that's required by the OSSRH Maven repository -->
+                        <flattenMode>ossrh</flattenMode>
+                        <!-- To make sure that `hibernate-tools-gradle` module that has a pom packaging will also publish the flattened pom -->
+                        <updatePomFile>true</updatePomFile>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>flatten-pom</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <!-- Skip the deploy plugin explicitly: we use nexus-staging-maven-plugin instead -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>${maven-deploy-plugin.skip}</skip>
+                </configuration>
+            </plugin>
+            <!--
+                 Configure the nexus-staging-maven-plugin explicitly (without <extension>true</extension>)
+                 in order to work around a problem in the "reports" module (see that module's POM for more info).
+             -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <!--
+                                This will only put artifacts in a staging directory.
+                                See the "reports" module for actual deployment, at the end of the build.
+                             -->
+                            <goal>deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <!--
+                                We want to override the rules for this configuration to remove the bannedRepositories rule from the JBoss parent.
+                            -->
+                            <rules combine.self="override">
+                                <requireJavaVersion>
+                                    <message>To build this project JDK ${jdk.min.version} (or greater) is required. Please install it.</message>
+                                    <version>${jdk.min.version}</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!--
+             WARNING: this MUST be the very last profile,
+             so that the "report" module is the very last module,
+             in particular when deploying artifacts to a Nexus repository.
+             See the "build/reports" module POM for more information.
+         -->
+        <profile>
+            <id>build-reports-as-last-module</id>
+            <activation>
+                <property>
+                    <name>!some.property.that.will.never.exist</name>
+                </property>
+            </activation>
+            <modules>
+                <module>reports</module>
+            </modules>
+        </profile>
+
+        <!-- DO NOT ADD ANY PROFILE AFTER THIS: see above -->
+    </profiles>
 
 </project>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 - 2024 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.tool</groupId>
+        <artifactId>hibernate-tools-parent</artifactId>
+        <version>6.5.4-SNAPSHOT</version>
+    </parent>
+    <artifactId>hibernate-tools-reports</artifactId>
+
+    <name>Hibernate Tools Reports</name>
+    <description>Hibernate Tools build reports</description>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.tool</groupId>
+            <artifactId>hibernate-tools-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.tool</groupId>
+            <artifactId>hibernate-tools-orm</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.tool</groupId>
+            <artifactId>hibernate-tools-orm-jbt</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.tool</groupId>
+            <artifactId>hibernate-tools-maven</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.tool</groupId>
+            <artifactId>hibernate-tools-gradle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.tool</groupId>
+            <artifactId>hibernate-tools-ant</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                Hack to deploy in the "reports" module without deploying the "reports" module itself.
+                The default lifecycle bindings of the plugin is to "stage locally" every artifact throughout
+                the maven execution, and only actually deploy the "locally staged" artifacts
+                in the very last executed module, which happens to be this "reports" module.
+                However, this "reports" module does not generate any artifact we want to deploy.
+                Thus, we'd like to prevent even its POM from being deployed: just deploy the "locally staged" artifacts,
+                without adding the POM from the "reports" module to these artifacts.
+                The default lifecycle bindings of the plugin does not offer a configuration option to do that,
+                so we have to explicitly bind it
+             -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <extensions>false</extensions>
+                <!-- The <configuration> element is inherited from the parent module. -->
+                <executions>
+                    <!-- Skip the default deployment, as explained above we don't want it. -->
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- ... but execute the deferred deployment for the other modules -->
+                    <execution>
+                        <id>deferred-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy-staged</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
  - Add 'reports' module
  - Modify pom.xml with following changes/additions:
    * Add needed properties for the CI run
    * Modify the 'distributionManagement' section with the needed deployment info
    * Add a 'build' section to (1) sign the artefacts to deploy (2) perform deployment to the sonatype repo (3) flatten the pom files
    * Add a 'profile' section for the release
