### PR TITLE
HBX-3048: Ant task hbm2java should generate classes using generics by default

### DIFF
--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
@@ -37,7 +37,7 @@ public class JpaDefaultTestIT {
 	}
 	
     @Test
-    public void testTutorial() throws Exception {
+    public void testJpaDefault() throws Exception {
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -56,7 +56,6 @@ public class JpaDefaultTestIT {
 		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
 		Statement statement = connection.createStatement();
 		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute("insert into PERSON values (1, 'foo')");
 		statement.close();
 		connection.close();	
 		assertTrue(databaseFile.exists());

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
@@ -37,7 +37,7 @@ public class NoAnnotationsTestIT {
 	}
 	
     @Test
-    public void testTutorial() throws Exception {
+    public void testNoAnnotations() throws Exception {
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -56,7 +56,6 @@ public class NoAnnotationsTestIT {
 		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
 		Statement statement = connection.createStatement();
 		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute("insert into PERSON values (1, 'foo')");
 		statement.close();
 		connection.close();	
 		assertTrue(databaseFile.exists());

--- a/ant/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/Hbm2JavaExporterTask.java
@@ -29,7 +29,7 @@ public class Hbm2JavaExporterTask extends ExporterTask {
 
 	boolean ejb3 = true;
 
-	boolean jdk5 = false;
+	boolean jdk5 = true;
 
 	public Hbm2JavaExporterTask(HibernateToolTask parent) {
 		super( parent );


### PR DESCRIPTION
  - Add a new integration test 'UseGenericsTestIT' to guard this new default behavior
  - Change the default value of the 'jdk5' field in 'Hbm2JavaExporterTask'
  - Some cleanup in other ant integration tests
