### PR TITLE
HBX-3000: Maven GenerateJava Mojo should generate annotated entities by default

### DIFF
--- a/maven/src/main/java/org/hibernate/tool/maven/GenerateJavaMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/GenerateJavaMojo.java
@@ -48,7 +48,7 @@ public class GenerateJavaMojo extends AbstractGenerationMojo {
     /** Code will contain JPA features, e.g. using annotations from jakarta.persistence
      * and org.hibernate.annotations. */
     @Parameter(defaultValue = "true")
-    private boolean ejb3 = true;
+    private boolean ejb3;
     
     /** Code will contain JDK 5 constructs such as generics and static imports. */
     @Parameter(defaultValue = "false")

--- a/maven/src/test/java/org/hibernate/tool/maven/GenerateJavaMojoTest.java
+++ b/maven/src/test/java/org/hibernate/tool/maven/GenerateJavaMojoTest.java
@@ -48,7 +48,11 @@ public class GenerateJavaMojoTest {
 		File personJavaFile = new File(outputDirectory, "Person.java");
 		// Person.java should not exist
 		assertFalse(personJavaFile.exists());
-		// Execute mojo with default value of 'ejb3' field which is 'true'
+		// Set value of field 'ejb3' to 'true' and execute mojo
+		Field ejb3Field = GenerateJavaMojo.class.getDeclaredField("ejb3");
+		ejb3Field.setAccessible(true);
+		ejb3Field.set(generateJavaMojo, true);
+		// Execute mojo
 		generateJavaMojo.executeExporter(createMetadataDescriptor());
 		// Person.java should exist
 		assertTrue(personJavaFile.exists());
@@ -66,6 +70,7 @@ public class GenerateJavaMojoTest {
 		Field ejb3Field = GenerateJavaMojo.class.getDeclaredField("ejb3");
 		ejb3Field.setAccessible(true);
 		ejb3Field.set(generateJavaMojo, false);
+		// Execute mojo
 		generateJavaMojo.executeExporter(createMetadataDescriptor());
 		// Person.java should exist
 		assertTrue(personJavaFile.exists());


### PR DESCRIPTION
  - Remove the default initialization of the GenerateJavaMojo#ejb3 field and adapt the unit test
