### PR TITLE
HBX-3068: Refactor the Ant integration tests to factor out common code

### DIFF
--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
@@ -1,16 +1,10 @@
 package org.hibernate.tool.ant.hbm2java;
 
-import org.apache.tools.ant.DefaultLogger;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.ProjectHelper;
 import org.hibernate.tool.it.ant.TestTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -21,13 +15,11 @@ import static org.junit.jupiter.api.Assertions.*;
 public class JpaDefaultTestIT extends TestTemplate {
 	
 	private File buildXmlFile;
-	private ByteArrayOutputStream output;
 	private File databaseFile;
 	private File personFile;
 	
 	@BeforeEach
 	public void beforeEach() {
-		output = new ByteArrayOutputStream();
 		databaseFile = new File(getProjectDir(), "database/test.mv.db");
 		assertFalse(databaseFile.exists());
 		personFile = new File(getProjectDir(), "generated/Person.java");
@@ -78,14 +70,6 @@ public class JpaDefaultTestIT extends TestTemplate {
 		assertTrue(hibernatePropertiesFile.exists());
 	}
 	
-    private void runAntBuild() {
-    	Project project = new Project();
-    	project.setBaseDir(getProjectDir());
-    	project.addBuildListener(getConsoleLogger());
-        ProjectHelper.getProjectHelper().parse(project, buildXmlFile);
-   	    project.executeTarget(project.getDefaultTarget());
-    }
-    
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -100,14 +84,6 @@ public class JpaDefaultTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
-    private DefaultLogger getConsoleLogger() {
-        DefaultLogger consoleLogger = new DefaultLogger();
-        consoleLogger.setErrorPrintStream(System.err);
-        consoleLogger.setOutputPrintStream(new PrintStream(output, true));
-        consoleLogger.setMessageOutputLevel(Project.MSG_INFO);
-        return consoleLogger;
-    }
-    
 	private String constructJdbcConnectionString() {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
@@ -1,16 +1,10 @@
 package org.hibernate.tool.ant.hbm2java;
 
-import org.apache.tools.ant.DefaultLogger;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.ProjectHelper;
 import org.hibernate.tool.it.ant.TestTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -21,13 +15,11 @@ import static org.junit.jupiter.api.Assertions.*;
 public class NoAnnotationsTestIT extends TestTemplate {
 	
 	private File buildXmlFile;
-	private ByteArrayOutputStream output;
 	private File databaseFile;
 	private File personFile;
 	
 	@BeforeEach
 	public void beforeEach() {
-		output = new ByteArrayOutputStream();
 		databaseFile = new File(getProjectDir(), "database/test.mv.db");
 		assertFalse(databaseFile.exists());
 		personFile = new File(getProjectDir(), "generated/Person.java");
@@ -78,14 +70,6 @@ public class NoAnnotationsTestIT extends TestTemplate {
 		assertTrue(hibernatePropertiesFile.exists());
 	}
 	
-    private void runAntBuild() {
-    	Project project = new Project();
-    	project.setBaseDir(getProjectDir());
-    	project.addBuildListener(getConsoleLogger());
-        ProjectHelper.getProjectHelper().parse(project, buildXmlFile);
-   	    project.executeTarget(project.getDefaultTarget());
-    }
-    
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -100,14 +84,6 @@ public class NoAnnotationsTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
-    private DefaultLogger getConsoleLogger() {
-        DefaultLogger consoleLogger = new DefaultLogger();
-        consoleLogger.setErrorPrintStream(System.err);
-        consoleLogger.setOutputPrintStream(new PrintStream(output, true));
-        consoleLogger.setMessageOutputLevel(Project.MSG_INFO);
-        return consoleLogger;
-    }
-    
 	private String constructJdbcConnectionString() {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
@@ -1,16 +1,10 @@
 package org.hibernate.tool.ant.hbm2java;
 
-import org.apache.tools.ant.DefaultLogger;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.ProjectHelper;
 import org.hibernate.tool.it.ant.TestTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -21,13 +15,11 @@ import static org.junit.jupiter.api.Assertions.*;
 public class NoGenericsTestIT extends TestTemplate {
 	
 	private File buildXmlFile;
-	private ByteArrayOutputStream output;
 	private File databaseFile;
 	private File personFile;
 	
 	@BeforeEach
 	public void beforeEach() {
-		output = new ByteArrayOutputStream();
 		databaseFile = new File(getProjectDir(), "database/test.mv.db");
 		assertFalse(databaseFile.exists());
 		personFile = new File(getProjectDir(), "generated/Person.java");
@@ -82,14 +74,6 @@ public class NoGenericsTestIT extends TestTemplate {
 		assertTrue(hibernatePropertiesFile.exists());
 	}
 	
-    private void runAntBuild() {
-    	Project project = new Project();
-    	project.setBaseDir(getProjectDir());
-    	project.addBuildListener(getConsoleLogger());
-        ProjectHelper.getProjectHelper().parse(project, buildXmlFile);
-   	    project.executeTarget(project.getDefaultTarget());
-    }
-    
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -110,14 +94,6 @@ public class NoGenericsTestIT extends TestTemplate {
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
 	}
 	
-    private DefaultLogger getConsoleLogger() {
-        DefaultLogger consoleLogger = new DefaultLogger();
-        consoleLogger.setErrorPrintStream(System.err);
-        consoleLogger.setOutputPrintStream(new PrintStream(output, true));
-        consoleLogger.setMessageOutputLevel(Project.MSG_INFO);
-        return consoleLogger;
-    }
-    
 	private String constructJdbcConnectionString() {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
@@ -1,16 +1,10 @@
 package org.hibernate.tool.ant.hbm2java;
 
-import org.apache.tools.ant.DefaultLogger;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.ProjectHelper;
 import org.hibernate.tool.it.ant.TestTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -21,13 +15,11 @@ import static org.junit.jupiter.api.Assertions.*;
 public class UseGenericsTestIT extends TestTemplate {
 	
 	private File buildXmlFile;
-	private ByteArrayOutputStream output;
 	private File databaseFile;
 	private File personFile;
 	
 	@BeforeEach
 	public void beforeEach() {
-		output = new ByteArrayOutputStream();
 		databaseFile = new File(getProjectDir(), "database/test.mv.db");
 		assertFalse(databaseFile.exists());
 		personFile = new File(getProjectDir(), "generated/Person.java");
@@ -82,14 +74,6 @@ public class UseGenericsTestIT extends TestTemplate {
 		assertTrue(hibernatePropertiesFile.exists());
 	}
 	
-    private void runAntBuild() {
-    	Project project = new Project();
-    	project.setBaseDir(getProjectDir());
-    	project.addBuildListener(getConsoleLogger());
-        ProjectHelper.getProjectHelper().parse(project, buildXmlFile);
-   	    project.executeTarget(project.getDefaultTarget());
-    }
-    
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -110,14 +94,6 @@ public class UseGenericsTestIT extends TestTemplate {
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
 	}
 	
-    private DefaultLogger getConsoleLogger() {
-        DefaultLogger consoleLogger = new DefaultLogger();
-        consoleLogger.setErrorPrintStream(System.err);
-        consoleLogger.setOutputPrintStream(new PrintStream(output, true));
-        consoleLogger.setMessageOutputLevel(Project.MSG_INFO);
-        return consoleLogger;
-    }
-    
 	private String constructJdbcConnectionString() {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}

--- a/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
@@ -4,32 +4,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 
-import org.apache.tools.ant.DefaultLogger;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.ProjectHelper;
 import org.hibernate.tool.it.ant.TestTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class TutorialTestIT extends TestTemplate {
 	
 	private File buildXmlFile;
-	private ByteArrayOutputStream output;
 	private File databaseFile;
 	private File personFile;
 	
 	@BeforeEach
 	public void beforeEach() {
-		output = new ByteArrayOutputStream();
 		databaseFile = new File(getProjectDir(), "database/test.mv.db");
 		assertFalse(databaseFile.exists());
 		personFile = new File(getProjectDir(), "generated/Person.java");
@@ -80,14 +72,6 @@ public class TutorialTestIT extends TestTemplate {
 		assertTrue(hibernatePropertiesFile.exists());
 	}
 	
-    private void runAntBuild() {
-    	Project project = new Project();
-    	project.setBaseDir(getProjectDir());
-    	project.addBuildListener(getConsoleLogger());
-        ProjectHelper.getProjectHelper().parse(project, buildXmlFile);
-   	    project.executeTarget(project.getDefaultTarget());
-    }
-    
 	private void verifyResult() {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -98,14 +82,6 @@ public class TutorialTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFile.isFile());
 	}
 	
-    private DefaultLogger getConsoleLogger() {
-        DefaultLogger consoleLogger = new DefaultLogger();
-        consoleLogger.setErrorPrintStream(System.err);
-        consoleLogger.setOutputPrintStream(new PrintStream(output, true));
-        consoleLogger.setMessageOutputLevel(Project.MSG_INFO);
-        return consoleLogger;
-    }
-    
 	private String constructJdbcConnectionString() {
 		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
 	}

--- a/ant/src/it/java/org/hibernate/tool/it/ant/TestTemplate.java
+++ b/ant/src/it/java/org/hibernate/tool/it/ant/TestTemplate.java
@@ -1,8 +1,12 @@
 package org.hibernate.tool.it.ant;
 
+import org.apache.tools.ant.DefaultLogger;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.ProjectHelper;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.PrintStream;
 
 public abstract class TestTemplate {
 
@@ -17,6 +21,23 @@ public abstract class TestTemplate {
 
     protected String constructBuildXmlFileContents() {
         return buildXmlFileContents.replace("@hibernateToolTaskXml@", hibernateToolTaskXml());
+    }
+
+    protected void runAntBuild() {
+        File buildXmlFile = new File(getProjectDir(), "build.xml");
+        Project project = new Project();
+        project.setBaseDir(getProjectDir());
+        project.addBuildListener(getConsoleLogger());
+        ProjectHelper.getProjectHelper().parse(project, buildXmlFile);
+        project.executeTarget(project.getDefaultTarget());
+    }
+
+    private DefaultLogger getConsoleLogger() {
+        DefaultLogger consoleLogger = new DefaultLogger();
+        consoleLogger.setErrorPrintStream(System.err);
+        consoleLogger.setOutputPrintStream(System.out);
+        consoleLogger.setMessageOutputLevel(Project.MSG_INFO);
+        return consoleLogger;
     }
 
     private static final String buildXmlFileContents =


### PR DESCRIPTION
  - Pull up methods 'getConsoleLogger()' and 'runAntBuild()'
  - Get rid of the 'output' ByteArrayStream
