### PR TITLE
HBX-3110: Add a functional test to guard the sanity of the Ant examples

### DIFF
--- a/ant/docs/examples/common/included.xml
+++ b/ant/docs/examples/common/included.xml
@@ -16,10 +16,10 @@
 <project name="common" xmlns:ivy="antlib:org.apache.ivy.ant">
 
     <property name="hibernate-tools.version" value="@project.version@"/>
-    <property name="javaee-api.version" value="8.0.1"/>
+    <property name="javaee-api.version" value="@javaee-api.version@"/>
     <property name="jdbc-driver.org" value="com.h2database"/>
     <property name="jdbc-driver.module" value="h2"/>
-    <property name="jdbc-driver.version" value="2.3.232"/>
+    <property name="jdbc-driver.version" value="@h2.version@"/>
 
     <ivy:cachepath
             organisation="org.hibernate.tool"


### PR DESCRIPTION
  - Modify 'common/included.xml' to be able to replace the versions of 'javaee-api' and 'h2' with the actual used versions
