### PR TITLE
HBX-3096: Add execution to 'exec-maven-plugin' to perform clean for the Gradle plugin subproject

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -92,6 +92,7 @@
                               <argument>clean</argument>
                               <argument>-PprojectVersion=${project.version}</argument>
                               <argument>-Ph2Version=${h2.version}</argument>
+                              <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
                           </arguments>
                       </configuration>
                       <goals>


### PR DESCRIPTION
  - Restore the 'maven.repo.local' system property when invoking 'gradle clean' to ${settings.localRepository}
