### PR TITLE
HBX-3096: Add execution to 'exec-maven-plugin' to perform clean for the Gradle plugin subproject

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -44,12 +44,12 @@
        <gradle.executable>./gradlew</gradle.executable>
    </properties>
 
-   <dependencies>
+<!--   <dependencies>
        <dependency>
            <groupId>org.hibernate.tool</groupId>
            <artifactId>hibernate-tools-orm</artifactId>
        </dependency>
-   </dependencies>
+   </dependencies> -->
 
    <build>
       <plugins>


### PR DESCRIPTION
  - Comment out the 'dependencies' section to see if it has any impact on the ci release
