### PR TITLE
HBX-2994: Backport automated releases to branch 6.4

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
 	}
 	tools {
 		maven 'Apache Maven 3.9'
-		jdk 'OpenJDK 21 Latest'
+		jdk 'OpenJDK 11 Latest'
 	}
 	options {
 		buildDiscarder logRotator(daysToKeepStr: '30', numToKeepStr: '10')


### PR DESCRIPTION
  - Use 'OpenJDK 11 Latest' as jdk in 'ci/release/Jenkinsfile'
