### PR TITLE
HBX-3038: Gradle 'generateJava' task should generate annotated entities by default

### DIFF
--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -18,6 +18,7 @@ public class GenerateJavaTask extends AbstractTask {
 	void doWork() {
 		getLogger().lifecycle("Creating Java exporter");
 		Exporter pojoExporter = ExporterFactory.createExporter(ExporterType.JAVA);
+		pojoExporter.getProperties().setProperty("ejb3", String.valueOf(getExtension().generateAnnotations));
 		File outputFolder = getOutputFolder();
 		pojoExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, createJdbcDescriptor());
 		pojoExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputFolder);


### PR DESCRIPTION
      - Use the 'generateAnnotations' configuration to set the 'ejb' property when creating the JavaExporter
