### PR TITLE
HBX-3068: Refactor the Ant integration tests to factor out common code

### DIFF
--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/JpaDefaultTestIT.java
@@ -22,25 +22,12 @@ public class JpaDefaultTestIT extends TestTemplate {
 		setDatabaseCreationScript(new String[] {
 				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
 		});
-    	createBuildXmlFile();
-    	createDatabase();
-    	createHibernatePropertiesFile();
-    	runAntBuild();
-    	verifyResult();
-    }
-
-	private void verifyResult() throws Exception {
-		File generatedOutputFolder = new File(getProjectDir(), "generated");
-		assertTrue(generatedOutputFolder.exists());
-		assertTrue(generatedOutputFolder.isDirectory());
-		assertEquals(1, generatedOutputFolder.list().length);
-		File generatedPersonJavaFile = new File(generatedOutputFolder, "Person.java");
-		assertTrue(generatedPersonJavaFile.exists());
-		assertTrue(generatedPersonJavaFile.isFile());
-		String generatedPersonJavaFileContents = new String(
-				Files.readAllBytes(generatedPersonJavaFile.toPath()));
+		createProjectAndBuild();
+		assertFolderExists("generated", 1);
+		assertFileExists("generated/Person.java");
+		String generatedPersonJavaFileContents = getFileContents("generated/Person.java");
 		assertTrue(generatedPersonJavaFileContents.contains("import jakarta.persistence.Entity;"));
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
-	}
-	
+   }
+
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoAnnotationsTestIT.java
@@ -23,25 +23,12 @@ public class NoAnnotationsTestIT extends TestTemplate {
 		setDatabaseCreationScript(new String[] {
 				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
 		});
-    	createBuildXmlFile();
-    	createDatabase();
-    	createHibernatePropertiesFile();
-    	runAntBuild();
-    	verifyResult();
-    }
-
-	private void verifyResult() throws Exception {
-		File generatedOutputFolder = new File(getProjectDir(), "generated");
-		assertTrue(generatedOutputFolder.exists());
-		assertTrue(generatedOutputFolder.isDirectory());
-		assertEquals(1, generatedOutputFolder.list().length);
-		File generatedPersonJavaFile = new File(generatedOutputFolder, "Person.java");
-		assertTrue(generatedPersonJavaFile.exists());
-		assertTrue(generatedPersonJavaFile.isFile());
-		String generatedPersonJavaFileContents = new String(
-				Files.readAllBytes(generatedPersonJavaFile.toPath()));
+		createProjectAndBuild();
+		assertFolderExists("generated", 1);
+		assertFileExists("generated/Person.java");
+		String generatedPersonJavaFileContents = getFileContents("generated/Person.java");
 		assertFalse(generatedPersonJavaFileContents.contains("import jakarta.persistence.Entity;"));
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
-	}
-	
+    }
+
 }

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/NoGenericsTestIT.java
@@ -26,10 +26,7 @@ public class NoGenericsTestIT extends TestTemplate {
 				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
 						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
 		});
-    	createBuildXmlFile();
-    	createDatabase();
-    	createHibernatePropertiesFile();
-    	runAntBuild();
+		createProjectAndBuild();
     	verifyResult();
     }
 

--- a/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/hbm2java/UseGenericsTestIT.java
@@ -25,10 +25,7 @@ public class UseGenericsTestIT extends TestTemplate {
 				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
 						"primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
 		});
-    	createBuildXmlFile();
-    	createDatabase();
-    	createHibernatePropertiesFile();
-    	runAntBuild();
+		createProjectAndBuild();
     	verifyResult();
     }
 

--- a/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/tutorial/TutorialTestIT.java
@@ -22,10 +22,7 @@ public class TutorialTestIT extends TestTemplate {
 		setDatabaseCreationScript(new String[] {
 				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
 		});
-    	createBuildXmlFile();
-    	createDatabase();
-    	createHibernatePropertiesFile();
-    	runAntBuild();
+		createProjectAndBuild();
     	verifyResult();
     }
 


### PR DESCRIPTION
  - Add method 'createProjectAndBuild()' to TestTemplate to factor out creation of build.xml, database and hibernate.properties and run the ant build.
  - Collapse the respective 'verifyResult()' methods straight into the test
  - Create 'assertFolderExists(...)' and 'assertFileExists(...)' methods in TestTemplate to factor out some common verifications

