### PR TITLE
HBX-3130: Take into account the 'hibernate.cfg.xml' file in the Ant reverse engineering task

### DIFF
--- a/ant/src/it/java/org/hibernate/tool/ant/ExamplesTestIT.java
+++ b/ant/src/it/java/org/hibernate/tool/ant/ExamplesTestIT.java
@@ -5,7 +5,6 @@ import org.apache.tools.ant.MagicNames;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.ProjectHelper;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -46,10 +45,15 @@ public class ExamplesTestIT {
         assertTrue(personFile.exists());
     }
 
-    @Disabled
     @Test
     public void testCfgXml() throws Exception {
         File buildFile = new File(baseFolder, "cfgxml/build.xml");
+        File cfgXmlFile = new File(baseFolder, "cfgxml/hibernate.cfg.xml");
+        String cfgXmlFileContents = Files.readString(cfgXmlFile.toPath())
+            .replace("jdbc:h2:tcp://localhost/./sakila", constructJdbcConnectionString())
+            .replace(">sa<", "><")
+            .replace(">SAKILA<", ">TEST<");
+        Files.writeString(cfgXmlFile.toPath(), cfgXmlFileContents);
         Project project = createProject(buildFile);
         assertNotNull(project);
         File personFile = new File(baseFolder, "cfgxml/generated/Person.java");

--- a/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
+++ b/ant/src/main/java/org/hibernate/tool/ant/JDBCConfigurationTask.java
@@ -19,12 +19,14 @@ package org.hibernate.tool.ant;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Path;
 import org.hibernate.boot.cfgxml.internal.ConfigLoader;
+import org.hibernate.boot.cfgxml.spi.LoadedConfig;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
@@ -121,8 +123,8 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 	public void setDetectOptimisticLock(boolean b) {
 		detectOptimisticLock = b;
 	}
-	
-    private RevengStrategy loadreverseEngineeringStrategy(final String className, RevengStrategy delegate) 
+
+    private RevengStrategy loadreverseEngineeringStrategy(final String className, RevengStrategy delegate)
     throws BuildException {
         try {
             Class<?> clazz = ReflectionUtil.classForName(className);			
@@ -147,9 +149,10 @@ public class JDBCConfigurationTask extends ConfigurationTask {
 		} 
     }
 
-	private Properties loadCfgXmlFile() {
+	private Map<String, Object> loadCfgXmlFile() {
 		return new ConfigLoader(new BootstrapServiceRegistryBuilder().build())
-				.loadProperties(getConfigurationFile());
+				.loadConfigXmlFile(getConfigurationFile())
+				.getConfigurationValues();
 	}
 
 	private Properties loadProperties() {


### PR DESCRIPTION
  - Enable the test and add proper reading of the 'hibernate.cfg.xml' configuration values
