### PR TITLE
HBX-3044: Gradle 'generateJava' task should use generics by default

### DIFF
--- a/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
+++ b/gradle/plugin/src/main/java/org/hibernate/tool/gradle/task/GenerateJavaTask.java
@@ -19,6 +19,7 @@ public class GenerateJavaTask extends AbstractTask {
 		getLogger().lifecycle("Creating Java exporter");
 		Exporter pojoExporter = ExporterFactory.createExporter(ExporterType.JAVA);
 		pojoExporter.getProperties().setProperty("ejb3", String.valueOf(getExtension().generateAnnotations));
+		pojoExporter.getProperties().setProperty("jdk5", String.valueOf(getExtension().useGenerics));
 		File outputFolder = getOutputFolder();
 		pojoExporter.getProperties().put(ExporterConstants.METADATA_DESCRIPTOR, createJdbcDescriptor());
 		pojoExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputFolder);


### PR DESCRIPTION
  - Change the 'GenerateJavaTask' to explicitly set property 'jdk5'
