### PR TITLE
HBX-2992: Backport automated releases to branch 6.5

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -67,6 +67,7 @@
                                 <argument>clean</argument>
                                 <argument>build</argument>
                                 <argument>-Pversion=${project.version}</argument>
+                                <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
                             </arguments>
                         </configuration>
                         <goals>


### PR DESCRIPTION
  - Use settings.localRepository instead of a custom property
