### PR TITLE
HBX-3050: Add a functional tests for the Maven generateJava mojo  guarding the sanity of the 5 minute tutorial

### DIFF
--- a/maven/docs/examples/5-minute-tutorial/README.md
+++ b/maven/docs/examples/5-minute-tutorial/README.md
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright 2004 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+To run this example:
+  - Have [Apache Maven](https://maven.apache.org) installed
+  - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
+  - Issue one of the following commands from a command-line window opened in this folder:
+    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+    - `mvn hbm2java -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}` 
+  

--- a/maven/docs/examples/5-minute-tutorial/pom.xml
+++ b/maven/docs/examples/5-minute-tutorial/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>@h2.version@</version>
+            <version>${h2.version}</version>
         </dependency>
     </dependencies>
 
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.hibernate.tool</groupId>
                 <artifactId>hibernate-tools-maven</artifactId>
-                <version>@project.version@</version>
+                <version>${hibernate.version}</version>
                 <executions>
                     <execution>
                         <id>Entity generation</id>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -34,6 +34,8 @@
     <!-- This is a publicly distributed module that should be published: -->
     <deploy.skip>false</deploy.skip>
     <maven.install.skip>false</maven.install.skip>
+    <!-- To run the integration tests we need to set ${hibernate.version} -->
+    <hibernate.version>${project.version}</hibernate.version>
   </properties>
 
   <dependencies>
@@ -149,6 +151,8 @@
           </execution>
         </executions>
       </plugin>
+      <!-- The Invoker plugin will populate the local Maven repository with the artefacts
+           needed to run the integration tests with the FailSafe plugin -->
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <version>${maven-invoker-plugin.version}</version>
@@ -164,7 +168,7 @@
           </execution>
         </executions>
       </plugin>
-      <!-- run the integration tests -->
+      <!-- Run the integration tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
@@ -235,7 +239,7 @@
                 </resource>
               </resources>
               <delimiters>
-                <delimiter>@*@</delimiter>
+                <delimiter>${*}</delimiter>
               </delimiters>
             </configuration>
           </execution>


### PR DESCRIPTION
  - Change the used property '@project.version@' into @hibernate.version@ and add the property to 'maven/pom.xml'
  - Change the delimiters for the filtering of the 'h2.version' and 'hibernate.version' properties in '5-minute-tutorial/pom.xml'
  - Add a 'README.md' to the '5-minute-tutorial' example, describing how to run it
