### PR TITLE
HBX-3068: Refactor the Ant integration tests to factor out common code

### DIFF
--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
@@ -13,6 +13,17 @@ public class JpaDefaultTestIT extends TestTemplate {
 
     @Test
     public void testJpaDefault() throws Exception {
+		setHibernateToolTaskXml(
+		"""
+						<hibernatetool destdir='generated'>                         \s
+							<jdbcconfiguration propertyfile='hibernate.properties'/>\s
+							<hbm2java/>                                             \s
+						</hibernatetool>                                            \s
+				"""
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -20,30 +31,6 @@ public class JpaDefaultTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -58,10 +45,4 @@ public class JpaDefaultTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java/>                                              \n" +
-			"        </hibernatetool>                                             \n" ;
-
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
@@ -14,6 +14,17 @@ public class NoAnnotationsTestIT extends TestTemplate {
 	
     @Test
     public void testNoAnnotations() throws Exception {
+		setHibernateToolTaskXml(
+		"""
+						<hibernatetool destdir='generated'>                         \s
+							<jdbcconfiguration propertyfile='hibernate.properties'/>\s
+							<hbm2java ejb3='false'/>                                \s
+						</hibernatetool>                                            \s
+				"""
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -21,30 +32,6 @@ public class NoAnnotationsTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -59,9 +46,4 @@ public class NoAnnotationsTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java ejb3='false'/>                                 \n" +
-			"        </hibernatetool>                                             \n" ;
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
@@ -14,6 +14,20 @@ public class NoGenericsTestIT extends TestTemplate {
 	
     @Test
     public void testUseGenerics() throws Exception {
+		setHibernateToolTaskXml(
+		"""
+						<hibernatetool destdir='generated'>                         \s
+							<jdbcconfiguration propertyfile='hibernate.properties'/>\s
+							<hbm2java jdk5='false'/>                                \s
+						</hibernatetool>                                            \s
+				"""
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), " +
+						"primary key (ID))",
+				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -21,33 +35,6 @@ public class NoGenericsTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), " +
-						"primary key (ID))",
-				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
-						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -68,10 +55,4 @@ public class NoGenericsTestIT extends TestTemplate {
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java jdk5='false'/>                                 \n" +
-			"        </hibernatetool>                                             \n" ;
-
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
@@ -13,6 +13,20 @@ public class UseGenericsTestIT extends TestTemplate {
 	
     @Test
     public void testUseGenerics() throws Exception {
+		setHibernateToolTaskXml(
+		"""
+						<hibernatetool destdir='generated'>                         \s
+							<jdbcconfiguration propertyfile='hibernate.properties'/>\s
+							<hbm2java/>                                             \s
+						</hibernatetool>                                            \s
+				"""
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), " +
+						"primary key (ID))",
+				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -20,33 +34,6 @@ public class UseGenericsTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), " +
-						"primary key (ID))",
-				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
-						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -67,9 +54,4 @@ public class UseGenericsTestIT extends TestTemplate {
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java/>                                              \n" +
-			"        </hibernatetool>                                             \n" ;
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
@@ -13,6 +13,17 @@ public class TutorialTestIT extends TestTemplate {
 	
     @Test
     public void testTutorial() throws Exception {
+		setHibernateToolTaskXml(
+		"""
+						<hibernatetool destdir='generated'>                         \s
+							<jdbcconfiguration propertyfile='hibernate.properties'/>\s
+							<hbm2java/>                                             \s
+						</hibernatetool>                                            \s
+				"""
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -20,30 +31,6 @@ public class TutorialTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -54,9 +41,4 @@ public class TutorialTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFile.isFile());
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java/>                                              \n" +
-			"        </hibernatetool>                                             \n" ;
 }

--- a/ant/src/it/java/org/hibernate/tool/it/ant/TestTemplate.java
+++ b/ant/src/it/java/org/hibernate/tool/it/ant/TestTemplate.java
@@ -11,24 +11,31 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class TestTemplate {
 
     @TempDir
     private File projectDir;
 
+    private String hibernateToolTaskXml;
+    private String[] databaseCreationScript;
+
     protected File getProjectDir() {
         return projectDir;
     }
 
-    protected abstract String hibernateToolTaskXml();
+    protected void setHibernateToolTaskXml(String xml) {
+        this.hibernateToolTaskXml = xml;
+    }
 
-    protected abstract String[] createDatabaseScript();
+    protected void setDatabaseCreationScript(String[] sqls) {
+        this.databaseCreationScript = sqls;
+    }
 
     protected String constructBuildXmlFileContents() {
-        return buildXmlFileContents.replace("@hibernateToolTaskXml@", hibernateToolTaskXml());
+        assertNotNull(hibernateToolTaskXml);
+        return buildXmlFileContents.replace("@hibernateToolTaskXml@", hibernateToolTaskXml);
     }
 
     protected void runAntBuild() {
@@ -57,13 +64,26 @@ public abstract class TestTemplate {
         assertFalse(databaseFile.isFile());
         Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
         Statement statement = connection.createStatement();
-        for (String sql : createDatabaseScript()) {
+        for (String sql : databaseCreationScript) {
             statement.execute(sql);
         }
         statement.close();
         connection.close();
         assertTrue(databaseFile.exists());
         assertTrue(databaseFile.isFile());
+    }
+
+    protected void createHibernatePropertiesFile() throws Exception {
+        File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
+        String hibernatePropertiesFileContents =
+                "hibernate.connection.driver_class=org.h2.Driver\n" +
+                "hibernate.connection.url=" + constructJdbcConnectionString() + "\n" +
+                "hibernate.connection.username=\n" +
+                "hibernate.connection.password=\n" +
+                "hibernate.default_catalog=TEST\n" +
+                "hibernate.default_schema=PUBLIC\n";
+        Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents);
+        assertTrue(hibernatePropertiesFile.exists());
     }
 
     private DefaultLogger getConsoleLogger() {
@@ -75,13 +95,15 @@ public abstract class TestTemplate {
     }
 
     private static final String buildXmlFileContents =
-            "<project name='tutorial' default='reveng'>                           \n" +
-            "    <taskdef                                                         \n" +
-            "            name='hibernatetool'                                     \n" +
-            "            classname='org.hibernate.tool.ant.HibernateToolTask'/>   \n" +
-            "    <target name='reveng'>                                           \n" +
-            "@hibernateToolTaskXml@" +
-            "    </target>                                                        \n" +
-            "</project>                                                           \n" ;
+            """
+                    <project name='tutorial' default='reveng'>                          \s
+                        <taskdef                                                        \s
+                                name='hibernatetool'                                    \s
+                                classname='org.hibernate.tool.ant.HibernateToolTask'/>  \s
+                        <target name='reveng'>                                          \s
+                    @hibernateToolTaskXml@\
+                        </target>                                                       \s
+                    </project>                                                          \s
+                    """;
 
 }


### PR DESCRIPTION
  - Pull up method 'createHibernatePropertiesFile()' to TestTemplate
  - Add 'hibernateToolTaskXml' and 'databaseCreationScript' instance variables to TestTemplate along with respective setter methods
  - Remove the methods 'createDatabaseScript()' and 'hibernateToolTaskXml()' from TestTemplate and instead use the instance variables above
  - Set the instance variables in the respective integration test classes appropriately and get rid of the inherited methods from above
