### PR TITLE
HBX-3001: Maven GenerateJava Mojo should use generics and static imports by default

### DIFF
--- a/maven/src/it/use-generics/invoker.properties
+++ b/maven/src/it/use-generics/invoker.properties
@@ -1,0 +1,18 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2018-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+invoker.goals = generate-resources

--- a/maven/src/it/use-generics/pom.xml
+++ b/maven/src/it/use-generics/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>use-generics</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>@h2.version@</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/src/it/use-generics/setup.bsh
+++ b/maven/src/it/use-generics/setup.bsh
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ *
+ * Copyright 2018-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.sql.DriverManager;
+import java.sql.Connection;
+import java.sql.Statement;
+
+String JDBC_CONNECTION = "jdbc:h2:" + basedir + "/test";
+String CREATE_PERSON_TABLE =
+    "create table PERSON (ID int not null,  NAME varchar(20), primary key (ID))";
+String CREATE_ITEM_TABLE =
+    "create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+    "   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))";
+
+Connection connection = DriverManager.getConnection(JDBC_CONNECTION);
+Statement statement = connection.createStatement();
+statement.execute(CREATE_PERSON_TABLE);
+statement.execute(CREATE_ITEM_TABLE);
+statement.close();
+connection.close();

--- a/maven/src/it/use-generics/src/main/resources/hibernate.properties
+++ b/maven/src/it/use-generics/src/main/resources/hibernate.properties
@@ -1,0 +1,21 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2018-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:./test
+hibernate.default_catalog=TEST
+hibernate.default_schema=PUBLIC

--- a/maven/src/it/use-generics/verify.bsh
+++ b/maven/src/it/use-generics/verify.bsh
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ *
+ * Copyright 2018-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Files;
+
+File personEntity = new File(basedir, "target/generated-sources/Person.java");
+if (!personEntity.isFile()) {
+    throw new FileNotFoundException("Could not find generated Java file: " + personEntity);
+}
+byte[] raw = Files.readAllBytes(personEntity.toPath());
+if (!new String(raw).contains("Set<Item>")) {
+    throw new RuntimeException("The generated Java file should use generics");
+}
+
+

--- a/maven/src/main/java/org/hibernate/tool/maven/GenerateJavaMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/GenerateJavaMojo.java
@@ -51,7 +51,7 @@ public class GenerateJavaMojo extends AbstractGenerationMojo {
     private boolean ejb3;
     
     /** Code will contain JDK 5 constructs such as generics and static imports. */
-    @Parameter(defaultValue = "false")
+    @Parameter(defaultValue = "true")
     private boolean jdk5;
 
     /** A path used for looking up user-edited templates. */


### PR DESCRIPTION
  - Add integration test 'use-generics' to verify that generics are used by default
  - Change the value by default of 'jdk5' to be 'true' instead of 'false'
