### PR TITLE
HBX-3096: Add execution to 'exec-maven-plugin' to perform clean for the Gradle plugin subproject

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -44,13 +44,6 @@
        <gradle.executable>./gradlew</gradle.executable>
    </properties>
 
-   <dependencies>
-       <dependency>
-           <groupId>org.hibernate.tool</groupId>
-           <artifactId>hibernate-tools-orm</artifactId>
-       </dependency>
-   </dependencies>
-
    <build>
       <plugins>
           <!-- Maven deploy is skipped on purpose as Gradle build will stage the artifact itself. -->
@@ -76,6 +69,7 @@
                               <argument>build</argument>
                               <argument>-PprojectVersion=${project.version}</argument>
                               <argument>-Ph2Version=${h2.version}</argument>
+                              <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
                           </arguments>
                       </configuration>
                       <goals>


### PR DESCRIPTION
  - Remove the unneeded dependency section from 'gradle/pom.xml'
  - Restore the '-Dmaven.repo.local' argument to the 'gradle-package' execution of the exec-maven-plugin
