### PR TITLE
HBX-3081: Update Hibernate ORM dependency to 7.0.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <google-java-format.version>1.27.0</google-java-format.version>
         <h2.version>2.3.232</h2.version>
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version>
-        <hibernate-orm.version>7.0.9.Final</hibernate-orm.version>
+        <hibernate-orm.version>7.0.10.Final</hibernate-orm.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <javaee-api.version>8.0.1</javaee-api.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
@@ -106,7 +106,7 @@
 
         <!-- Plugins not managed by the JBoss parent POM: -->
         <maven-wrapper-plugin.version>3.3.2</maven-wrapper-plugin.version>
-        <flatten-maven-plugin.version>1.7.1</flatten-maven-plugin.version>
+        <flatten-maven-plugin.version>1.7.2</flatten-maven-plugin.version>
         <maven-invoker-plugin.version>3.9.1</maven-invoker-plugin.version>
 
         <!--


### PR DESCRIPTION
  - Update of 'flatten-maven-plugin' dependency to 1.7.2

