### PR TITLE
Bump hibernate-orm.version from 7.2.21.Final to 7.2.22.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <google-java-format.version>1.28.0</google-java-format.version>
         <h2.version>2.4.240</h2.version>
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version>
-        <hibernate-orm.version>7.2.21.Final</hibernate-orm.version>
+        <hibernate-orm.version>7.2.22.Final</hibernate-orm.version>
         <hsqldb.version>2.7.4</hsqldb.version>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>


### PR DESCRIPTION
Please delete this text, and add a link to the Jira issue solved by this PR;
see https://hibernate.atlassian.net/browse/HBX.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HBX-<digits>`).
