### PR TITLE
HBX-3038: Gradle 'generateJava' task should generate annotated entities by default

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.tool.gradle.tutorial;
+package org.hibernate.tool.gradle.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -17,7 +17,7 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class TutorialTest {
+public class JpaDefaultTest {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
 			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");
@@ -125,7 +125,7 @@ public class TutorialTest {
 		assertTrue(buildResult.getOutput().contains("BUILD SUCCESSFUL"));
 	}
 	
-	private void verifyProject() {
+	private void verifyProject() throws Exception {
 		File generatedOutputFolder = new File(projectDir, "app/generated-sources");
 		assertTrue(generatedOutputFolder.exists());
 		assertTrue(generatedOutputFolder.isDirectory());
@@ -133,6 +133,9 @@ public class TutorialTest {
 		File generatedPersonJavaFile = new File(generatedOutputFolder, "Person.java");
 		assertTrue(generatedPersonJavaFile.exists());
 		assertTrue(generatedPersonJavaFile.isFile());
+		String generatedPersonJavaFileContents = new String(
+				Files.readAllBytes(generatedPersonJavaFile.toPath()));
+		assertTrue(generatedPersonJavaFileContents.contains("import jakarta.persistence.Entity;"));
 	}
 	
 	private void addHibernateToolsPluginLine(StringBuffer gradleBuildFileContents) {

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/Extension.java
@@ -26,6 +26,7 @@ public class Extension {
 	public String outputFolder = "generated-sources";
 	public String packageName = "";
 	public String revengStrategy = null;
+	public Boolean generateAnnotations = true;
 	
 	public Extension(Project project) {}
 	

--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -35,6 +35,7 @@ public class GenerateJavaTask extends AbstractTask {
 	void doWork() {
 		getLogger().lifecycle("Creating Java exporter");
 		Exporter pojoExporter = ExporterFactory.createExporter(ExporterType.JAVA);
+        pojoExporter.getProperties().setProperty("ejb3", String.valueOf(getExtension().generateAnnotations));
 		File outputFolder = getOutputFolder();
 		pojoExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, createJdbcDescriptor());
 		pojoExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputFolder);
@@ -42,5 +43,5 @@ public class GenerateJavaTask extends AbstractTask {
 		pojoExporter.start();
 		getLogger().lifecycle("Java export finished");
 	}
-
+	
 }

--- a/orm/src/main/java/org/hibernate/tool/internal/export/java/JavaExporter.java
+++ b/orm/src/main/java/org/hibernate/tool/internal/export/java/JavaExporter.java
@@ -47,6 +47,8 @@ public class JavaExporter extends GenericExporter {
 		if(!getProperties().containsKey("jdk5")) {
 			getProperties().put("jdk5", "false");
 		}	
+		System.out.println("value of 'ejb3' is : " + getProperties().getProperty("ejb3"));
+		System.out.println("value of 'jdk5' is : " + getProperties().getProperty("jdk5"));
 		super.setupContext();
 	}
 }


### PR DESCRIPTION
  - Add 'generateAnnotations' configuration to the Hibernate Tools Gradle extension with default value 'true'
  - Use the 'generateAnnotations' configuration above to set the 'ejb' property when creating the JavaExporter
  - Add a functional test that checks this behavior
