### PR TITLE
HBX-3080: Refactor the Gradle integration tests to factor out common code

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
@@ -26,12 +26,7 @@ public class JpaDefaultTest extends TestTemplate {
 				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))",
 				"insert into PERSON values (1, 'foo')"
 		});
-		assertTrue(getProjectDir().exists());
-		createGradleProject();
-		editGradleBuildFile();
-		editGradlePropertiesFile();
-		createDatabase();
-		createHibernatePropertiesFile();
+		createProject();
 		executeGenerateJavaTask();
 		verifyProject();
 	}

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
@@ -26,12 +26,7 @@ public class NoAnnotationsTest extends TestTemplate {
 				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))",
 				"insert into PERSON values (1, 'foo')"
 		});
-		assertTrue(getProjectDir().exists());
-		createGradleProject();
-		editGradleBuildFile();
-		editGradlePropertiesFile();
-		createDatabase();
-		createHibernatePropertiesFile();
+		createProject();
 		executeGenerateJavaTask();
 		verifyProject();
 	}

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
@@ -26,12 +26,7 @@ public class NoGenerics extends TestTemplate {
 				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
 						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
 		});
-		assertTrue(getProjectDir().exists());
-		createGradleProject();
-		editGradleBuildFile();
-		editGradlePropertiesFile();
-		createDatabase();
-		createHibernatePropertiesFile();
+		createProject();
 		executeGenerateJavaTask();
 		verifyProject();
 	}

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
@@ -26,12 +26,7 @@ public class UseGenerics extends TestTemplate {
 				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
 						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
 		});
-		assertTrue(getProjectDir().exists());
-		createGradleProject();
-		editGradleBuildFile();
-		editGradlePropertiesFile();
-		createDatabase();
-		createHibernatePropertiesFile();
+		createProject();
 		executeGenerateJavaTask();
 		verifyProject();
 	}

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/tutorial/TutorialTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/tutorial/TutorialTest.java
@@ -26,12 +26,7 @@ public class TutorialTest extends TestTemplate {
 				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))",
 				"insert into PERSON values (1, 'foo')"
 		});
-		assertTrue(getProjectDir().exists());
-		createGradleProject();
-		editGradleBuildFile();
-		editGradlePropertiesFile();
-		createDatabase();
-		createHibernatePropertiesFile();
+		createProject();
 		executeGenerateJavaTask();
 		verifyProject();
 	}

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
@@ -39,7 +39,15 @@ public class TestTemplate {
     protected String[] getDatabaseCreationScript() { return databaseCreationScript; }
     protected void setDatabaseCreationScript(String[] script) { databaseCreationScript = script; }
 
-    protected void createGradleProject() throws Exception {
+    protected void createProject() throws Exception {
+        initGradleProject();
+        editGradleBuildFile();
+        editGradlePropertiesFile();
+        createDatabase();
+        createHibernatePropertiesFile();
+    }
+
+    protected void initGradleProject() throws Exception {
         GradleRunner runner = GradleRunner.create();
         runner.withArguments(GRADLE_INIT_PROJECT_ARGUMENTS);
         runner.forwardOutput();


### PR DESCRIPTION
  - Factor out the project and database creation and initialization in a 'createProject()' method
  - Rename the TestTemplate#createGradleProject() to TestTemplate#initGradleProject()
