### PR TITLE
HBX-3096: Revert remove the '-Dmaven.repo.local=${settings.localRepository}' argument from the 'gradle-package' execution

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -76,6 +76,7 @@
                               <argument>build</argument>
                               <argument>-PprojectVersion=${project.version}</argument>
                               <argument>-Ph2Version=${h2.version}</argument>
+                              <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
                           </arguments>
                       </configuration>
                       <goals>


### PR DESCRIPTION
This reverts commit 25ca8b269df0691ecbe729cc235f4e253cbf5aee.
