### PR TITLE
HBX-3000: Maven GenerateJava Mojo should generate annotated entities by default

### DIFF
--- a/maven/src/it/GenerateJavaWithAnnotations/invoker.properties
+++ b/maven/src/it/GenerateJavaWithAnnotations/invoker.properties
@@ -1,0 +1,18 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2018-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+invoker.goals = generate-resources

--- a/maven/src/it/GenerateJavaWithAnnotations/setup.bsh
+++ b/maven/src/it/GenerateJavaWithAnnotations/setup.bsh
@@ -1,12 +1,26 @@
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ *
+ * Copyright 2018-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import java.sql.DriverManager;
 import java.sql.Connection;
 
-String JDBC_CONNECTION = "jdbc:h2:mem:test";
+String JDBC_CONNECTION = "jdbc:h2:" + basedir + "/test";
 String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
 
-DriverManager
-	.getConnection(JDBC_CONNECTION)
-	.createStatement()
-	.execute(CREATE_PERSON_TABLE);
-
-System.out.println("Database created!");
+Connection connection = DriverManager.getConnection(JDBC_CONNECTION);
+connection.createStatement().execute(CREATE_PERSON_TABLE);
+connection.close();

--- a/maven/src/it/GenerateJavaWithAnnotations/src/main/resources/hibernate.properties
+++ b/maven/src/it/GenerateJavaWithAnnotations/src/main/resources/hibernate.properties
@@ -1,0 +1,21 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2018-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:./test
+hibernate.default_catalog=TEST
+hibernate.default_schema=PUBLIC

--- a/maven/src/it/GenerateJavaWithAnnotations/verify.bsh
+++ b/maven/src/it/GenerateJavaWithAnnotations/verify.bsh
@@ -1,1 +1,29 @@
-System.out.println("Hello from 'verify.bsh'");
+/*
+ * Hibernate Tools, Tooling for your Hibernate Projects
+ *
+ * Copyright 2018-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Files;
+
+File personEntity = new File(basedir, "target/generated-sources/Person.java");
+if (!personEntity.isFile()) {
+    throw new FileNotFoundException("Could not find generated JPA Entity: " + personEntity);
+}
+byte[] raw = Files.readAllBytes(personEntity.toPath());
+if (!new String(raw).contains("import jakarta.persistence.Entity;")) {
+    throw new RuntimeException("The generated java file is not a JPA Entity");
+}
+
+

--- a/maven/src/main/java/org/hibernate/tool/maven/GenerateJavaMojo.java
+++ b/maven/src/main/java/org/hibernate/tool/maven/GenerateJavaMojo.java
@@ -49,7 +49,7 @@ public class GenerateJavaMojo extends AbstractGenerationMojo {
 
     /** Code will contain JPA features, e.g. using annotations from jakarta.persistence
      * and org.hibernate.annotations. */
-    @Parameter(defaultValue = "false")
+    @Parameter(defaultValue = "true")
     private boolean ejb3;
     
     /** Code will contain JDK 5 constructs such as generics and static imports. */


### PR DESCRIPTION
  - Change the default value of 'ejb3' in class 'GenerateJavaMojo' to 'true' to make it happen
  - Add file 'invoker.properties' for GenerateJavaWithAnnotations to only execute phase 'generate-resources'
  - Modify 'setup.bsh' for GenerateJavaWithAnnotations to create test database in basedir
  - Add file 'hibernate.properties' for GenerateJavaWithAnnotations so that the Person entity is generated
  - Modify 'verify.bsh' to verify that the Person entity is generated properly with annotations
