### PR TITLE
HBX-3080: Refactor the Gradle integration tests to factor out common code

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
@@ -17,7 +17,9 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class JpaDefaultTest {
+import org.hibernate.tool.it.gradle.TestTemplate;
+
+public class JpaDefaultTest extends TestTemplate {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
 			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
@@ -17,7 +17,9 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class NoAnnotationsTest {
+import org.hibernate.tool.it.gradle.TestTemplate;
+
+public class NoAnnotationsTest extends TestTemplate {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
 			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
@@ -16,7 +16,9 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class NoGenerics {
+import org.hibernate.tool.it.gradle.TestTemplate;
+
+public class NoGenerics extends TestTemplate {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
 			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
@@ -16,7 +16,9 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class UseGenerics {
+import org.hibernate.tool.it.gradle.TestTemplate;
+
+public class UseGenerics extends TestTemplate {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
 			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.it.gradle;
+
+public class TestTemplate {
+
+}


### PR DESCRIPTION
  - Create integration test template class 'org.hibernate.tool.it.gradle.TestTemplate'
  - Make the following classes extends the template from above:
    * org.hibernate.tool.gradle.java.JpaDefaultTest
    * org.hibernate.tool.gradle.java.NoAnnotationsTest
    * org.hibernate.tool.gradle.java.NoGenerics
    * org.hibernate.tool.gradle.java.UseGenerics
