### PR TITLE
HBX-3096: Add execution to 'exec-maven-plugin' to perform clean for the Gradle plugin subproject

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -76,7 +76,6 @@
                                 <argument>build</argument>
                                 <argument>-PprojectVersion=${project.version}</argument>
                                 <argument>-Ph2Version=${h2.version}</argument>
-                                <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
                             </arguments>
                         </configuration>
                         <goals>
@@ -113,7 +112,6 @@
                                         <argument>publishPluginMavenPublicationToStagingRepository</argument>
                                         <argument>-PprojectVersion=${project.version}</argument>
                                         <argument>-Ph2Version=${h2.version}</argument>
-                                        <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
                                         <argument>-PmavenStagingDirectory=${local.staging.releases.repo.url}</argument>
                                     </arguments>
                                 </configuration>


### PR DESCRIPTION
  - Remove '-Dlocal.maven.repo' argument
