### PR TITLE
HBX-3038: Gradle 'generateJava' task should generate annotated entities by default

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class JpaDefaultTest {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
-			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");
+			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "11");
 	
 	@TempDir
 	private File projectDir;

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class NoAnnotationsTest {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
-			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");
+			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "11");
 	
 	@TempDir
 	private File projectDir;


### PR DESCRIPTION
  - Change the java version to 11 as that's the minimum version for the 6.6 branch
