### PR TITLE
HBX-3080: Refactor the Gradle integration tests to factor out common code

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
@@ -22,35 +22,18 @@ public class JpaDefaultTest extends TestTemplate {
 	
 	@Test
 	public void testTutorial() throws Exception {
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))",
+				"insert into PERSON values (1, 'foo')"
+		});
 		assertTrue(getProjectDir().exists());
 		createGradleProject();
 		editGradleBuildFile();
 		editGradlePropertiesFile();
 		createDatabase();
 		createHibernatePropertiesFile();
-		verifyDatabase();
 		executeGenerateJavaTask();
 		verifyProject();
-	}
-	
-	private void verifyDatabase() throws Exception {
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		ResultSet resultSet = connection.createStatement().executeQuery("select * from PERSON");
-		assertTrue(resultSet.next());
-		assertEquals(1, resultSet.getInt(1));
-		assertEquals("foo", resultSet.getString(2));
-	}
-	
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute("insert into PERSON values (1, 'foo')");
-		statement.close();
-		connection.close();	
-		assertTrue(getDatabaseFile().exists());
-		assertTrue(getDatabaseFile().isFile());
 	}
 	
 	private void executeGenerateJavaTask() throws Exception {

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
@@ -22,35 +22,18 @@ public class NoAnnotationsTest extends TestTemplate {
 	
 	@Test
 	public void testTutorial() throws Exception {
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))",
+				"insert into PERSON values (1, 'foo')"
+		});
 		assertTrue(getProjectDir().exists());
 		createGradleProject();
 		editGradleBuildFile();
 		editGradlePropertiesFile();
 		createDatabase();
 		createHibernatePropertiesFile();
-		verifyDatabase();
 		executeGenerateJavaTask();
 		verifyProject();
-	}
-	
-	private void verifyDatabase() throws Exception {
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		ResultSet resultSet = connection.createStatement().executeQuery("select * from PERSON");
-		assertTrue(resultSet.next());
-		assertEquals(1, resultSet.getInt(1));
-		assertEquals("foo", resultSet.getString(2));
-	}
-	
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute("insert into PERSON values (1, 'foo')");
-		statement.close();
-		connection.close();	
-		assertTrue(getDatabaseFile().exists());
-		assertTrue(getDatabaseFile().isFile());
 	}
 	
 	private void executeGenerateJavaTask() throws Exception {

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
@@ -21,6 +21,11 @@ public class NoGenerics extends TestTemplate {
 	
 	@Test
 	public void testTutorial() throws Exception {
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null,  NAME varchar(20), primary key (ID))",
+				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+		});
 		assertTrue(getProjectDir().exists());
 		createGradleProject();
 		editGradleBuildFile();
@@ -30,23 +35,7 @@ public class NoGenerics extends TestTemplate {
 		executeGenerateJavaTask();
 		verifyProject();
 	}
-	
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE =
-			    "create table PERSON (ID int not null,  NAME varchar(20), primary key (ID))";
-		String CREATE_ITEM_TABLE =
-			    "create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
-			    "   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute(CREATE_ITEM_TABLE);
-		statement.close();
-		connection.close();
-		assertTrue(getDatabaseFile().exists());
-		assertTrue(getDatabaseFile().isFile());
-	}
-	
+
 	private void executeGenerateJavaTask() throws Exception {
 		GradleRunner gradleRunner = GradleRunner.create();
 		gradleRunner.forwardOutput();

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
@@ -21,6 +21,11 @@ public class UseGenerics extends TestTemplate {
 	
 	@Test
 	public void testTutorial() throws Exception {
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null,  NAME varchar(20), primary key (ID))",
+				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+		});
 		assertTrue(getProjectDir().exists());
 		createGradleProject();
 		editGradleBuildFile();
@@ -30,23 +35,7 @@ public class UseGenerics extends TestTemplate {
 		executeGenerateJavaTask();
 		verifyProject();
 	}
