### PR TITLE
HBX-3080: Refactor the Gradle integration tests to factor out common code

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/JpaDefaultTest.java
@@ -27,18 +27,8 @@ public class JpaDefaultTest extends TestTemplate {
 				"insert into PERSON values (1, 'foo')"
 		});
 		createProject();
-		executeGenerateJavaTask();
+		executeGradleCommand("generateJava");
 		verifyProject();
-	}
-	
-	private void executeGenerateJavaTask() throws Exception {
-		GradleRunner gradleRunner = GradleRunner.create();
-		gradleRunner.forwardOutput();
-		gradleRunner.withProjectDir(getProjectDir());
-		gradleRunner.withPluginClasspath();
-		gradleRunner.withArguments("generateJava");
-		BuildResult buildResult = gradleRunner.build();
-		assertTrue(buildResult.getOutput().contains("BUILD SUCCESSFUL"));
 	}
 	
 	private void verifyProject() throws Exception {

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
@@ -27,18 +27,8 @@ public class NoAnnotationsTest extends TestTemplate {
 				"insert into PERSON values (1, 'foo')"
 		});
 		createProject();
-		executeGenerateJavaTask();
+		executeGradleCommand("generateJava");
 		verifyProject();
-	}
-	
-	private void executeGenerateJavaTask() throws Exception {
-		GradleRunner gradleRunner = GradleRunner.create();
-		gradleRunner.forwardOutput();
-		gradleRunner.withProjectDir(getProjectDir());
-		gradleRunner.withPluginClasspath();
-		gradleRunner.withArguments("generateJava");
-		BuildResult buildResult = gradleRunner.build();
-		assertTrue(buildResult.getOutput().contains("BUILD SUCCESSFUL"));
 	}
 	
 	private void verifyProject() throws Exception {

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
@@ -27,20 +27,10 @@ public class NoGenerics extends TestTemplate {
 						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
 		});
 		createProject();
-		executeGenerateJavaTask();
+		executeGradleCommand("generateJava");
 		verifyProject();
 	}
 
-	private void executeGenerateJavaTask() throws Exception {
-		GradleRunner gradleRunner = GradleRunner.create();
-		gradleRunner.forwardOutput();
-		gradleRunner.withProjectDir(getProjectDir());
-		gradleRunner.withPluginClasspath();
-		gradleRunner.withArguments("generateJava");
-		BuildResult buildResult = gradleRunner.build();
-		assertTrue(buildResult.getOutput().contains("BUILD SUCCESSFUL"));
-	}
-	
 	private void verifyProject() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "app/generated-sources");
 		assertTrue(generatedOutputFolder.exists());

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/UseGenerics.java
@@ -27,20 +27,10 @@ public class UseGenerics extends TestTemplate {
 						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
 		});
 		createProject();
-		executeGenerateJavaTask();
+		executeGradleCommand("generateJava");
 		verifyProject();
 	}
 
-	private void executeGenerateJavaTask() throws Exception {
-		GradleRunner gradleRunner = GradleRunner.create();
-		gradleRunner.forwardOutput();
-		gradleRunner.withProjectDir(getProjectDir());
-		gradleRunner.withPluginClasspath();
-		gradleRunner.withArguments("generateJava");
-		BuildResult buildResult = gradleRunner.build();
-		assertTrue(buildResult.getOutput().contains("BUILD SUCCESSFUL"));
-	}
-	
 	private void verifyProject() throws Exception {
 		File generatedOutputFolder = new File(getProjectDir(), "app/generated-sources");
 		assertTrue(generatedOutputFolder.exists());

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/tutorial/TutorialTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/tutorial/TutorialTest.java
@@ -27,18 +27,8 @@ public class TutorialTest extends TestTemplate {
 				"insert into PERSON values (1, 'foo')"
 		});
 		createProject();
-		executeGenerateJavaTask();
+		executeGradleCommand("generateJava");
 		verifyProject();
-	}
-	
-	private void executeGenerateJavaTask() throws Exception {
-		GradleRunner gradleRunner = GradleRunner.create();
-		gradleRunner.forwardOutput();
-		gradleRunner.withProjectDir(getProjectDir());
-		gradleRunner.withPluginClasspath();
-		gradleRunner.withArguments("generateJava");
-		BuildResult buildResult = gradleRunner.build();
-		assertTrue(buildResult.getOutput().contains("BUILD SUCCESSFUL"));
 	}
 	
 	private void verifyProject() {

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
@@ -17,8 +17,8 @@ import org.gradle.testkit.runner.GradleRunner;
 
 public class TestTemplate {
 
-    protected static final List<String> GRADLE_INIT_PROJECT_ARGUMENTS = List.of(
-            "init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17");
+    protected static final String[] GRADLE_INIT_PROJECT_ARGUMENTS = new String[] {
+            "init", "--type", "java-application", "--dsl", "groovy", "--test-framework", "junit-jupiter", "--java-version", "17"};
 
     @TempDir
     private File projectDir;
@@ -39,6 +39,16 @@ public class TestTemplate {
     protected String[] getDatabaseCreationScript() { return databaseCreationScript; }
     protected void setDatabaseCreationScript(String[] script) { databaseCreationScript = script; }
 
+    protected void executeGradleCommand(String ... gradleCommandLine) {
+        GradleRunner runner = GradleRunner.create();
+        runner.withArguments(gradleCommandLine);
+        runner.forwardOutput();
+        runner.withPluginClasspath();
+        runner.withProjectDir(getProjectDir());
+        BuildResult buildResult = runner.build();
+        assertTrue(buildResult.getOutput().contains("BUILD SUCCESSFUL"));
+    }
+
     protected void createProject() throws Exception {
         initGradleProject();
         editGradleBuildFile();
@@ -48,12 +58,7 @@ public class TestTemplate {
     }
 
     protected void initGradleProject() throws Exception {
-        GradleRunner runner = GradleRunner.create();
-        runner.withArguments(GRADLE_INIT_PROJECT_ARGUMENTS);
-        runner.forwardOutput();
-        runner.withProjectDir(getProjectDir());
-        BuildResult buildResult = runner.build();
-        assertTrue(buildResult.getOutput().contains("BUILD SUCCESSFUL"));
+        executeGradleCommand(GRADLE_INIT_PROJECT_ARGUMENTS);
         setGradlePropertiesFile(new File(getProjectDir(), "gradle.properties"));
         assertTrue(getGradlePropertiesFile().exists());
         assertTrue(getGradlePropertiesFile().isFile());


### PR DESCRIPTION
  - Create method 'executeGradleCommand(String...)' in class TestTemplate to execute Gradle command lines
  - Use above method in the 'TestTemplate#initGradleProject()' method
  - Replace the 'executeGenerateJavaTask()' methods in the different test classes using the above method
