### PR TITLE
HBX-3057: Update Hibernate ORM dependency to version 6.2.42.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,24 +87,24 @@
 
         <ant.version>1.10.15</ant.version>
         <antlr.version>4.13.2</antlr.version>
-        <commons-collections.version>4.4</commons-collections.version>
+        <commons-collections.version>4.5.0</commons-collections.version>
         <freemarker.version>2.3.34</freemarker.version>
         <!-- version 1.24.0 of google-java-format is the last one compatible with java 11 -->
         <google-java-format.version>1.24.0</google-java-format.version>
         <h2.version>2.3.232</h2.version>
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version>
-        <hibernate-orm.version>6.2.41.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.2.42.Final</hibernate-orm.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <javaee-api.version>8.0.1</javaee-api.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <junit-jupiter.version>5.13.2</junit-jupiter.version>
+        <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <mysql.version>8.0.22</mysql.version>
         <oracle.version>19.3.0.0</oracle.version>
         <sqlserver.version>9.2.1.jre8</sqlserver.version>
 
         <!-- Plugins not managed by the JBoss parent POM: -->
         <maven-wrapper-plugin.version>3.3.2</maven-wrapper-plugin.version>
-        <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
+        <flatten-maven-plugin.version>1.7.2</flatten-maven-plugin.version>
 
         <!--
             We don't want to publish or sign any modules by default.


### PR DESCRIPTION
  - update commons-collections dependency to 4.5.0
  - update junit-jupiter dependency to 5.13.4
  - update flatten-maven-plugin dependency to 1.7.2
