### PR TITLE
HBX-3080: Refactor the Gradle integration tests to factor out common code

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/tutorial/TutorialTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/tutorial/TutorialTest.java
@@ -17,7 +17,9 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class TutorialTest {
+import org.hibernate.tool.it.gradle.TestTemplate;
+
+public class TutorialTest extends TestTemplate {
 	
 	private static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
 			"init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");


### PR DESCRIPTION
  - Make integration test class 'org.hibernate.tool.gradle.tutorial.TutorialTest' extend the template
