### PR TITLE
HBX-3068: Refactor the Ant integration tests to factor out common code

### DIFF
--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
@@ -1,31 +1,16 @@
 package org.hibernate.tool.ant.hbm2java;
 
-import org.hibernate.tool.it.ant.TestTemplate;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.Statement;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.hibernate.tool.it.ant.TestTemplate;
+import org.junit.jupiter.api.Test;
 
 public class JpaDefaultTestIT extends TestTemplate {
-	
-	private File buildXmlFile;
-	private File databaseFile;
-	private File personFile;
-	
-	@BeforeEach
-	public void beforeEach() {
-		databaseFile = new File(getProjectDir(), "database/test.mv.db");
-		assertFalse(databaseFile.exists());
-		personFile = new File(getProjectDir(), "generated/Person.java");
-		assertFalse(personFile.exists());
-	}
-	
+
     @Test
     public void testJpaDefault() throws Exception {
     	createBuildXmlFile();
@@ -39,23 +24,12 @@ public class JpaDefaultTestIT extends TestTemplate {
 		return  hibernateToolTaskXml;
 	}
 
-    private void createBuildXmlFile() throws Exception {
-    	buildXmlFile = new File(getProjectDir(), "build.xml");
-    	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
-    }
-    
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.close();
-		connection.close();	
-		assertTrue(databaseFile.exists());
-		assertTrue(databaseFile.isFile());
+	protected String[] createDatabaseScript() {
+		return new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		};
 	}
-	
+
 	private void createHibernatePropertiesFile() throws Exception {
 		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
 		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
@@ -84,10 +58,6 @@ public class JpaDefaultTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
-	private String constructJdbcConnectionString() {
-		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
-	}
-	    
 	private static final String hibernateToolTaskXml =
 			"        <hibernatetool destdir='generated'>                          \n" +
 			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
@@ -1,30 +1,16 @@
 package org.hibernate.tool.ant.hbm2java;
 
-import org.hibernate.tool.it.ant.TestTemplate;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.Statement;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.hibernate.tool.it.ant.TestTemplate;
+import org.junit.jupiter.api.Test;
 
 public class NoAnnotationsTestIT extends TestTemplate {
-	
-	private File buildXmlFile;
-	private File databaseFile;
-	private File personFile;
-	
-	@BeforeEach
-	public void beforeEach() {
-		databaseFile = new File(getProjectDir(), "database/test.mv.db");
-		assertFalse(databaseFile.exists());
-		personFile = new File(getProjectDir(), "generated/Person.java");
-		assertFalse(personFile.exists());
-	}
 	
     @Test
     public void testNoAnnotations() throws Exception {
@@ -39,23 +25,12 @@ public class NoAnnotationsTestIT extends TestTemplate {
 		return  hibernateToolTaskXml;
 	}
 
-	private void createBuildXmlFile() throws Exception {
-    	buildXmlFile = new File(getProjectDir(), "build.xml");
-    	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
-    }
-    
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.close();
-		connection.close();	
-		assertTrue(databaseFile.exists());
-		assertTrue(databaseFile.isFile());
+	protected String[] createDatabaseScript() {
+		return new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		};
 	}
-	
+
 	private void createHibernatePropertiesFile() throws Exception {
 		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
 		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
@@ -84,10 +59,6 @@ public class NoAnnotationsTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
-	private String constructJdbcConnectionString() {
-		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
-	}
-	    
 	private static final String hibernateToolTaskXml =
 			"        <hibernatetool destdir='generated'>                          \n" +
 			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
@@ -1,30 +1,16 @@
 package org.hibernate.tool.ant.hbm2java;
 
-import org.hibernate.tool.it.ant.TestTemplate;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.Statement;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.hibernate.tool.it.ant.TestTemplate;
+import org.junit.jupiter.api.Test;
 
 public class NoGenericsTestIT extends TestTemplate {
-	
-	private File buildXmlFile;
-	private File databaseFile;
-	private File personFile;
-	
-	@BeforeEach
-	public void beforeEach() {
-		databaseFile = new File(getProjectDir(), "database/test.mv.db");
-		assertFalse(databaseFile.exists());
-		personFile = new File(getProjectDir(), "generated/Person.java");
-		assertFalse(personFile.exists());
-	}
 	
     @Test
     public void testUseGenerics() throws Exception {
@@ -39,27 +25,15 @@ public class NoGenericsTestIT extends TestTemplate {
 		return  hibernateToolTaskXml;
 	}
 
-	private void createBuildXmlFile() throws Exception {
-    	buildXmlFile = new File(getProjectDir(), "build.xml");
-    	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
-    }
-    
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
-		String CREATE_ITEM_TABLE =
+	protected String[] createDatabaseScript() {
+		return new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), " +
+						"primary key (ID))",
 				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
-						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute(CREATE_ITEM_TABLE);
-		statement.close();
-		connection.close();	
-		assertTrue(databaseFile.exists());
-		assertTrue(databaseFile.isFile());
+						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+		};
 	}
-	
+
 	private void createHibernatePropertiesFile() throws Exception {
 		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
 		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
@@ -94,10 +68,6 @@ public class NoGenericsTestIT extends TestTemplate {
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
 	}
 	
-	private String constructJdbcConnectionString() {
-		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
-	}
-	    
 	private static final String hibernateToolTaskXml =
 			"        <hibernatetool destdir='generated'>                          \n" +
 			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
@@ -1,30 +1,15 @@
 package org.hibernate.tool.ant.hbm2java;
 
-import org.hibernate.tool.it.ant.TestTemplate;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.Statement;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.hibernate.tool.it.ant.TestTemplate;
+import org.junit.jupiter.api.Test;
 
 public class UseGenericsTestIT extends TestTemplate {
-	
-	private File buildXmlFile;
-	private File databaseFile;
-	private File personFile;
-	
-	@BeforeEach
-	public void beforeEach() {
-		databaseFile = new File(getProjectDir(), "database/test.mv.db");
-		assertFalse(databaseFile.exists());
-		personFile = new File(getProjectDir(), "generated/Person.java");
-		assertFalse(personFile.exists());
-	}
 	
     @Test
     public void testUseGenerics() throws Exception {
@@ -39,27 +24,15 @@ public class UseGenericsTestIT extends TestTemplate {
 		return  hibernateToolTaskXml;
 	}
 
-	private void createBuildXmlFile() throws Exception {
-    	buildXmlFile = new File(getProjectDir(), "build.xml");
-    	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
-    }
-    
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
-		String CREATE_ITEM_TABLE =
+	protected String[] createDatabaseScript() {
+		return new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), " +
+						"primary key (ID))",
 				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
-						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute(CREATE_ITEM_TABLE);
-		statement.close();
-		connection.close();	
-		assertTrue(databaseFile.exists());
-		assertTrue(databaseFile.isFile());
+						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+		};
 	}
-	
+
 	private void createHibernatePropertiesFile() throws Exception {
 		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
 		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
@@ -94,10 +67,6 @@ public class UseGenericsTestIT extends TestTemplate {
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
 	}
 	
-	private String constructJdbcConnectionString() {
-		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
-	}
-	    
 	private static final String hibernateToolTaskXml =
 			"        <hibernatetool destdir='generated'>                          \n" +
 			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +

--- a/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
@@ -1,32 +1,15 @@
 package org.hibernate.tool.ant.tutorial;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.Statement;
 
 import org.hibernate.tool.it.ant.TestTemplate;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TutorialTestIT extends TestTemplate {
-	
-	private File buildXmlFile;
-	private File databaseFile;
-	private File personFile;
-	
-	@BeforeEach
-	public void beforeEach() {
-		databaseFile = new File(getProjectDir(), "database/test.mv.db");
-		assertFalse(databaseFile.exists());
-		personFile = new File(getProjectDir(), "generated/Person.java");
-		assertFalse(personFile.exists());
-	}
 	
     @Test
     public void testTutorial() throws Exception {
@@ -41,23 +24,12 @@ public class TutorialTestIT extends TestTemplate {
 		return  hibernateToolTaskXml;
 	}
 
-	private void createBuildXmlFile() throws Exception {
-    	buildXmlFile = new File(getProjectDir(), "build.xml");
-    	assertFalse(buildXmlFile.exists());
-    	Files.writeString(buildXmlFile.toPath(), constructBuildXmlFileContents());
-    }
-    
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.close();
-		connection.close();	
-		assertTrue(databaseFile.exists());
-		assertTrue(databaseFile.isFile());
+	protected String[] createDatabaseScript() {
+		return new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		};
 	}
-	
+
 	private void createHibernatePropertiesFile() throws Exception {
 		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
 		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
@@ -82,10 +54,6 @@ public class TutorialTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFile.isFile());
 	}
 	
-	private String constructJdbcConnectionString() {
-		return "jdbc:h2:" + getProjectDir().getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
-	}
-	    
 	private static final String hibernateToolTaskXml =
 			"        <hibernatetool destdir='generated'>                          \n" +
 			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +


### PR DESCRIPTION
  - Create an abstract method 'createDatabaseScript()' to return an array of SQL statements for the database creation
  - Implement this method in the integration test classes
  - Modify the 'createDatabase()' method to use the above script and pull up to TestTemplate
  - Pull up the methods 'constructJdbcConnectionString()' and createBuildXmlFile() to TestTemplate
  - Get rid of the local variables and '@BeforeEach' method for all the integration test classes
