### PR TITLE
HBX-3096: Add execution to 'exec-maven-plugin' to perform clean for the Gradle plugin subproject

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
 		)
 		string(
 				name: 'DEVELOPMENT_VERSION',
-				defaultValue: '7.1.1-SNAPSHOT',
+				defaultValue: '7.1.2-SNAPSHOT',
 				description: 'The next version to be used after the release, e.g. 7.1.2-SNAPSHOT.',
 				trim: true
 		)

--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -44,13 +44,6 @@
        <gradle.executable>./gradlew</gradle.executable>
    </properties>
 
-   <dependencies>
-       <dependency>
-           <groupId>org.hibernate.tool</groupId>
-           <artifactId>hibernate-tools-orm</artifactId>
-       </dependency>
-   </dependencies>
-
    <build>
       <plugins>
           <!-- Maven deploy is skipped on purpose as Gradle build will stage the artifact itself. -->
@@ -67,13 +60,29 @@
 			<artifactId>exec-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>gradle</id>
+                        <id>gradle-package</id>
                         <phase>prepare-package</phase>
                         <configuration>
                             <executable>${gradle.executable}</executable>
                             <arguments>
                                 <argument>clean</argument>
                                 <argument>build</argument>
+                                <argument>-PprojectVersion=${project.version}</argument>
+                                <argument>-Ph2Version=${h2.version}</argument>
+                                <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                            </arguments>
+                        </configuration>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>gradle-clean</id>
+                        <phase>clean</phase>
+                        <configuration>
+                            <executable>${gradle.executable}</executable>
+                            <arguments>
+                                <argument>clean</argument>
                                 <argument>-PprojectVersion=${project.version}</argument>
                                 <argument>-Ph2Version=${h2.version}</argument>
                             </arguments>
@@ -112,6 +121,7 @@
                                         <argument>publishPluginMavenPublicationToStagingRepository</argument>
                                         <argument>-PprojectVersion=${project.version}</argument>
                                         <argument>-Ph2Version=${h2.version}</argument>
+                                        <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
                                         <argument>-PmavenStagingDirectory=${local.staging.releases.repo.url}</argument>
                                     </arguments>
                                 </configuration>


### PR DESCRIPTION
  - Restore '-Dmaven.repo.local' argument for the 'gradle-package' execution
  - Remove the unneeded dependencies section in the 'gradle/pom.xml'
  - Correct typo in Jenkinsfile
