### PR TITLE
HBX-3000: Maven GenerateJava Mojo should generate annotated entities by default

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -166,10 +166,18 @@
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <version>${maven-invoker-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <debug>true</debug>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+          <preBuildHookScript>setup</preBuildHookScript>
           <postBuildHookScript>verify</postBuildHookScript>
         </configuration>
         <executions>

--- a/maven/src/it/GenerateJavaWithAnnotations/setup.bsh
+++ b/maven/src/it/GenerateJavaWithAnnotations/setup.bsh
@@ -1,0 +1,12 @@
+import java.sql.DriverManager;
+import java.sql.Connection;
+
+String JDBC_CONNECTION = "jdbc:h2:mem:test";
+String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
+
+DriverManager
+	.getConnection(JDBC_CONNECTION)
+	.createStatement()
+	.execute(CREATE_PERSON_TABLE);
+
+System.out.println("Database created!");

--- a/maven/src/it/GenerateJavaWithAnnotations/verify.bsh
+++ b/maven/src/it/GenerateJavaWithAnnotations/verify.bsh
@@ -1,0 +1,1 @@
+System.out.println("Hello from 'verify.bsh'");


### PR DESCRIPTION
  - Add pre-build script 'setup.bsh' for GenerateJavaWithAnnotations to create a database
  - Add post-build script 'verify.bsh' for GenerateJavaWithAnnotations
