### PR TITLE
HBX-3080: Refactor the Gradle integration tests to factor out common code

### DIFF
--- a/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/GenerateJavaTest.java
+++ b/gradle/plugin/src/functionalTest/java/org/hibernate/tool/gradle/GenerateJavaTest.java
@@ -21,43 +21,35 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.hibernate.tool.gradle.test.func.utils.FuncTestConstants;
 import org.hibernate.tool.gradle.test.func.utils.FuncTestTemplate;
+import org.hibernate.tool.it.gradle.TestTemplate;
 import org.junit.jupiter.api.Test;
 
-class GenerateJavaTest extends FuncTestTemplate implements FuncTestConstants {
+class GenerateJavaTest extends TestTemplate {
 
-    private static final String BUILD_FILE_HIBERNATE_TOOLS_SECTION = 
-            "hibernateTools {\n" +
-            "  packageName = 'foo.model'\n" +
-            "}\n";
-
-	@Override
-	public String getBuildFileHibernateToolsSection() {
-	    return BUILD_FILE_HIBERNATE_TOOLS_SECTION;
+	@Test
+	public void testPackageName() throws Exception {
+		setDatabaseCreationScript(new String[] {
+				"create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+		});
+		setHibernateToolsExtensionSection(
+				"hibernateTools { \n" +
+				"  packageName = 'foo.model' \n" +
+				"}"
+		);
+		createProject();
+		executeGradleCommand("generateJava");
+		File generatedSourcesFolder = new File(getProjectDir(), "app/generated-sources");
+		assertTrue(generatedSourcesFolder.exists());
+		assertTrue(generatedSourcesFolder.isDirectory());
+		File fooFile = new File(generatedSourcesFolder, "foo/model/Person.java");
+		assertTrue(fooFile.exists());
+		assertTrue(fooFile.isFile());
 	}
 
-    @Test 
-    void testGenerateJava() throws IOException {
-    	performTask("generateJava", true);
-    }
-    
-    @Override
-    protected void verifyBuild(BuildResult buildResult) {
-    	try {
-	        File generatedSourcesFolder = new File(projectDir, "generated-sources");
-	        assertTrue(buildResult.getOutput().contains(
-	        		"Starting Java export to directory: " + generatedSourcesFolder.getCanonicalPath()));
-	        assertTrue(generatedSourcesFolder.exists());
-	        assertTrue(generatedSourcesFolder.isDirectory());
-	        File fooFile = new File(generatedSourcesFolder, "foo/model/Foo.java");
-	        assertTrue(fooFile.exists());
-	        assertTrue(fooFile.isFile());
-    	} catch (Exception e) {
-    		throw new RuntimeException(e);
-    	}
-    }
-    
-  }
+
+}


### PR DESCRIPTION
  - Make test class 'GenerateJavaTest' extend 'TestTemplate'
  - Rename the test method to 'testPackageName' and adapt it to the new template
