### PR TITLE
HBX-3044: Gradle 'generateJava' task should use generics by default

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class NoGenerics {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
-			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");
+			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "11");
 	
 	@TempDir
 	private File projectDir;

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class UseGenerics {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
-			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");
+			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "11");
 	
 	@TempDir
 	private File projectDir;


### PR DESCRIPTION
  - Change the java version to 11 as that's the minimum version for the 6.6 branch
