### PR TITLE
HBX-3068: Refactor the Ant integration tests to factor out common code

### DIFF
--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
@@ -42,11 +42,15 @@ public class JpaDefaultTestIT extends TestTemplate {
     	runAntBuild();
     	verifyResult();
     }
-    
+
+	protected String hibernateToolTaskXml() {
+		return  hibernateToolTaskXml;
+	}
+
     private void createBuildXmlFile() throws Exception {
     	buildXmlFile = new File(getProjectDir(), "build.xml");
     	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), buildXmlFileContents);
+    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
     }
     
 	private void createDatabase() throws Exception {
@@ -108,18 +112,10 @@ public class JpaDefaultTestIT extends TestTemplate {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}
 	    
-    private static final String buildXmlFileContents = 
-    		
-    		"<project name='tutorial' default='reveng'>                           \n" +
-    		"    <taskdef                                                         \n" + 
-    		"            name='hibernatetool'                                     \n" +
-    	    "            classname='org.hibernate.tool.ant.HibernateToolTask'/>   \n" +    		
-    		"    <target name='reveng'>                                           \n" +
-    		"        <hibernatetool destdir='generated'>                          \n" +
-    		"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-    		"            <hbm2java/>                                              \n" +
-    		"        </hibernatetool>                                             \n" +
-    		"    </target>                                                        \n" +		
-    		"</project>                                                           \n" ;
+	private static final String hibernateToolTaskXml =
+			"        <hibernatetool destdir='generated'>                          \n" +
+			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+			"            <hbm2java/>                                              \n" +
+			"        </hibernatetool>                                             \n" ;
 
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
@@ -42,11 +42,15 @@ public class NoAnnotationsTestIT extends TestTemplate {
     	runAntBuild();
     	verifyResult();
     }
-    
-    private void createBuildXmlFile() throws Exception {
+
+	protected String hibernateToolTaskXml() {
+		return  hibernateToolTaskXml;
+	}
+
+	private void createBuildXmlFile() throws Exception {
     	buildXmlFile = new File(getProjectDir(), "build.xml");
     	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), buildXmlFileContents);
+    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
     }
     
 	private void createDatabase() throws Exception {
@@ -108,18 +112,9 @@ public class NoAnnotationsTestIT extends TestTemplate {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}
 	    
-    private static final String buildXmlFileContents = 
-    		
-    		"<project name='tutorial' default='reveng'>                           \n" +
-    		"    <taskdef                                                         \n" + 
-    		"            name='hibernatetool'                                     \n" +
-    	    "            classname='org.hibernate.tool.ant.HibernateToolTask'/>   \n" +    		
-    		"    <target name='reveng'>                                           \n" +
-    		"        <hibernatetool destdir='generated'>                          \n" +
-    		"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-    		"            <hbm2java ejb3='false'/>                                 \n" +
-    		"        </hibernatetool>                                             \n" +
-    		"    </target>                                                        \n" +		
-    		"</project>                                                           \n" ;
-
+	private static final String hibernateToolTaskXml =
+			"        <hibernatetool destdir='generated'>                          \n" +
+			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+			"            <hbm2java ejb3='false'/>                                 \n" +
+			"        </hibernatetool>                                             \n" ;
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
@@ -42,11 +42,15 @@ public class NoGenericsTestIT extends TestTemplate {
     	runAntBuild();
     	verifyResult();
     }
-    
-    private void createBuildXmlFile() throws Exception {
+
+	protected String hibernateToolTaskXml() {
+		return  hibernateToolTaskXml;
+	}
+
+	private void createBuildXmlFile() throws Exception {
     	buildXmlFile = new File(getProjectDir(), "build.xml");
     	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), buildXmlFileContents);
+    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
     }
     
 	private void createDatabase() throws Exception {
@@ -118,18 +122,10 @@ public class NoGenericsTestIT extends TestTemplate {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}
 	    
-    private static final String buildXmlFileContents = 
-    		
-    		"<project name='tutorial' default='reveng'>                           \n" +
-    		"    <taskdef                                                         \n" + 
-    		"            name='hibernatetool'                                     \n" +
-    	    "            classname='org.hibernate.tool.ant.HibernateToolTask'/>   \n" +    		
-    		"    <target name='reveng'>                                           \n" +
-    		"        <hibernatetool destdir='generated'>                          \n" +
-    		"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-    		"            <hbm2java jdk5='false'/>                                 \n" +
-    		"        </hibernatetool>                                             \n" +
-    		"    </target>                                                        \n" +		
-    		"</project>                                                           \n" ;
+	private static final String hibernateToolTaskXml =
+			"        <hibernatetool destdir='generated'>                          \n" +
+			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+			"            <hbm2java jdk5='false'/>                                 \n" +
+			"        </hibernatetool>                                             \n" ;
 
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
@@ -42,11 +42,15 @@ public class UseGenericsTestIT extends TestTemplate {
     	runAntBuild();
     	verifyResult();
     }
-    
-    private void createBuildXmlFile() throws Exception {
+
+	protected String hibernateToolTaskXml() {
+		return  hibernateToolTaskXml;
+	}
+
+	private void createBuildXmlFile() throws Exception {
     	buildXmlFile = new File(getProjectDir(), "build.xml");
     	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), buildXmlFileContents);
+    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
     }
     
 	private void createDatabase() throws Exception {
@@ -118,18 +122,9 @@ public class UseGenericsTestIT extends TestTemplate {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}
 	    
-    private static final String buildXmlFileContents = 
-    		
-    		"<project name='tutorial' default='reveng'>                           \n" +
-    		"    <taskdef                                                         \n" + 
-    		"            name='hibernatetool'                                     \n" +
-    	    "            classname='org.hibernate.tool.ant.HibernateToolTask'/>   \n" +    		
-    		"    <target name='reveng'>                                           \n" +
-    		"        <hibernatetool destdir='generated'>                          \n" +
-    		"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-    		"            <hbm2java/>                                              \n" +
-    		"        </hibernatetool>                                             \n" +
-    		"    </target>                                                        \n" +		
-    		"</project>                                                           \n" ;
-
+	private static final String hibernateToolTaskXml =
+			"        <hibernatetool destdir='generated'>                          \n" +
+			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+			"            <hbm2java/>                                              \n" +
+			"        </hibernatetool>                                             \n" ;
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
@@ -44,11 +44,15 @@ public class TutorialTestIT extends TestTemplate {
     	runAntBuild();
     	verifyResult();
     }
-    
-    private void createBuildXmlFile() throws Exception {
+
+	protected String hibernateToolTaskXml() {
+		return  hibernateToolTaskXml;
+	}
+
+	private void createBuildXmlFile() throws Exception {
     	buildXmlFile = new File(getProjectDir(), "build.xml");
     	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), buildXmlFileContents);
+    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
     }
     
 	private void createDatabase() throws Exception {
@@ -106,18 +110,9 @@ public class TutorialTestIT extends TestTemplate {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}
 	    
-    private static final String buildXmlFileContents = 
-    		
-    		"<project name='tutorial' default='reveng'>                           \n" +
-    		"    <taskdef                                                         \n" + 
-    		"            name='hibernatetool'                                     \n" +
-    	    "            classname='org.hibernate.tool.ant.HibernateToolTask'/>   \n" +    		
-    		"    <target name='reveng'>                                           \n" +
-    		"        <hibernatetool destdir='generated'>                          \n" +
-    		"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-    		"            <hbm2java/>                                              \n" +
-    		"        </hibernatetool>                                             \n" +
-    		"    </target>                                                        \n" +		
-    		"</project>                                                           \n" ;
-
+	private static final String hibernateToolTaskXml =
+			"        <hibernatetool destdir='generated'>                          \n" +
+			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+			"            <hbm2java/>                                              \n" +
+			"        </hibernatetool>                                             \n" ;
 }

