### PR TITLE
HBX-3096: Add execution to 'exec-maven-plugin' to perform clean for the Gradle plugin subproject

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -85,7 +85,7 @@
                   </execution>
                   <execution>
                       <id>gradle-clean</id>
-                      <phase>clean</phase>
+                      <phase>pre-clean</phase>
                       <configuration>
                           <executable>${gradle.executable}</executable>
                           <arguments>


### PR DESCRIPTION
  - Bind the 'gradle-clean' execution to the 'pre-clean' maven lifecycle phase