-	
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE =
-			    "create table PERSON (ID int not null,  NAME varchar(20), primary key (ID))";
-		String CREATE_ITEM_TABLE =
-			    "create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
-			    "   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute(CREATE_ITEM_TABLE);
-		statement.close();
-		connection.close();
-		assertTrue(getDatabaseFile().exists());
-		assertTrue(getDatabaseFile().isFile());
-	}
-	
+
 	private void executeGenerateJavaTask() throws Exception {
 		GradleRunner gradleRunner = GradleRunner.create();
 		gradleRunner.forwardOutput();

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/tutorial/TutorialTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/tutorial/TutorialTest.java
@@ -22,35 +22,18 @@ public class TutorialTest extends TestTemplate {
 	
 	@Test
 	public void testTutorial() throws Exception {
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))",
+				"insert into PERSON values (1, 'foo')"
+		});
 		assertTrue(getProjectDir().exists());
 		createGradleProject();
 		editGradleBuildFile();
 		editGradlePropertiesFile();
 		createDatabase();
 		createHibernatePropertiesFile();
-		verifyDatabase();
 		executeGenerateJavaTask();
 		verifyProject();
-	}
-	
-	private void verifyDatabase() throws Exception {
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		ResultSet resultSet = connection.createStatement().executeQuery("select * from PERSON");
-		assertTrue(resultSet.next());
-		assertEquals(1, resultSet.getInt(1));
-		assertEquals("foo", resultSet.getString(2));
-	}
-	
-	private void createDatabase() throws Exception {
-		String CREATE_PERSON_TABLE = "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))";
-		Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
-		Statement statement = connection.createStatement();
-		statement.execute(CREATE_PERSON_TABLE);
-		statement.execute("insert into PERSON values (1, 'foo')");
-		statement.close();
-		connection.close();	
-		assertTrue(getDatabaseFile().exists());
-		assertTrue(getDatabaseFile().isFile());
 	}
 	
 	private void executeGenerateJavaTask() throws Exception {

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
 import java.util.List;
 
 import org.junit.jupiter.api.io.TempDir;
@@ -24,6 +27,8 @@ public class TestTemplate {
     private File gradleBuildFile;
     private File databaseFile;
 
+    private String[] databaseCreationScript;
+
     protected File getProjectDir() { return projectDir; }
     protected File getGradlePropertiesFile() { return gradlePropertiesFile; }
     protected void setGradlePropertiesFile(File f) { this.gradlePropertiesFile = f; }
@@ -31,6 +36,8 @@ public class TestTemplate {
     protected void setGradleBuildFile(File f) { gradleBuildFile = f; }
     protected File getDatabaseFile() { return databaseFile; }
     protected void setDatabaseFile(File f) { databaseFile = f; }
+    protected String[] getDatabaseCreationScript() { return databaseCreationScript; }
+    protected void setDatabaseCreationScript(String[] script) { databaseCreationScript = script; }
 
     protected void createGradleProject() throws Exception {
         GradleRunner runner = GradleRunner.create();
@@ -84,6 +91,18 @@ public class TestTemplate {
                 .append("hibernate.default_schema=PUBLIC\n");
         Files.writeString(hibernatePropertiesFile.toPath(), hibernatePropertiesFileContents.toString());
         assertTrue(hibernatePropertiesFile.exists());
+    }
+
+    protected void createDatabase() throws Exception {
+        Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
+        Statement statement = connection.createStatement();
+        for (String sql : getDatabaseCreationScript()) {
+            statement.execute(sql);
+        }
+        statement.close();
+        connection.close();
+        assertTrue(getDatabaseFile().exists());
+        assertTrue(getDatabaseFile().isFile());
     }
 
     protected String constructH2DatabaseDependencyLine() {


### PR DESCRIPTION
  - Add instance variable 'databaseCreationScript' to TestTemplate along with getter/setter
  - Extract the database creation SQL and use the setter above to populate the instance variable
  - Pull up method 'createDatabase()' to the class TestTemplate
  - Omit the calls to 'verifyDatabase()' and remove the method
