### PR TITLE
HBX-3110: Add a functional test to guard the sanity of the Ant examples

### DIFF
--- a/ant/docs/examples/common/included.xml
+++ b/ant/docs/examples/common/included.xml
@@ -15,7 +15,7 @@
   -->
 <project name="common" xmlns:ivy="antlib:org.apache.ivy.ant">
 
-    <property name="hibernate-tools.version" value="7.1.1.Final"/>
+    <property name="hibernate-tools.version" value="@project.version@"/>
     <property name="javaee-api.version" value="8.0.1"/>
     <property name="jdbc-driver.org" value="com.h2database"/>
     <property name="jdbc-driver.module" value="h2"/>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -62,22 +62,63 @@
 
     <build>
         <plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>filter-test-resources</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testResources</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${project.build.testOutputDirectory}</directory>
+									<filtering>true</filtering>
+									<includes>
+										<include>common/included.xml</include>
+									</includes>
+								</resource>
+							</resources>
+							<delimiters>
+								<delimiter>@*@</delimiter>
+							</delimiters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
-                    <execution>
-                        <id>add-test-source</id>
-                        <phase>generate-test-sources</phase>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/it/java</source>
-                            </sources>
-                        </configuration>
-                    </execution>
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/it/java</source>
+							</sources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>add-test-resource</id>
+						<phase>generate-test-resources</phase>
+						<goals>
+							<goal>add-test-resource</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>docs/examples</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
                 </executions>
             </plugin>
 			<plugin>

--- a/ant/src/it/java/org/hibernate/tool/ant/ExamplesTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/ExamplesTestIT.java
@@ -1,0 +1,17 @@
+package org.hibernate.tool.ant;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+public class ExamplesTestIT {
+
+    @Test
+    public void testSomethin() {
+        URL url = getClass().getClassLoader().getResource("5-minute-tutorial/build.xml");
+        System.out.println(url);
+    }
+
+}


### PR DESCRIPTION
  - Add a delimiter to 'ant/docs/examples/common/included.xml' to be able to filter the version
  - Adapt the 'ant/pom.xml' to copy the examples as test resources while filtering for the version
  - Create a new test class (doing nothing much at this time)
