### PR TITLE
HBX-3128: Avoid use of Maven invoker plugin while performing functional testing

### DIFF
--- a/maven/docs/examples/hbm2java/jpa-annotations/README.md
+++ b/maven/docs/examples/hbm2java/jpa-annotations/README.md
@@ -16,6 +16,6 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+  - Issue the following commands from a command-line window opened in this folder:
+    `mvn generate-sources -Dh2.version=${h2.version} -Dhibernate.version=${hibernate.version}`
   

--- a/maven/docs/examples/hbm2java/jpa-annotations/pom.xml
+++ b/maven/docs/examples/hbm2java/jpa-annotations/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-no-annotations</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <ejb3>true</ejb3>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/jpa-annotations/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/jpa-annotations/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/no-generics-default/README.md
+++ b/maven/docs/examples/hbm2java/no-generics-default/README.md
@@ -16,6 +16,6 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+  - Issue the following commands from a command-line window opened in this folder:
+    `mvn generate-sources -Dh2.version=${h2.version} -Dhibernate.version=${hibernate.version}`
   

--- a/maven/docs/examples/hbm2java/no-generics-default/pom.xml
+++ b/maven/docs/examples/hbm2java/no-generics-default/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-no-generics</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/no-generics-default/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/no-generics-default/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/no-jpa-default/README.md
+++ b/maven/docs/examples/hbm2java/no-jpa-default/README.md
@@ -16,6 +16,6 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+  - Issue the following commands from a command-line window opened in this folder:
+    `mvn generate-sources -Dh2.version=${h2.version} -Dhibernate.version=${hibernate.version}`
   

--- a/maven/docs/examples/hbm2java/no-jpa-default/pom.xml
+++ b/maven/docs/examples/hbm2java/no-jpa-default/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-no-jpa-default</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/no-jpa-default/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/no-jpa-default/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/output-directory/README.md
+++ b/maven/docs/examples/hbm2java/output-directory/README.md
@@ -16,6 +16,11 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
-  
+  - Issue the following command from a command-line window opened in this folder:
+```shell
+mvn generate-sources 
+  -Dh2.version=${h2.version} 
+  -Dhibernate.version=${hibernate.version}  
+  -Doutput.dir=./generated-classes
+```
+    

--- a/maven/docs/examples/hbm2java/output-directory/pom.xml
+++ b/maven/docs/examples/hbm2java/output-directory/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-jpa-default</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputDirectory>${output.dir}</outputDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/output-directory/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/output-directory/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/template-path/README.md
+++ b/maven/docs/examples/hbm2java/template-path/README.md
@@ -16,6 +16,11 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
-  
+  - Issue the following command from a command-line window opened in this folder:
+```shell
+mvn generate-sources 
+  -Dh2.version=${h2.version} 
+  -Dhibernate.version=${hibernate.version}  
+  -Dtemplate.dir=./templates
+```
+    

--- a/maven/docs/examples/hbm2java/template-path/pom.xml
+++ b/maven/docs/examples/hbm2java/template-path/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-template-path</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <templatePath>${template.dir}</templatePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/template-path/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/template-path/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/docs/examples/hbm2java/template-path/templates/pojo/Pojo.ftl
+++ b/maven/docs/examples/hbm2java/template-path/templates/pojo/Pojo.ftl
@@ -13,9 +13,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-To run this example:
-  - Have [Apache Maven](https://maven.apache.org) installed
-  - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
-  
+// This is just an example of a custom template
+
+

--- a/maven/docs/examples/hbm2java/use-generics/README.md
+++ b/maven/docs/examples/hbm2java/use-generics/README.md
@@ -16,6 +16,6 @@
 To run this example:
   - Have [Apache Maven](https://maven.apache.org) installed
   - Have [H2 Sakila database](https://github.com/hibernate/sakila-h2) running
-  - Issue one of the following commands from a command-line window opened in this folder:
-    - `mvn generate-sources -Dh2.version=${h2.version} -Dproject.version=${hibernate.version}`
+  - Issue the following commands from a command-line window opened in this folder:
+    `mvn generate-sources -Dh2.version=${h2.version} -Dhibernate.version=${hibernate.version}`
   

--- a/maven/docs/examples/hbm2java/use-generics/pom.xml
+++ b/maven/docs/examples/hbm2java/use-generics/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 - 2025 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.hibernate.tool.maven.test</groupId>
+    <artifactId>hbm2java-use-generics</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-maven</artifactId>
+                <version>${hibernate.version}</version>
+                <executions>
+                    <execution>
+                        <id>Entity generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>hbm2java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jdk5>true</jdk5>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/docs/examples/hbm2java/use-generics/src/main/resources/hibernate.properties
+++ b/maven/docs/examples/hbm2java/use-generics/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+############################################################################
+# Hibernate Tools, Tooling for your Hibernate Projects                     #
+#                                                                          #
+# Copyright 2004-2025 Red Hat, Inc.                                        #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" basis,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+hibernate.connection.driver_class=org.h2.Driver
+hibernate.connection.url=jdbc:h2:tcp://localhost/./sakila
+hibernate.connection.username=sa
+hibernate.default_catalog=SAKILA
+hibernate.default_schema=PUBLIC
+

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -168,19 +168,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Run the integration tests -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <!-- add the integration test source folder -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -198,6 +185,7 @@
               </sources>
             </configuration>
           </execution>
+          <!-- add the examples as test resources -->
           <execution>
             <id>add-test-resource</id>
             <phase>generate-test-resources</phase>
@@ -218,6 +206,8 @@
           </execution>
         </executions>
       </plugin>
+      <!-- filter the pom.xml files of the examples to replace the
+           h2 and hibernate versions for the integration tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
@@ -239,9 +229,22 @@
                 </resource>
               </resources>
               <delimiters>
-                <delimiter>${*}</delimiter>
+                <delimiter>${*.version}</delimiter>
               </delimiters>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Run the integration tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
  - Reorganize 'pom.xml' file
  - Reorganize test class ExamplesTestIT
  - Add the 'hbm2java/jpa-default' example
  - Remove erroneous line from '5-minute-tutorial/README.md'
  - Add a test for jpa-default and reorganize test class
  - Add the 'hbm2java/no-annotations' example
  - Add a test for no-annotations and reorganize test class
  - Add the 'hbm2java/no-generics' example
  - Add a test for no-generics
  - Add the 'hbm2java/use-generics' example
  - Add a test for use-generics
  - Make sure database is correctly created
  - Add assertion for the amount of generated files
  - Modify some utility methods to accept file name parameter
  - Add the 'hbm2java/template-path' example
  - Add a test for template-path
  - Add the 'hbm2java/output-dir' example
  - Add a test for 'hbm2java/output-dir'

