### PR TITLE
HBX-3128: Avoid use of Maven invoker plugin while performing functional testing 

### DIFF
--- a/maven/docs/examples/hbm2java/jpa-default/README.md
+++ b/maven/docs/examples/hbm2java/jpa-default/README.md
@@ -16,6 +16,6 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+  - Issue the following commands from a command-line window opened in this folder:
+    `mvn generate-sources -Dh2.version=${h2.version} -Dhibernate.version=${hibernate.version}`
   

--- a/maven/docs/examples/hbm2java/jpa-default/pom.xml
+++ b/maven/docs/examples/hbm2java/jpa-default/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-jpa-default</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/jpa-default/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/jpa-default/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/no-annotations/README.md
+++ b/maven/docs/examples/hbm2java/no-annotations/README.md
@@ -16,6 +16,6 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+  - Issue the following commands from a command-line window opened in this folder:
+    `mvn generate-sources -Dh2.version=${h2.version} -Dhibernate.version=${hibernate.version}`
   

--- a/maven/docs/examples/hbm2java/no-annotations/pom.xml
+++ b/maven/docs/examples/hbm2java/no-annotations/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-no-annotations</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <ejb3>false</ejb3>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/no-annotations/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/no-annotations/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/no-generics/README.md
+++ b/maven/docs/examples/hbm2java/no-generics/README.md
@@ -16,6 +16,6 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+  - Issue the following commands from a command-line window opened in this folder:
+    `mvn generate-sources -Dh2.version=${h2.version} -Dhibernate.version=${hibernate.version}`
   

--- a/maven/docs/examples/hbm2java/no-generics/pom.xml
+++ b/maven/docs/examples/hbm2java/no-generics/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-no-generics</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jdk5>false</jdk5>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/no-generics/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/no-generics/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/output-directory/README.md
+++ b/maven/docs/examples/hbm2java/output-directory/README.md
@@ -16,6 +16,11 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
-  
+  - Issue the following command from a command-line window opened in this folder:
+```shell
+mvn generate-sources 
+  -Dh2.version=${h2.version} 
+  -Dhibernate.version=${hibernate.version}  
+  -Doutput.dir=./generated-classes
+```
+    

--- a/maven/docs/examples/hbm2java/output-directory/pom.xml
+++ b/maven/docs/examples/hbm2java/output-directory/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-jpa-default</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputDirectory>${output.dir}</outputDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/output-directory/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/output-directory/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/template-path/README.md
+++ b/maven/docs/examples/hbm2java/template-path/README.md
@@ -16,6 +16,11 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
-  
+  - Issue the following command from a command-line window opened in this folder:
+```shell
+mvn generate-sources 
+  -Dh2.version=${h2.version} 
+  -Dhibernate.version=${hibernate.version}  
+  -Dtemplate.dir=./templates
+```
+    

