### PR TITLE
HBX-3112: Add the dependencies of the Maven plugin build to the dependency management section in the parent pom

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -30,9 +30,6 @@
   <name>Hibernate Tools Maven Plugin</name>
   <description>Maven plugin to provide hibernate-tools reverse engineering and code/schema generation abilities.</description>
 
-    <developers>
-  </developers>
-
   <properties>
     <!-- This is a publicly distributed module that should be published: -->
     <deploy.skip>false</deploy.skip>


### PR DESCRIPTION
  - Remove unneeded '<developers/>' section from 'maven/pom.xml'
