### PR TITLE
HBX-3080: Refactor the Gradle integration tests to factor out common code

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoAnnotationsTest.java
@@ -26,6 +26,11 @@ public class NoAnnotationsTest extends TestTemplate {
 				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))",
 				"insert into PERSON values (1, 'foo')"
 		});
+		setHibernateToolsExtensionSection(
+				"hibernateTools { \n" +
+				"  generateAnnotations=false \n" +
+				"}"
+		);
 		createProject();
 		executeGradleCommand("generateJava");
 		verifyProject();
@@ -43,19 +48,6 @@ public class NoAnnotationsTest extends TestTemplate {
 				Files.readAllBytes(generatedPersonJavaFile.toPath()));
 		assertFalse(generatedPersonJavaFileContents.contains("import jakarta.persistence.Entity;"));
 		assertTrue(generatedPersonJavaFileContents.contains("public class Person "));
-	}
-	
-	protected void addHibernateToolsExtension(StringBuffer gradleBuildFileContents) {
-		int pos = gradleBuildFileContents.indexOf("dependencies {");
-		pos = gradleBuildFileContents.indexOf("}", pos);
-		StringBuffer hibernateToolsExtension = new StringBuffer();
-		hibernateToolsExtension
-			.append("\n")
-			.append("\n")
-			.append("hibernateTools { \n")
-			.append("  generateAnnotations=false \n")
-			.append("}");
-		gradleBuildFileContents.insert(pos + 1, hibernateToolsExtension.toString());
 	}
 	
 }

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/java/NoGenerics.java
@@ -26,6 +26,11 @@ public class NoGenerics extends TestTemplate {
 				"create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
 						"   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
 		});
+		setHibernateToolsExtensionSection(
+				"hibernateTools { \n" +
+				"  useGenerics=false \n" +
+				"}"
+		);
 		createProject();
 		executeGradleCommand("generateJava");
 		verifyProject();
@@ -49,19 +54,6 @@ public class NoGenerics extends TestTemplate {
 		String generatedItemJavaFileContents = new String(
 				Files.readAllBytes(generatedItemJavaFile.toPath()));
 		assertTrue(generatedItemJavaFileContents.contains("public class Item "));
-	}
-	
-	protected void addHibernateToolsExtension(StringBuffer gradleBuildFileContents) {
-		int pos = gradleBuildFileContents.indexOf("dependencies {");
-		pos = gradleBuildFileContents.indexOf("}", pos);
-		StringBuffer hibernateToolsExtension = new StringBuffer();
-		hibernateToolsExtension
-			.append("\n")
-			.append("\n")
-			.append("hibernateTools { \n")
-			.append("  useGenerics=false \n")
-			.append("}");
-		gradleBuildFileContents.insert(pos + 1, hibernateToolsExtension.toString());
 	}
 	
 }

--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/it/gradle/TestTemplate.java
@@ -28,6 +28,7 @@ public class TestTemplate {
     private File databaseFile;
 
     private String[] databaseCreationScript;
+    private String hibernateToolsExtensionSection;
 
     protected File getProjectDir() { return projectDir; }
     protected File getGradlePropertiesFile() { return gradlePropertiesFile; }
@@ -38,6 +39,8 @@ public class TestTemplate {
     protected void setDatabaseFile(File f) { databaseFile = f; }
     protected String[] getDatabaseCreationScript() { return databaseCreationScript; }
     protected void setDatabaseCreationScript(String[] script) { databaseCreationScript = script; }
+    protected String getHibernateToolsExtensionSection() { return hibernateToolsExtensionSection; }
+    protected void setHibernateToolsExtensionSection(String s) { hibernateToolsExtensionSection = s; }
 
     protected void executeGradleCommand(String ... gradleCommandLine) {
         GradleRunner runner = GradleRunner.create();
@@ -143,6 +146,14 @@ public class TestTemplate {
         gradleBuildFileContents.insert(pos, constructHibernateToolsPluginLine() + "\n");
     }
 
-    protected void addHibernateToolsExtension(StringBuffer gradleBuildFileContents) {}
-
+    protected void addHibernateToolsExtension(StringBuffer gradleBuildFileContents) {
+        String extension = getHibernateToolsExtensionSection();
+        if (extension != null) {
+            int pos = gradleBuildFileContents.indexOf("dependencies {");
+            pos = gradleBuildFileContents.indexOf("}", pos);
+            gradleBuildFileContents.insert(pos + 1, "\n\n" + extension);
+        }
+    }
 }
+
+


### PR DESCRIPTION
  - Create an instance variable 'hibernateToolsExtensionSection' in TestTemplate along with setter/getter
  - Pull up method 'TestTemplate#addHibernateToolsExtension(StringBuffer)' making use of the above instance variable
  - Set the instance variable above in the test method of the 'NoGenerics' and 'NoAnnotationsTest' test classes