--- a/ant/src/it/java/org/hibernate/tool/it/ant/TestTemplate.java
+++ b/ant/src/it/java/org/hibernate/tool/it/ant/TestTemplate.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 
-public class TestTemplate {
+public abstract class TestTemplate {
 
     @TempDir
     private File projectDir;
@@ -12,5 +12,21 @@ public class TestTemplate {
     protected File getProjectDir() {
         return projectDir;
     }
+
+    protected abstract String hibernateToolTaskXml();
+
+    protected String constructBuildXmlFileContents() {
+        return buildXmlFileContents.replace("@hibernateToolTaskXml@", hibernateToolTaskXml());
+    }
+
+    private static final String buildXmlFileContents =
+            "<project name='tutorial' default='reveng'>                           \n" +
+            "    <taskdef                                                         \n" +
+            "            name='hibernatetool'                                     \n" +
+            "            classname='org.hibernate.tool.ant.HibernateToolTask'/>   \n" +
+            "    <target name='reveng'>                                           \n" +
+            "@hibernateToolTaskXml@" +
+            "    </target>                                                        \n" +
+            "</project>                                                           \n" ;
 
 }


### PR DESCRIPTION
  - Create a new private static variable 'hibernateToolTaskXml' in the test classes with the specifics for each test
  - Pull up the private static variable 'buildXmlFileContents' and provide a placeholder for the Hibernate Tool task xml
  - Create a protected method 'constructBuildXmlFileContents' that performs the substitution of the placeholder above
  - Create an abstract method 'hibernateToolTaskXml()' that is used in the substitution above and implement in all the subclasses
