### PR TITLE
HBX-3068: Refactor the Ant integration tests to factor out common code

### DIFF
--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
@@ -13,6 +13,15 @@ public class JpaDefaultTestIT extends TestTemplate {
 
     @Test
     public void testJpaDefault() throws Exception {
+		setHibernateToolTaskXml(
+				"        <hibernatetool destdir='generated'>                          \n" +
+				"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+				"            <hbm2java/>                                              \n" +
+				"        </hibernatetool>                                             \n"
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -20,30 +29,6 @@ public class JpaDefaultTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -58,10 +43,4 @@ public class JpaDefaultTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java/>                                              \n" +
-			"        </hibernatetool>                                             \n" ;
-
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
@@ -14,6 +14,15 @@ public class NoAnnotationsTestIT extends TestTemplate {
 	
     @Test
     public void testNoAnnotations() throws Exception {
+		setHibernateToolTaskXml(
+				"        <hibernatetool destdir='generated'>                          \n" +
+				"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+				"            <hbm2java ejb3='false'/>                                 \n" +
+				"        </hibernatetool>                                             \n"
+			);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -21,30 +30,6 @@ public class NoAnnotationsTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -59,9 +44,4 @@ public class NoAnnotationsTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java ejb3='false'/>                                 \n" +
-			"        </hibernatetool>                                             \n" ;
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
@@ -14,6 +14,18 @@ public class NoGenericsTestIT extends TestTemplate {
 	
     @Test
     public void testUseGenerics() throws Exception {
+		setHibernateToolTaskXml(
+				"        <hibernatetool destdir='generated'>                          \n" +
+				"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+				"            <hbm2java jdk5='false'/>                                 \n" +
+				"        </hibernatetool>                                             \n"
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), " +
+						"primary key (ID))",
+				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -21,33 +33,6 @@ public class NoGenericsTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), " +
-						"primary key (ID))",
-				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
-						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -68,10 +53,4 @@ public class NoGenericsTestIT extends TestTemplate {
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java jdk5='false'/>                                 \n" +
-			"        </hibernatetool>                                             \n" ;
-
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
@@ -13,6 +13,18 @@ public class UseGenericsTestIT extends TestTemplate {
 	
     @Test
     public void testUseGenerics() throws Exception {
+		setHibernateToolTaskXml(
+				"        <hibernatetool destdir='generated'>                          \n" +
+				"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+				"            <hbm2java/>                                              \n" +
+				"        </hibernatetool>                                             \n"
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), " +
+						"primary key (ID))",
+				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -20,33 +32,6 @@ public class UseGenericsTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), " +
-						"primary key (ID))",
-				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
-						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -67,9 +52,4 @@ public class UseGenericsTestIT extends TestTemplate {
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java/>                                              \n" +
-			"        </hibernatetool>                                             \n" ;
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
@@ -13,6 +13,15 @@ public class TutorialTestIT extends TestTemplate {
 	
     @Test
     public void testTutorial() throws Exception {
+		setHibernateToolTaskXml(
+				"        <hibernatetool destdir='generated'>                          \n" +
+				"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
+				"            <hbm2java/>                                              \n" +
+				"        </hibernatetool>                                             \n"
+		);
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		});
     	createBuildXmlFile();
     	createDatabase();
     	createHibernatePropertiesFile();
@@ -20,30 +29,6 @@ public class TutorialTestIT extends TestTemplate {
     	verifyResult();
     }
 
-	protected String hibernateToolTaskXml() {
-		return  hibernateToolTaskXml;
-	}
-
-	protected String[] createDatabaseScript() {
-		return new String[] {
-				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
-		};
-	}
-
-	private void createHibernatePropertiesFile() throws Exception {
-		File hibernatePropertiesFile = new File(getProjectDir(), "hibernate.properties");
-		StringBuffer hibernatePropertiesFileContents = new StringBuffer();	
-		hibernatePropertiesFileContents
-			.append("hibernate.connection.driver_class=org.h2.Driver\n")
-			.append("hibernate.connection.url=" + constructJdbcConnectionString() + "\n")
-			.append("hibernate.connection.username=\n")
-			.append("hibernate.connection.password=\n")
-			.append("hibernate.default_catalog=TEST\n")
-			.append("hibernate.default_schema=PUBLIC\n");
-		Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
-		assertTrue(hibernatePropertiesFile.exists());
-	}
-	
 	private void verifyResult() {
 		File generatedOutputFolder = new File(getProjectDir(), "generated");
 		assertTrue(generatedOutputFolder.exists());
@@ -54,9 +39,4 @@ public class TutorialTestIT extends TestTemplate {
 		assertTrue(generatedPersonJavaFile.isFile());
 	}
 	
-	private static final String hibernateToolTaskXml =
-			"        <hibernatetool destdir='generated'>                          \n" +
-			"            <jdbcconfiguration propertyfile='hibernate.properties'/> \n" +
-			"            <hbm2java/>                                              \n" +
-			"        </hibernatetool>                                             \n" ;
 }


### PR DESCRIPTION
  - Pull up method 'createHibernatePropertiesFile()' to TestTemplate
  - Add 'hibernateToolTaskXml' and 'databaseCreationScript' instance variables to TestTemplate along with respective setter methods
  - Remove the methods 'createDatabaseScript()' and 'hibernateToolTaskXml()' from TestTemplate and instead use the instance variables above
  - Set the instance variables in the respective integration test classes appropriately and get rid of the inherited methods from above
