### PR TITLE
HBX-3038: Gradle 'generateJava' task should generate annotated entities by default

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
@@ -136,6 +136,7 @@ public class JpaDefaultTest {
 		String generatedPersonJavaFileContents = new String(
 				Files.readAllBytes(generatedPersonJavaFile.toPath()));
 		assertTrue(generatedPersonJavaFileContents.contains("import jakarta.persistence.Entity;"));
+		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
 	private void addHibernateToolsPluginLine(StringBuffer gradleBuildFileContents) {

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
@@ -137,6 +137,7 @@ public class NoAnnotationsTest {
 		String generatedPersonJavaFileContents = new String(
 				Files.readAllBytes(generatedPersonJavaFile.toPath()));
 		assertFalse(generatedPersonJavaFileContents.contains("import jakarta.persistence.Entity;"));
+		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
 	private void addHibernateToolsPluginLine(StringBuffer gradleBuildFileContents) {


### PR DESCRIPTION
  - Add assertion to verify the existence of 'public class Person ' in JpaDefaultTest and NoAnnotationsTest