--- a/maven/docs/examples/hbm2java/template-path/pom.xml
+++ b/maven/docs/examples/hbm2java/template-path/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-template-path</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <templatePath>${template.dir}</templatePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/template-path/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/template-path/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/template-path/templates/pojo/Pojo.ftl
+++ b/maven/docs/examples/hbm2java/template-path/templates/pojo/Pojo.ftl
@@ -13,9 +13,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-To run this example:
-  - Have [Apache Maven](https://maven.apache.org) installed
-  - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
-  
+// This is just an example of a custom template
+
+

--- a/maven/docs/examples/hbm2java/use-generics/README.md
+++ b/maven/docs/examples/hbm2java/use-generics/README.md
@@ -16,6 +16,6 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+  - Issue the following commands from a command-line window opened in this folder:
+    `mvn generate-sources -Dh2.version=${h2.version} -Dhibernate.version=${hibernate.version}`
   

--- a/maven/docs/examples/hbm2java/use-generics/pom.xml
+++ b/maven/docs/examples/hbm2java/use-generics/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-use-generics</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/use-generics/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/use-generics/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -181,19 +181,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Run the integration tests -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <!-- add the integration test source folder -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -211,6 +198,7 @@
               </sources>
             </configuration>
           </execution>
+          <!-- add the examples as test resources -->
           <execution>
             <id>add-test-resource</id>
             <phase>generate-test-resources</phase>
@@ -231,6 +219,8 @@
           </execution>
         </executions>
       </plugin>
+      <!-- filter the pom.xml files of the examples to replace the
+           h2 and hibernate versions for the integration tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
@@ -252,16 +242,29 @@
                 </resource>
               </resources>
               <delimiters>
-                <delimiter>${*}</delimiter>
+                <delimiter>${*.version}</delimiter>
               </delimiters>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Run the integration tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
 
-   <reporting>
+  <reporting>
     <plugins>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>

--- a/maven/src/functionalTest/java/org/hibernate/tool/maven/ExamplesTestIT.java
+++ b/maven/src/functionalTest/java/org/hibernate/tool/maven/ExamplesTestIT.java
@@ -1,11 +1,13 @@
 package org.hibernate.tool.maven;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 
 import org.apache.maven.cli.MavenCli;
 
@@ -21,6 +23,17 @@ public class ExamplesTestIT {
     private static File baseFolder;
     private static File localRepo;
 
+    private File projectFolder;
+    private MavenCli mavenCli;
+
+    @TempDir
+    private File tempFolder;
+
+    private String[] databaseCreationScript = new String[] {
+            // This is the default database which can be overridden per test
+            "create table PERSON (ID int not null, NAME varchar(20), primary key (ID))"
+    };
+
     @BeforeAll
     public static void beforeAll() throws Exception {
         // The needed resource for this test are put in place
@@ -29,32 +42,92 @@ public class ExamplesTestIT {
         // See the 'pom.xml'
         baseFolder = determineBaseFolder();
         localRepo = new File(baseFolder.getParentFile(), "local-repo");
-        createDatabase();
     }
-
-    private MavenCli mavenCli;
 
     @Test
     public void test5MinuteTutorial() throws Exception {
-        File projectFolder = prepareProjectFolder("5-minute-tutorial");
-        File generatedPersonFile = new File(projectFolder, "target/generated-sources/Person.java");
-        assertFalse(generatedPersonFile.exists());
-        new MavenCli().doMain(
-                new String[]{"-Dmaven.repo.local=" + localRepo.getAbsolutePath(), "generate-sources"},
-                projectFolder.getAbsolutePath(),
-                null,
-                null);
-        assertTrue(generatedPersonFile.exists());
-        String personFileContents = new String(Files.readAllBytes(generatedPersonFile.toPath()));
-        assertTrue(personFileContents.contains("public class Person"));
+        prepareProject("5-minute-tutorial");
+        assertNotGeneratedYet("Person.java");
+        runGenerateSources();
+        assertNumberOfGeneratedFiles(1);
+        assertGeneratedContains("Person.java", "public class Person");
     }
 
-    private File prepareProjectFolder(String projectName) throws Exception {
-        File projectFolder = new File(baseFolder, projectName);
+    @Test
+    public void testJpaDefault() throws Exception {
+        prepareProject("hbm2java/jpa-default");
+        assertNotGeneratedYet("Person.java");
+        runGenerateSources();
+        assertNumberOfGeneratedFiles(1);
+        assertGeneratedContains("Person.java","import jakarta.persistence.Entity;");
+    }
+
+    @Test
+    public void testNoAnnotations() throws Exception {
+        prepareProject("hbm2java/no-annotations");
+        assertNotGeneratedYet("Person.java");
+        runGenerateSources();
+        assertNumberOfGeneratedFiles(1);
+        assertGeneratedDoesNotContain("Person.java", "import jakarta.persistence.Entity;");
+    }
+
+    @Test
+    public void testNoGenerics() throws Exception {
+        databaseCreationScript = new String[] {
+                "create table PERSON (ID int not null,  NAME varchar(20), primary key (ID))",
+                "create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+                        "   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+        };
+        prepareProject("hbm2java/no-generics");
+        assertNotGeneratedYet("Person.java");
+        runGenerateSources();
+        assertNumberOfGeneratedFiles(2);
+        assertGeneratedDoesNotContain("Person.java", "Set<Item>");
+    }
+
+    @Test
+    public void testOutputDirectory() throws Exception {
+        System.setProperty("output.dir", "${project.basedir}/generated-classes");
+        prepareProject("hbm2java/output-directory");
+        File outputDirectory = new File(projectFolder, "generated-classes");
+        File personFile = new File(outputDirectory, "Person.java");
+        assertFalse(outputDirectory.exists());
+        assertFalse(personFile.exists());
+        runGenerateSources();
+        assertEquals(1, outputDirectory.list().length); // 1 file is generated in 'generated-classes'
+        assertTrue(personFile.exists()); // The Person.java file should have been generated
+    }
+
+    @Test
+    public void testTemplatePath() throws Exception {
+        System.setProperty("template.dir", "${project.basedir}/templates");
+        prepareProject("hbm2java/template-path");
+        assertNotGeneratedYet("Person.java");
+        runGenerateSources();
+        assertNumberOfGeneratedFiles(1);
+        assertGeneratedContains("Person.java", "// This is just an example of a custom template");
+    }
+
+    @Test
+    public void testUseGenerics() throws Exception {
+        databaseCreationScript = new String[] {
+                "create table PERSON (ID int not null,  NAME varchar(20), primary key (ID))",
+                "create table ITEM (ID int not null,  NAME varchar(20), OWNER_ID int not null, " +
+                        "   primary key (ID), foreign key (OWNER_ID) references PERSON(ID))"
+        };
+        prepareProject("hbm2java/use-generics");
+        assertNotGeneratedYet("Person.java");
+        runGenerateSources();
+        assertNumberOfGeneratedFiles(2);
+        assertGeneratedContains("Person.java", "Set<Item>");
+    }
+
+    private void prepareProject(String projectName) throws Exception {
+        projectFolder = new File(baseFolder, projectName);
         assertTrue(projectFolder.exists());
         System.setProperty(MVN_HOME, projectFolder.getAbsolutePath());
         createHibernatePropertiesFile(projectFolder);
-        return projectFolder;
+        createDatabase();
     }
 
     private void createHibernatePropertiesFile(File projectFolder) throws Exception {
@@ -73,26 +146,58 @@ public class ExamplesTestIT {
         assertTrue(hibernatePropertiesFile.exists());
     }
 
+    private void runGenerateSources() {
+        new MavenCli().doMain(
+                new String[]{"-Dmaven.repo.local=" + localRepo.getAbsolutePath(), "generate-sources"},
+                projectFolder.getAbsolutePath(),
+                null,
+                null);
+    }
+
+    private void assertNotGeneratedYet(String fileName) {
+        assertFalse(new File(projectFolder, "target/generated-sources/" + fileName).exists());
+    }
+
+    private void assertGeneratedContains(String fileName, String contents) throws Exception {
+        assertTrue(readGeneratedContents(fileName).contains(contents));
+    }
+
+    private void assertGeneratedDoesNotContain(String fileName, String contents) throws Exception {
+        assertFalse(readGeneratedContents(fileName).contains(contents));
+    }
+
+    private void assertNumberOfGeneratedFiles(int amount) throws Exception {
+        assertEquals(amount, new File(projectFolder, "target/generated-sources").list().length);
+    }
+
+    private String readGeneratedContents(String fileName) throws Exception {
+        File generatedPersonFile = new File(projectFolder, "target/generated-sources/" + fileName);
+        assertTrue(generatedPersonFile.exists());
+        return new String(Files.readAllBytes(generatedPersonFile.toPath()));
+    }
+
     private static File determineBaseFolder() throws Exception {
         return new File(ExamplesTestIT.class.getClassLoader().getResource("5-minute-tutorial/pom.xml").toURI())
                 .getParentFile().getParentFile();
     }
 
-    private static void createDatabase() throws Exception {
-        File databaseFile = new File(baseFolder, "database/test.mv.db");
+    private void createDatabase() throws Exception {
+        File databaseFile = new File(tempFolder, "database/test.mv.db");
         assertFalse(databaseFile.exists());
         assertFalse(databaseFile.isFile());
         Connection connection = DriverManager.getConnection(constructJdbcConnectionString());
         Statement statement = connection.createStatement();
-        statement.execute("create table PERSON (ID int not null, NAME varchar(20), primary key (ID))");
+        for (String s : databaseCreationScript) {
+            statement.execute(s);
+        }
         statement.close();
         connection.close();
         assertTrue(databaseFile.exists());
         assertTrue(databaseFile.isFile());
     }
 
-    private static String constructJdbcConnectionString() {
-        return "jdbc:h2:" + baseFolder.getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
+    private String constructJdbcConnectionString() {
+        return "jdbc:h2:" + tempFolder.getAbsolutePath() + "/database/test;AUTO_SERVER=TRUE";
     }
 
 }


### PR DESCRIPTION
  - Reorganize 'pom.xml' file
  - Reorganize test class ExamplesTestIT
  - Add the 'hbm2java/jpa-default' example
  - Remove erroneous line from '5-minute-tutorial/README.md'
  - Add a test for jpa-default and reorganize test class
  - Add the 'hbm2java/no-annotations' example
  - Add a test for no-annotations and reorganize test class
  - Add the 'hbm2java/no-generics' example
  - Add a test for no-generics
  - Add the 'hbm2java/use-generics' example
  - Add a test for use-generics
  - Make sure database is correctly created
  - Add assertion for the amount of generated files
  - Modify some utility methods to accept file name parameter
  - Add the 'hbm2java/template-path' example
  - Add a test for template-path
  - Add the 'hbm2java/output-dir' example
  - Add a test for 'hbm2java/output-dir'
