### PR TITLE
HBX-3011: Switch to Maven Central publishing

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -36,13 +36,13 @@ pipeline {
 	parameters {
 		string(
 				name: 'RELEASE_VERSION',
-				defaultValue: '',
+				defaultValue: '5.6.16.Final',
 				description: 'The version to be released, e.g. 5.6.16.Final.',
 				trim: true
 		)
 		string(
 				name: 'DEVELOPMENT_VERSION',
-				defaultValue: '',
+				defaultValue: '5.6.17-SNAPSHOT',
 				description: 'The next version to be used after the release, e.g. 5.6.17-SNAPSHOT.',
 				trim: true
 		)
@@ -53,7 +53,7 @@ pipeline {
 		)
 		booleanParam(
 				name: 'RELEASE_PUBLISH_AUTOMATICALLY',
-				defaultValue: true,
+				defaultValue: false,
 				description: 'If true, staging repository will get closed and published automatically, otherwise the artifacts will only be uploaded and the publishing (releasing the staging repository) has to be performed manually at Maven Central portal.'
 		)
 	}


### PR DESCRIPTION
  - change the default value of 'RELEASE_PUBLISH_AUTOMATICALLY' to 'false'
  - fill out default versions (5.6.16.Final and 5.6.17-SNAPSHOT respectively)
